### PR TITLE
Implement hardening checks for user namespaces

### DIFF
--- a/src/check.c
+++ b/src/check.c
@@ -401,6 +401,17 @@ int check_requirements_detailed(void) {
                  "Required for --net=nat; no fallback exists if absent",
                  check_veth_support(), "OPT");
 
+  /* HARDENING */
+  check_append("\n" C_BOLD "[HARDENING]" C_RESET
+               "\nThese checks are not required for Droidspaces to work, "
+               "but are recommended for hardened kernels:\n\n");
+
+  int has_user_ns = access("/proc/self/ns/user", F_OK) == 0;
+  print_ds_check("CONFIG_USER_NS disabled",
+                 "Kernel exposes user namespace support, which Droidspaces "
+                 "does not require and hardened kernels should disable",
+                 !has_user_ns, "OPT");
+
   /* FINAL SUMMARY */
   check_append("\n" C_BOLD "Summary:" C_RESET "\n\n");
   if (missing_must > 0)


### PR DESCRIPTION
Added warning for user namespace, relating to CVE-2026-43284.

This adds a new hardening diagnostic to `droidspaces check` that warns when the running kernel exposes user namespace support through:

```c
/proc/self/ns/user
```

Droidspaces does not require user namespaces for its own container model, and neither the current runtime checks nor the documented kernel requirements depend on `CONFIG_USER_NS`. Since enabling user namespaces expands the exposed kernel attack surface, this is worth flagging explicitly in the requirements checker.

The check is placed in a dedicated **hardening** section rather than under mandatory requirements, because this is a security recommendation rather than a runtime prerequisite.
