### PR TITLE
container.c: canonicalize rootfs paths to prevent symlink TOCTOU attacks

### DIFF
--- a/src/container.c
+++ b/src/container.c
@@ -301,6 +301,28 @@ int start_rootfs(struct ds_config *cfg) {
     }
   }
 
+  /* 0a. Resolve any symlinks in rootfs paths to canonical absolute paths.
+   *     This prevents symlink-based attacks and ensures that all subsequent
+   *     operations use the intended location. */
+  if (cfg->rootfs_path[0]) {
+    char resolved[PATH_MAX];
+    if (realpath(cfg->rootfs_path, resolved) == NULL) {
+      ds_error("Failed to resolve rootfs path '%s': %s", cfg->rootfs_path,
+               strerror(errno));
+      goto cleanup;
+    }
+    safe_strncpy(cfg->rootfs_path, resolved, sizeof(cfg->rootfs_path));
+  }
+  if (cfg->rootfs_img_path[0]) {
+    char resolved[PATH_MAX];
+    if (realpath(cfg->rootfs_img_path, resolved) == NULL) {
+      ds_error("Failed to resolve rootfs image path '%s': %s",
+               cfg->rootfs_img_path, strerror(errno));
+      goto cleanup;
+    }
+    safe_strncpy(cfg->rootfs_img_path, resolved, sizeof(cfg->rootfs_img_path));
+  }
+
   /* 1. Preparation */
   ensure_workspace();
 


### PR DESCRIPTION
This change improves container startup security by resolving --rootfs and --rootfs-img paths to their canonical absolute form using realpath(3) before any filesystem operations occur.

Previously, Droidspaces accepted user-provided paths directly. If those paths contained symlinks, an attacker could potentially modify the symlink target between validation and usage, creating a TOCTOU (time-of-check to time-of-use) vulnerability.

By canonicalizing paths early in start_rootfs():
  All symlinks are resolved to their real filesystem location.
  Broken symlinks fail early with a clear error.
  Container mounts, chdir, and pivot_root operate on the same   verified path.

This eliminates symlink-based attack vectors while improving reliability and debugging clarity during container startup.