### PR TITLE
android.c: add NULL check for rootfs_path in android_setup_storage() and harden android_setup_storage path handling and mkdir checks

### DIFF
--- a/src/android.c
+++ b/src/android.c
@@ -166,15 +166,25 @@ int android_setup_storage(const char *rootfs_path) {
   /* Create target directories inside rootfs: storage/, storage/emulated/,
    * storage/emulated/0 */
   char path[PATH_MAX];
+  int ret;
 
-  snprintf(path, sizeof(path), "%s/storage", rootfs_path);
-  mkdir(path, 0755);
+  ret = snprintf(path, sizeof(path), "%s/storage", rootfs_path);
+  if (ret < 0 || (size_t)ret >= sizeof(path))
+    return -1;
+  if (mkdir(path, 0755) < 0 && errno != EEXIST)
+    return -1;
 
-  snprintf(path, sizeof(path), "%s/storage/emulated", rootfs_path);
-  mkdir(path, 0755);
+  ret = snprintf(path, sizeof(path), "%s/storage/emulated", rootfs_path);
+  if (ret < 0 || (size_t)ret >= sizeof(path))
+    return -1;
+  if (mkdir(path, 0755) < 0 && errno != EEXIST)
+    return -1;
 
-  snprintf(path, sizeof(path), "%s/storage/emulated/0", rootfs_path);
-  mkdir(path, 0755);
+  ret = snprintf(path, sizeof(path), "%s/storage/emulated/0", rootfs_path);
+  if (ret < 0 || (size_t)ret >= sizeof(path))
+    return -1;
+  if (mkdir(path, 0755) < 0 && errno != EEXIST)
+    return -1;
 
   ds_log("Mounting Android internal storage to /storage/emulated/0...");
   if (mount(storage_src, path, NULL, MS_BIND | MS_REC, NULL) < 0) {


### PR DESCRIPTION
If the function is accidentally called with a NULL pointer, it would previously cause undefined behavior or a crash during snprintf().

Now it logs a warning and safely returns -1 instead.