### PR TITLE
security: reject unsafe container names and bind destinations

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -93,11 +93,22 @@ static void parse_bind_mounts(const char *value, struct ds_config *cfg) {
     char *sep = strchr(token, ':');
     if (sep) {
       *sep = '\0';
-      const char *src = trim_whitespace(token);
-      const char *dest = trim_whitespace(sep + 1);
+      const char *src_raw = trim_whitespace(token);
+      const char *dest_raw = trim_whitespace(sep + 1);
 
-      /* Use proper allocation function instead of direct array access */
-      ds_config_add_bind(cfg, src, dest);
+      char *src_exp = ds_resolve_path_arg(src_raw);
+      char *dest_exp = ds_resolve_path_arg(dest_raw);
+      const char *src = src_exp ? src_exp : src_raw;
+      const char *dest = dest_exp ? dest_exp : dest_raw;
+
+      /* Validate before storing - caller's responsibility, same as CLI path */
+      if (!validate_bind_destination(dest)) {
+        ds_warn("Skipping unsafe bind destination '%s' from config.", dest);
+      } else {
+        ds_config_add_bind(cfg, src, dest);
+      }
+      free(src_exp);
+      free(dest_exp);
     }
     token = strtok_r(NULL, ",", &saveptr);
   }
@@ -107,6 +118,9 @@ int ds_config_add_bind(struct ds_config *cfg, const char *src,
                        const char *dest) {
   if (!src || !dest || src[0] == '\0' || dest[0] == '\0')
     return 0;
+  /* Defensive: callers must pre-validate; this is a last-resort assert */
+  if (!validate_bind_destination(dest))
+    return -1;
 
   /* Check for duplication */
   for (int i = 0; i < cfg->bind_count; i++) {

--- a/src/droidspace.h
+++ b/src/droidspace.h
@@ -403,6 +403,8 @@ void write_monitor_debug_log(const char *name, const char *fmt, ...);
 int copy_file(const char *src, const char *dst);
 void sort_bind_mounts(struct ds_config *cfg);
 void sanitize_container_name(const char *name, char *out, size_t size);
+int validate_container_name(const char *name);
+int validate_bind_destination(const char *dest);
 
 /* ---------------------------------------------------------------------------
  * config.c

--- a/src/main.c
+++ b/src/main.c
@@ -104,6 +104,17 @@ void print_usage(void) {
  * Validation Helpers
  * ---------------------------------------------------------------------------*/
 
+static int reject_container_name(const char *name, int *ret) {
+  if (!validate_container_name(name)) {
+    ds_error("Invalid container name '%s'. Use only letters, numbers, "
+             "'.', '_', '-' and spaces.",
+             name);
+    *ret = 1;
+    return -1;
+  }
+  return 0;
+}
+
 static int validate_kernel_version(void) {
   int major = 0, minor = 0;
   if (get_kernel_version(&major, &minor) < 0) {
@@ -380,6 +391,8 @@ int main(int argc, char **argv) {
       safe_strncpy(cfg.config_file, optarg, sizeof(cfg.config_file));
       cfg.config_file_specified = 1;
     } else if (opt == 'n') {
+      if (reject_container_name(optarg, &ret) < 0)
+        goto cleanup;
       safe_strncpy(cfg.container_name, optarg, sizeof(cfg.container_name));
     } else if (opt == 'r') {
       safe_strncpy(temp_r, optarg, sizeof(temp_r));
@@ -530,6 +543,8 @@ int main(int argc, char **argv) {
       cfg.is_img_mount = 1;
       break;
     case 'n':
+      if (reject_container_name(optarg, &ret) < 0)
+        goto cleanup;
       safe_strncpy(cfg.container_name, optarg, sizeof(cfg.container_name));
       break;
     case 'h':
@@ -578,6 +593,13 @@ int main(int argc, char **argv) {
 
         if (dest[0] != '/') {
           ds_error("Bind destination must be an absolute path: %s", dest);
+          ret = 1;
+          goto cleanup;
+        }
+        if (!validate_bind_destination(dest)) {
+          ds_error("Unsafe bind destination '%s': path traversal or control "
+                   "characters not allowed.",
+                   dest);
           ret = 1;
           goto cleanup;
         }

--- a/src/utils.c
+++ b/src/utils.c
@@ -1365,3 +1365,52 @@ void sort_bind_mounts(struct ds_config *cfg) {
   qsort(cfg->binds, cfg->bind_count, sizeof(struct ds_bind_mount),
         compare_bind_mounts);
 }
+
+int validate_container_name(const char *name) {
+  if (!name || !name[0])
+    return 0;
+
+  if (strcmp(name, ".") == 0 || strcmp(name, "..") == 0)
+    return 0;
+
+  size_t len = strlen(name);
+  if (len >= 256)
+    return 0;
+
+  for (size_t i = 0; i < len; i++) {
+    unsigned char c = (unsigned char)name[i];
+    if (!(isalnum(c) || c == '.' || c == '_' || c == '-' || c == ' '))
+      return 0;
+  }
+
+  return 1;
+}
+
+int validate_bind_destination(const char *dest) {
+  if (!dest || dest[0] != '/' || dest[1] == '\0')
+    return 0;
+
+  if (strlen(dest) >= PATH_MAX)
+    return 0;
+
+  const char *p = dest;
+  while (*p) {
+    while (*p == '/')
+      p++;
+    const char *start = p;
+    while (*p && *p != '/')
+      p++;
+    size_t len = (size_t)(p - start);
+    if (len == 0)
+      continue;
+    if ((len == 1 && start[0] == '.') ||
+        (len == 2 && start[0] == '.' && start[1] == '.'))
+      return 0;
+    for (size_t i = 0; i < len; i++) {
+      if (iscntrl((unsigned char)start[i]))
+        return 0;
+    }
+  }
+
+  return 1;
+}


### PR DESCRIPTION
- container names are now validated against a strict allowlist (letters, numbers, '.', '_', '-', spaces) at parse time, preventing path traversal and injection via --name

- bind destinations from both --bind and container.config are validated for absolute paths, no '..' components, and no control characters before being stored or mounted

- invalid entries from container.config emit a warning instead of silently getting dropped

this is an enhanced version of this PR: https://github.com/ravindu644/Droidspaces-OSS/pull/80