### PR TITLE
boot-module: sepolicy.rule: make termux happy

### DIFF
--- a/Android/app/src/main/assets/boot-module/etc/droidspaces.te
+++ b/Android/app/src/main/assets/boot-module/etc/droidspaces.te
@@ -201,3 +201,6 @@ allow su system_data_file file entrypoint
 allow system_server droidspacesd binder { call transfer }
 allow system_server droidspacesd fd use
 allow system_server droidspacesd fifo_file write
+
+# Termux related
+allow untrusted_app_27 droidspacesd fd use

--- a/Android/app/src/main/assets/boot-module/etc/droidspaces.te
+++ b/Android/app/src/main/assets/boot-module/etc/droidspaces.te
@@ -203,4 +203,5 @@ allow system_server droidspacesd fd use
 allow system_server droidspacesd fifo_file write
 
 # Termux related
-allow untrusted_app_27 droidspacesd fd use
+# Only uncommet line below if you are encounter any problems about dri3
+# allow untrusted_app_27 droidspacesd fd use

--- a/Documentation/GPU-Acceleration.md
+++ b/Documentation/GPU-Acceleration.md
@@ -133,6 +133,13 @@ For Qualcomm Adreno GPUs, Droidspaces supports **native hardware acceleration** 
    ```bash
    dbus-launch --exit-with-session startxfce4
    ```
+
+> [!TIP]
+>
+> **If you encountered any problems related to dri3,** try edit `/data/adb/modules/droidspaces/etc/droidspaces.te` and uncomet line:
+>
+> `allow untrusted_app_27 droidspacesd fd use`
+
 ---
 
 <a id="linux"></a>


### PR DESCRIPTION
add an sepolicy rule to fix some dri3 related issues on Termux, benifits to GPU acceleration.

here is the original avc audit logs:
avc: denied { use } for comm="main" path="/dmabuf:" dev="dmabuf" ino=10379
scontext=u:r:untrusted_app_27:s0:c42,c258,c512,c768
tcontext=u:r:droidspacesd:s0 tclass=fd permissive=0 app=com.termux