### PR TITLE
socketd: expose backend-backed Docker snapshot inventory for Portainer

### DIFF
--- a/src/container.c
+++ b/src/container.c
@@ -1169,6 +1169,7 @@ int start_rootfs(struct ds_config *cfg) {
        * the same memory.  The DHCP thread is intentionally joinable so stop()
        * can join before memset. */
       ds_dhcp_server_stop();
+      ds_socketd_record_core_event("restart", cfg->container_name, cfg->uuid);
 
       goto reboot_loop;
     }
@@ -1305,6 +1306,7 @@ int start_rootfs(struct ds_config *cfg) {
     }
 
     show_info(cfg, 1);
+    ds_socketd_record_core_event("start", cfg->container_name, cfg->uuid);
     ds_log("Container '%s' is running in background.", cfg->container_name);
     if (is_android()) {
       ds_log("Use 'su -c \"%s --name='%s' enter\"' to connect.", cfg->prog_name,
@@ -1515,6 +1517,7 @@ int stop_rootfs(struct ds_config *cfg, int skip_unmount) {
 
   /* 5. Complete resource cleanup. */
   cleanup_container_resources(cfg, pid, skip_unmount, unkillable);
+  ds_socketd_record_core_event("die", cfg->container_name, cfg->uuid);
 
   if (!cfg->foreground)
     ds_log("Container '%s' stopped.", cfg->container_name);

--- a/src/droidspace.h
+++ b/src/droidspace.h
@@ -432,6 +432,7 @@ ds_init_type_t detect_container_init(const char *path);
 int get_user_shell(const char *user, char *shell_buf, size_t size);
 void check_kernel_recommendation(void);
 void write_monitor_debug_log(const char *name, const char *fmt, ...);
+void ds_socketd_record_core_event(const char *action, const char *container_name, const char *uuid);
 int copy_file(const char *src, const char *dst);
 void sort_bind_mounts(struct ds_config *cfg);
 void sanitize_container_name(const char *name, char *out, size_t size);

--- a/src/socketd/backend_client.cpp
+++ b/src/socketd/backend_client.cpp
@@ -8,6 +8,7 @@
 #include <cstdint>
 #include <cstring>
 #include <string>
+#include <utility>
 
 #include <sys/socket.h>
 #include <sys/un.h>
@@ -108,6 +109,53 @@ int connect_backend(std::string& error) {
   }
 
   return fd;
+}
+
+std::uint64_t ntoh64(std::uint64_t value) {
+#if defined(__BYTE_ORDER__) && (__BYTE_ORDER__ == __ORDER_BIG_ENDIAN__)
+  return value;
+#else
+  return (static_cast<std::uint64_t>(
+              ntohl(static_cast<std::uint32_t>(value & 0xffffffffULL)))
+          << 32) |
+         static_cast<std::uint64_t>(
+             ntohl(static_cast<std::uint32_t>(value >> 32)));
+#endif
+}
+
+std::uint64_t hton64(std::uint64_t value) {
+  return ntoh64(value);
+}
+
+std::string decode_fixed_string(const char* data, std::size_t size) {
+  if (!data || size == 0) {
+    return {};
+  }
+
+  const void* nul = std::memchr(data, '\0', size);
+  const std::size_t len =
+      nul ? static_cast<const char*>(nul) - data : size;
+
+  /*
+   * CONCERN(socketd-wire):
+   * Backend wire strings are fixed-width char arrays rather than
+   * length-prefixed blobs. Decode defensively and tolerate a field that fills
+   * its entire slot without an in-bounds NUL terminator.
+   */
+  return std::string(data, len);
+}
+
+bool expect_ok_status(std::uint16_t status,
+                      const char* operation,
+                      std::string& error) {
+  if (status == DS_SOCKETD_STATUS_OK) {
+    return true;
+  }
+
+  error = operation;
+  error += " returned backend status ";
+  error += std::to_string(status);
+  return false;
 }
 
 }  // namespace
@@ -242,6 +290,242 @@ bool BackendClient::capabilities(CapabilitiesResult& out,
   std::uint32_t mask_be = 0;
   std::memcpy(&mask_be, payload.data(), sizeof(mask_be));
   out.mask = ntohl(mask_be);
+
+  return true;
+}
+
+bool BackendClient::list_containers(
+    bool include_all,
+    std::vector<ContainerRecordResult>& out,
+    std::string& error) const {
+  ds_socketd_list_containers_req req {};
+  req.include_all = include_all ? 1u : 0u;
+
+  std::uint16_t status = DS_SOCKETD_STATUS_INTERNAL_ERROR;
+  std::string payload;
+
+  if (!request(DS_SOCKETD_OP_LIST_CONTAINERS,
+               &req,
+               static_cast<std::uint32_t>(sizeof(req)),
+               status,
+               payload,
+               error)) {
+    return false;
+  }
+
+  if (!expect_ok_status(status, "LIST_CONTAINERS", error)) {
+    return false;
+  }
+
+  if (payload.size() % sizeof(ds_socketd_container_record) != 0) {
+    error = "LIST_CONTAINERS returned payload of invalid size";
+    return false;
+  }
+
+  out.clear();
+
+  const std::size_t count =
+      payload.size() / sizeof(ds_socketd_container_record);
+  out.reserve(count);
+
+  for (std::size_t i = 0; i < count; ++i) {
+    ds_socketd_container_record wire {};
+    std::memcpy(&wire,
+                payload.data() + i * sizeof(wire),
+                sizeof(wire));
+
+    ContainerRecordResult result;
+    result.name =
+        decode_fixed_string(wire.name, sizeof(wire.name));
+    result.uuid =
+        decode_fixed_string(wire.uuid, sizeof(wire.uuid));
+    result.rootfs_path =
+        decode_fixed_string(wire.rootfs_path, sizeof(wire.rootfs_path));
+    result.hostname =
+        decode_fixed_string(wire.hostname, sizeof(wire.hostname));
+    result.nat_ip =
+        decode_fixed_string(wire.nat_ip, sizeof(wire.nat_ip));
+    result.custom_init =
+        decode_fixed_string(wire.custom_init, sizeof(wire.custom_init));
+
+    result.pid = static_cast<std::int32_t>(
+        ntohl(static_cast<std::uint32_t>(wire.pid_be)));
+
+    result.net_mode = wire.net_mode;
+
+    result.started_at = static_cast<std::int64_t>(
+        ntoh64(static_cast<std::uint64_t>(wire.started_at_be)));
+
+    std::size_t port_count = wire.port_count;
+    if (port_count > DS_SOCKETD_RECORD_PORTS_MAX) {
+      port_count = DS_SOCKETD_RECORD_PORTS_MAX;
+    }
+
+    result.ports.reserve(port_count);
+
+    for (std::size_t j = 0; j < port_count; ++j) {
+      const ds_socketd_port_record& port_wire = wire.ports[j];
+
+      ContainerPortResult port;
+      port.host_port = ntohs(port_wire.host_port_be);
+      port.host_port_end = ntohs(port_wire.host_port_end_be);
+      port.container_port = ntohs(port_wire.container_port_be);
+      port.container_port_end =
+          ntohs(port_wire.container_port_end_be);
+      port.proto = port_wire.proto;
+
+      result.ports.push_back(std::move(port));
+    }
+
+    out.push_back(std::move(result));
+  }
+
+  return true;
+}
+
+bool BackendClient::info(InfoResult& out, std::string& error) const {
+  std::uint16_t status = DS_SOCKETD_STATUS_INTERNAL_ERROR;
+  std::string payload;
+
+  if (!request(DS_SOCKETD_OP_INFO, nullptr, 0,
+               status, payload, error)) {
+    return false;
+  }
+
+  if (!expect_ok_status(status, "INFO", error)) {
+    return false;
+  }
+
+  if (payload.size() != sizeof(ds_socketd_info_payload)) {
+    error = "INFO returned payload of unexpected size";
+    return false;
+  }
+
+  ds_socketd_info_payload wire {};
+  std::memcpy(&wire, payload.data(), sizeof(wire));
+
+  out.containers_total = ntohl(wire.containers_total_be);
+  out.containers_running = ntohl(wire.containers_running_be);
+  out.containers_stopped = ntohl(wire.containers_stopped_be);
+
+  return true;
+}
+
+bool BackendClient::list_images(
+    std::vector<ImageRecordResult>& out,
+    std::string& error) const {
+  std::uint16_t status = DS_SOCKETD_STATUS_INTERNAL_ERROR;
+  std::string payload;
+
+  if (!request(DS_SOCKETD_OP_LIST_IMAGES, nullptr, 0,
+               status, payload, error)) {
+    return false;
+  }
+
+  if (!expect_ok_status(status, "LIST_IMAGES", error)) {
+    return false;
+  }
+
+  if (payload.size() % sizeof(ds_socketd_image_record) != 0) {
+    error = "LIST_IMAGES returned payload of invalid size";
+    return false;
+  }
+
+  out.clear();
+
+  const std::size_t count =
+      payload.size() / sizeof(ds_socketd_image_record);
+  out.reserve(count);
+
+  for (std::size_t i = 0; i < count; ++i) {
+    ds_socketd_image_record wire {};
+    std::memcpy(&wire,
+                payload.data() + i * sizeof(wire),
+                sizeof(wire));
+
+    ImageRecordResult result;
+    result.name =
+        decode_fixed_string(wire.name, sizeof(wire.name));
+    result.rootfs_path =
+        decode_fixed_string(wire.rootfs_path, sizeof(wire.rootfs_path));
+    result.uuid =
+        decode_fixed_string(wire.uuid, sizeof(wire.uuid));
+
+    result.is_running =
+        ntohl(static_cast<std::uint32_t>(wire.is_running_be)) != 0;
+
+    result.created_at = static_cast<std::int64_t>(
+        ntoh64(static_cast<std::uint64_t>(wire.created_at_be)));
+
+    out.push_back(std::move(result));
+  }
+
+  return true;
+}
+
+bool BackendClient::poll_events(
+    std::int64_t since,
+    std::vector<CoreEventResult>& out,
+    std::string& error) const {
+  if (since < 0) {
+    error = "POLL_EVENTS does not accept a negative 'since' value";
+    return false;
+  }
+
+  ds_socketd_poll_events_req req {};
+  req.since_be = static_cast<std::int64_t>(
+      hton64(static_cast<std::uint64_t>(since)));
+
+  std::uint16_t status = DS_SOCKETD_STATUS_INTERNAL_ERROR;
+  std::string payload;
+
+  if (!request(DS_SOCKETD_OP_POLL_EVENTS,
+               &req,
+               static_cast<std::uint32_t>(sizeof(req)),
+               status,
+               payload,
+               error)) {
+    return false;
+  }
+
+  if (!expect_ok_status(status, "POLL_EVENTS", error)) {
+    return false;
+  }
+
+  if (payload.size() % sizeof(ds_socketd_core_event_record) != 0) {
+    error = "POLL_EVENTS returned payload of invalid size";
+    return false;
+  }
+
+  out.clear();
+
+  const std::size_t count =
+      payload.size() / sizeof(ds_socketd_core_event_record);
+  out.reserve(count);
+
+  for (std::size_t i = 0; i < count; ++i) {
+    ds_socketd_core_event_record wire {};
+    std::memcpy(&wire,
+                payload.data() + i * sizeof(wire),
+                sizeof(wire));
+
+    CoreEventResult result;
+    result.time = static_cast<std::int64_t>(
+        ntoh64(static_cast<std::uint64_t>(wire.time_be)));
+    result.time_nano = static_cast<std::int64_t>(
+        ntoh64(static_cast<std::uint64_t>(wire.time_nano_be)));
+
+    result.type =
+        decode_fixed_string(wire.type, sizeof(wire.type));
+    result.action =
+        decode_fixed_string(wire.action, sizeof(wire.action));
+    result.actor_id =
+        decode_fixed_string(wire.actor_id, sizeof(wire.actor_id));
+    result.actor_name =
+        decode_fixed_string(wire.actor_name, sizeof(wire.actor_name));
+
+    out.push_back(std::move(result));
+  }
 
   return true;
 }

--- a/src/socketd/backend_client.h
+++ b/src/socketd/backend_client.h
@@ -2,11 +2,56 @@
 
 #include <cstdint>
 #include <string>
+#include <vector>
 
 namespace droidspaces::socketd {
 
 struct CapabilitiesResult {
   std::uint32_t mask = 0;
+};
+
+struct ContainerPortResult {
+  std::uint16_t host_port = 0;
+  std::uint16_t host_port_end = 0;
+  std::uint16_t container_port = 0;
+  std::uint16_t container_port_end = 0;
+  std::uint8_t proto = 0; /* 0 = tcp, 1 = udp */
+};
+
+struct ContainerRecordResult {
+  std::string name;
+  std::string uuid;
+  std::string rootfs_path;
+  std::string hostname;
+  std::string nat_ip;
+  std::string custom_init;
+  std::int32_t pid = 0;
+  std::uint8_t net_mode = 0; /* 0 = host, 1 = nat, 2 = none */
+  std::int64_t started_at = 0;
+  std::vector<ContainerPortResult> ports;
+};
+
+struct InfoResult {
+  std::uint32_t containers_total = 0;
+  std::uint32_t containers_running = 0;
+  std::uint32_t containers_stopped = 0;
+};
+
+struct ImageRecordResult {
+  std::string name;
+  std::string rootfs_path;
+  std::string uuid;
+  bool is_running = false;
+  std::int64_t created_at = 0;
+};
+
+struct CoreEventResult {
+  std::int64_t time = 0;
+  std::int64_t time_nano = 0;
+  std::string type;
+  std::string action;
+  std::string actor_id;
+  std::string actor_name;
 };
 
 class BackendClient {
@@ -15,6 +60,19 @@ class BackendClient {
 
   bool ping(std::string& error) const;
   bool capabilities(CapabilitiesResult& out, std::string& error) const;
+
+  bool list_containers(bool include_all,
+                       std::vector<ContainerRecordResult>& out,
+                       std::string& error) const;
+
+  bool info(InfoResult& out, std::string& error) const;
+
+  bool list_images(std::vector<ImageRecordResult>& out,
+                   std::string& error) const;
+
+  bool poll_events(std::int64_t since,
+                   std::vector<CoreEventResult>& out,
+                   std::string& error) const;
 
  private:
   bool request(std::uint16_t opcode,

--- a/src/socketd/container_list.cpp
+++ b/src/socketd/container_list.cpp
@@ -1,24 +1,203 @@
 #include "container_list.h"
 
+#include "backend_client.h"
+
+#include <cstddef>
+#include <cstdint>
+#include <string>
+#include <utility>
+#include <vector>
+
 namespace droidspaces::socketd {
+namespace {
+
+std::string json_escape(const std::string& input) {
+  std::string out;
+  out.reserve(input.size());
+
+  constexpr char kHex[] = "0123456789abcdef";
+
+  for (unsigned char ch : input) {
+    switch (ch) {
+      case '"':
+        out += "\\\"";
+        break;
+      case '\\':
+        out += "\\\\";
+        break;
+      case '\b':
+        out += "\\b";
+        break;
+      case '\f':
+        out += "\\f";
+        break;
+      case '\n':
+        out += "\\n";
+        break;
+      case '\r':
+        out += "\\r";
+        break;
+      case '\t':
+        out += "\\t";
+        break;
+      default:
+        if (ch < 0x20) {
+          out += "\\u00";
+          out += kHex[(ch >> 4) & 0x0f];
+          out += kHex[ch & 0x0f];
+        } else {
+          out += static_cast<char>(ch);
+        }
+        break;
+    }
+  }
+
+  return out;
+}
+
+const char* container_state(const ContainerRecordResult& record) {
+  return record.pid > 0 ? "running" : "exited";
+}
+
+const char* container_status(const ContainerRecordResult& record) {
+  return record.pid > 0 ? "Up" : "Exited";
+}
+
+const char* port_type(std::uint8_t proto) {
+  return proto == 1u ? "udp" : "tcp";
+}
+
+void append_ports_json(std::string& out,
+                       const ContainerRecordResult& record) {
+  out += "\"Ports\":[";
+
+  for (std::size_t i = 0; i < record.ports.size(); ++i) {
+    if (i != 0) {
+      out += ",";
+    }
+
+    const ContainerPortResult& port = record.ports[i];
+
+    out += "{";
+    out += "\"PrivatePort\":";
+    out += std::to_string(port.container_port);
+    out += ",";
+    out += "\"PublicPort\":";
+    out += std::to_string(port.host_port);
+    out += ",";
+    out += "\"Type\":\"";
+    out += port_type(port.proto);
+    out += "\"";
+    out += "}";
+  }
+
+  out += "]";
+}
+
+void append_network_settings_json(std::string& out,
+                                  const ContainerRecordResult& record) {
+  out += "\"NetworkSettings\":{\"Networks\":{";
+
+  /*
+   * The Phase 4 public JSON projection follows the current compatibility plan:
+   * only NAT-mode containers receive a Docker-style synthetic bridge attachment
+   * in /containers/json. Host and none modes remain represented by an empty
+   * Networks object here.
+   */
+  if (record.net_mode == 1u && !record.nat_ip.empty()) {
+    out += "\"droidspaces-bridge\":{";
+    out += "\"IPAddress\":\"";
+    out += json_escape(record.nat_ip);
+    out += "\"";
+    out += "}";
+  }
+
+  out += "}}";
+}
+
+void append_container_json(std::string& out,
+                           const ContainerRecordResult& record) {
+  const std::string command =
+      record.custom_init.empty() ? "/sbin/init" : record.custom_init;
+
+  out += "{";
+
+  out += "\"Id\":\"";
+  out += json_escape(record.uuid);
+  out += "\",";
+
+  out += "\"Names\":[\"/";
+  out += json_escape(record.name);
+  out += "\"],";
+
+  out += "\"Image\":\"";
+  out += json_escape(record.rootfs_path);
+  out += "\",";
+
+  out += "\"ImageID\":\"";
+  out += json_escape(record.uuid);
+  out += "\",";
+
+  out += "\"Command\":\"";
+  out += json_escape(command);
+  out += "\",";
+
+  out += "\"Created\":";
+  out += std::to_string(record.started_at > 0 ? record.started_at : 0);
+  out += ",";
+
+  append_ports_json(out, record);
+  out += ",";
+
+  out += "\"Labels\":{},";
+
+  out += "\"State\":\"";
+  out += container_state(record);
+  out += "\",";
+
+  out += "\"Status\":\"";
+  out += container_status(record);
+  out += "\",";
+
+  append_network_settings_json(out, record);
+  out += ",";
+
+  out += "\"Mounts\":[]";
+
+  out += "}";
+}
+
+}  // namespace
 
 bool request_container_list_json_from_core(
     const ContainerListRequest& request,
     std::string& json_out,
     std::string& error) {
-  (void)request;
   error.clear();
 
-  /*
-   * TODO(socketd-core-bridge):
-   * Replace this dummy payload with a request to the Droidspaces core through
-   * the private socketd backend protocol once Portainer-side behavior for the
-   * public /containers/json endpoint has been confirmed.
-   *
-   * The HTTP layer must continue to depend on this socketd-owned seam, not on
-   * core runtime internals directly.
-   */
-  json_out = "[]\n";
+  BackendClient backend;
+  std::vector<ContainerRecordResult> records;
+
+  if (!backend.list_containers(request.include_all, records, error)) {
+    return false;
+  }
+
+  std::string body;
+  body.reserve(256 + records.size() * 512);
+
+  body += "[";
+
+  for (std::size_t i = 0; i < records.size(); ++i) {
+    if (i != 0) {
+      body += ",";
+    }
+
+    append_container_json(body, records[i]);
+  }
+
+  body += "]\n";
+
+  json_out = std::move(body);
   return true;
 }
 

--- a/src/socketd/container_list.h
+++ b/src/socketd/container_list.h
@@ -17,12 +17,10 @@ struct ContainerListRequest {
 };
 
 /*
- * Socketd-owned seam for obtaining the container-list payload.
- *
- * For the current extension-only bring-up step this is deliberately a dummy:
- * it returns an empty Docker-shaped JSON list so Portainer can advance to its
- * next probe. Once that behavior is confirmed, this function becomes the
- * place where socketd requests real container data from the core bridge.
+ * Socketd-owned seam for obtaining the Docker-compatible container list
+ * payload. The HTTP server remains independent of backend protocol details;
+ * this layer requests typed core records through BackendClient and renders the
+ * public JSON shape expected by Docker-compatible consumers.
  */
 bool request_container_list_json_from_core(
     const ContainerListRequest& request,

--- a/src/socketd/event_log.cpp
+++ b/src/socketd/event_log.cpp
@@ -1,5 +1,7 @@
 #include "event_log.h"
 
+#include "backend_client.h"
+
 #include <algorithm>
 #include <chrono>
 #include <cstddef>
@@ -184,6 +186,24 @@ std::string encode_event_json_line(const SocketdEvent& event) {
   return out;
 }
 
+SocketdEvent socketd_event_from_core_event(const CoreEventResult& core) {
+  SocketdEvent event;
+  event.type = core.type;
+  event.action = core.action;
+  event.actor_id = core.actor_id;
+  event.time = core.time;
+  event.time_nano = core.time_nano;
+
+  if (!core.actor_name.empty()) {
+    event.attributes.push_back(EventAttribute{
+        "name",
+        core.actor_name,
+    });
+  }
+
+  return event;
+}
+
 }  // namespace
 
 void record_socketd_event(const std::string& type,
@@ -220,13 +240,6 @@ bool request_event_log_stream_from_core(
   error.clear();
   stream_out.clear();
 
-  /*
-   * TODO(socketd-core-events):
-   * This endpoint currently exposes extension-owned daemon events from the
-   * socketd-local event journal. When the socket extension has a validated
-   * need for core-runtime lifecycle events, merge in a backend-provided event
-   * stream behind this same socketd-owned seam.
-   */
   std::int64_t since = 0;
   std::int64_t until = 0;
 
@@ -243,11 +256,56 @@ bool request_event_log_stream_from_core(
     return false;
   }
 
+  std::vector<SocketdEvent> merged_events;
+  merged_events.reserve(g_socketd_events.size());
+
   for (const SocketdEvent& event : g_socketd_events) {
     if (!event_in_window(event, since, until)) {
       continue;
     }
 
+    merged_events.push_back(event);
+  }
+
+  BackendClient backend;
+  std::vector<CoreEventResult> core_events;
+  std::string backend_error;
+
+  if (backend.poll_events(since, core_events, backend_error)) {
+    merged_events.reserve(merged_events.size() + core_events.size());
+
+    for (const CoreEventResult& core_event : core_events) {
+      SocketdEvent event = socketd_event_from_core_event(core_event);
+
+      if (!event_in_window(event, since, until)) {
+        continue;
+      }
+
+      merged_events.push_back(std::move(event));
+    }
+  } else {
+    /*
+     * CONCERN(socketd-events):
+     * The event endpoint follows the current compatibility plan and degrades
+     * gracefully when the privileged backend is unavailable: socketd-local
+     * daemon events remain visible instead of failing the entire /events
+     * response. If a later contract requires hard backend failure, tighten
+     * that policy here.
+     */
+  }
+
+  std::stable_sort(
+      merged_events.begin(),
+      merged_events.end(),
+      [](const SocketdEvent& lhs, const SocketdEvent& rhs) {
+        if (lhs.time_nano != rhs.time_nano) {
+          return lhs.time_nano < rhs.time_nano;
+        }
+
+        return lhs.time < rhs.time;
+      });
+
+  for (const SocketdEvent& event : merged_events) {
     stream_out += encode_event_json_line(event);
   }
 

--- a/src/socketd/event_log.h
+++ b/src/socketd/event_log.h
@@ -17,10 +17,8 @@ struct SocketdEventAttributes {
 
 /*
  * Record a socketd-owned engine-style event in the extension-local journal.
- *
- * The public /events endpoint exposes this journal in Docker-compatible
- * event-stream form. This deliberately covers only events owned by the socket
- * extension itself; core-engine events remain a later, separate backend seam.
+ * These local daemon events are merged with backend core lifecycle events by
+ * request_event_log_stream_from_core().
  */
 void record_socketd_event(const std::string& type,
                           const std::string& action,
@@ -29,8 +27,11 @@ void record_socketd_event(const std::string& type,
                           std::size_t attribute_count);
 
 /*
- * Return historical socketd-owned events matching the requested time window
- * as a Docker-compatible stream of JSON objects.
+ * Return events matching the requested time window as a Docker-compatible
+ * stream of JSON objects. The response merges:
+ *
+ *   - socketd-owned local events recorded in this process, and
+ *   - core lifecycle events fetched from the privileged backend bridge.
  */
 bool request_event_log_stream_from_core(
     const EventsRequest& request,

--- a/src/socketd/snapshot_lists.cpp
+++ b/src/socketd/snapshot_lists.cpp
@@ -1,19 +1,127 @@
 #include "snapshot_lists.h"
 
+#include "backend_client.h"
+
+#include <cstddef>
+#include <string>
+#include <utility>
+#include <vector>
+
 namespace droidspaces::socketd {
+namespace {
+
+std::string json_escape(const std::string& input) {
+  std::string out;
+  out.reserve(input.size());
+
+  constexpr char kHex[] = "0123456789abcdef";
+
+  for (unsigned char ch : input) {
+    switch (ch) {
+      case '"':
+        out += "\\\"";
+        break;
+      case '\\':
+        out += "\\\\";
+        break;
+      case '\b':
+        out += "\\b";
+        break;
+      case '\f':
+        out += "\\f";
+        break;
+      case '\n':
+        out += "\\n";
+        break;
+      case '\r':
+        out += "\\r";
+        break;
+      case '\t':
+        out += "\\t";
+        break;
+      default:
+        if (ch < 0x20) {
+          out += "\\u00";
+          out += kHex[(ch >> 4) & 0x0f];
+          out += kHex[ch & 0x0f];
+        } else {
+          out += static_cast<char>(ch);
+        }
+        break;
+    }
+  }
+
+  return out;
+}
+
+void append_image_json(std::string& out,
+                       const ImageRecordResult& image) {
+  out += "{";
+
+  out += "\"Containers\":";
+  out += image.is_running ? "1" : "0";
+  out += ",";
+
+  out += "\"Created\":";
+  out += std::to_string(image.created_at > 0 ? image.created_at : 0);
+  out += ",";
+
+  out += "\"Id\":\"";
+  out += json_escape(image.uuid);
+  out += "\",";
+
+  out += "\"Labels\":{},";
+
+  out += "\"ParentId\":\"\",";
+
+  out += "\"RepoDigests\":[],";
+
+  out += "\"RepoTags\":[\"";
+  out += json_escape(image.name);
+  out += ":latest\"],";
+
+  /*
+   * CONCERN(socketd-images):
+   * This public image summary intentionally follows the current compatibility
+   * plan's minimal pseudo-image projection. If a later Docker/Portainer
+   * compatibility pass requires additional image-summary fields, extend this
+   * socketd JSON seam rather than changing the core-side image record.
+   */
+  out += "\"Size\":0,";
+  out += "\"VirtualSize\":0";
+
+  out += "}";
+}
+
+}  // namespace
 
 bool request_image_list_json_from_core(std::string& json_out,
                                        std::string& error) {
   error.clear();
 
-  /*
-   * TODO(socketd-snapshot-images):
-   * This is a deliberate dummy response. Portainer's snapshot pass requests
-   * /images/json, but Droidspaces has not yet decided whether Docker-style
-   * image inventory is meaningful to expose. Keep this extension-local until
-   * a socketd-owned need for core data is established.
-   */
-  json_out = "[]\n";
+  BackendClient backend;
+  std::vector<ImageRecordResult> images;
+
+  if (!backend.list_images(images, error)) {
+    return false;
+  }
+
+  std::string body;
+  body.reserve(256 + images.size() * 256);
+
+  body += "[";
+
+  for (std::size_t i = 0; i < images.size(); ++i) {
+    if (i != 0) {
+      body += ",";
+    }
+
+    append_image_json(body, images[i]);
+  }
+
+  body += "]\n";
+
+  json_out = std::move(body);
   return true;
 }
 
@@ -22,10 +130,8 @@ bool request_volume_list_json_from_core(std::string& json_out,
   error.clear();
 
   /*
-   * TODO(socketd-snapshot-volumes):
-   * This is a deliberate dummy response. The Docker-compatible /volumes route
-   * returns an object, not a bare array, so preserve that shape while exposing
-   * no volume inventory.
+   * Docker-managed named volumes have no direct Droidspaces analogue.
+   * Keep the endpoint structurally valid while intentionally exposing none.
    */
   json_out = "{\"Volumes\":[],\"Warnings\":[]}\n";
   return true;
@@ -36,12 +142,65 @@ bool request_network_list_json_from_core(std::string& json_out,
   error.clear();
 
   /*
-   * TODO(socketd-snapshot-networks):
-   * This is a deliberate dummy response. Portainer requests /networks during
-   * its snapshot pass; return a structurally valid empty list and avoid
-   * projecting Docker network semantics into the Droidspaces core.
+   * Fixed public compatibility facade for Droidspaces networking modes.
+   * These are socketd-owned Docker-shaped descriptors; no mutable Docker
+   * network object is being introduced into the core runtime.
    */
-  json_out = "[]\n";
+  json_out =
+      "["
+      "{"
+      "\"Name\":\"droidspaces-bridge\","
+      "\"Id\":\"droidspaces-bridge\","
+      "\"Created\":\"1970-01-01T00:00:00Z\","
+      "\"Scope\":\"local\","
+      "\"Driver\":\"bridge\","
+      "\"EnableIPv6\":false,"
+      "\"IPAM\":{\"Driver\":\"default\",\"Options\":{},\"Config\":[]},"
+      "\"Internal\":false,"
+      "\"Attachable\":false,"
+      "\"Ingress\":false,"
+      "\"ConfigFrom\":{\"Network\":\"\"},"
+      "\"ConfigOnly\":false,"
+      "\"Containers\":{},"
+      "\"Options\":{},"
+      "\"Labels\":{}"
+      "},"
+      "{"
+      "\"Name\":\"host\","
+      "\"Id\":\"host\","
+      "\"Created\":\"1970-01-01T00:00:00Z\","
+      "\"Scope\":\"local\","
+      "\"Driver\":\"host\","
+      "\"EnableIPv6\":false,"
+      "\"IPAM\":{\"Driver\":\"default\",\"Options\":{},\"Config\":[]},"
+      "\"Internal\":false,"
+      "\"Attachable\":false,"
+      "\"Ingress\":false,"
+      "\"ConfigFrom\":{\"Network\":\"\"},"
+      "\"ConfigOnly\":false,"
+      "\"Containers\":{},"
+      "\"Options\":{},"
+      "\"Labels\":{}"
+      "},"
+      "{"
+      "\"Name\":\"none\","
+      "\"Id\":\"none\","
+      "\"Created\":\"1970-01-01T00:00:00Z\","
+      "\"Scope\":\"local\","
+      "\"Driver\":\"null\","
+      "\"EnableIPv6\":false,"
+      "\"IPAM\":{\"Driver\":\"default\",\"Options\":{},\"Config\":[]},"
+      "\"Internal\":false,"
+      "\"Attachable\":false,"
+      "\"Ingress\":false,"
+      "\"ConfigFrom\":{\"Network\":\"\"},"
+      "\"ConfigOnly\":false,"
+      "\"Containers\":{},"
+      "\"Options\":{},"
+      "\"Labels\":{}"
+      "}"
+      "]\n";
+
   return true;
 }
 

--- a/src/socketd/snapshot_lists.h
+++ b/src/socketd/snapshot_lists.h
@@ -7,13 +7,10 @@ namespace droidspaces::socketd {
 /*
  * Extension-owned seams for Portainer snapshot inventory probes.
  *
- * These functions intentionally return dummy payloads for now. Portainer has
- * been observed requesting images, volumes, and networks during its Docker
- * snapshot pass after /containers/json succeeds.
- *
- * No core-engine change is warranted at this stage: first we confirm that
- * Portainer's UI settles when these discovery probes receive structurally
- * valid empty responses.
+ * Images are rendered from typed backend pseudo-image records. Volumes and
+ * networks remain socketd-owned compatibility projections: Droidspaces has no
+ * Docker-managed named-volume model, while the network list is a fixed public
+ * facade over Droidspaces networking modes.
  */
 
 bool request_image_list_json_from_core(std::string& json_out,

--- a/src/socketd_bridge.c
+++ b/src/socketd_bridge.c
@@ -356,6 +356,57 @@ static int socketd_append_container_record(
   return 0;
 }
 
+static int socketd_count_installed_containers(uint32_t *count_out) {
+  if (!count_out)
+    return -1;
+
+  *count_out = 0;
+
+  char containers_path[PATH_MAX];
+  snprintf(containers_path, sizeof(containers_path), "%s/Containers",
+           get_workspace_dir());
+
+  DIR *containers_dir = opendir(containers_path);
+  if (!containers_dir) {
+    if (errno == ENOENT)
+      return 0;
+    return -1;
+  }
+
+  uint32_t count = 0;
+  struct dirent *ent;
+
+  /*
+   * CONCERN(socketd-info):
+   * Treat the workspace inventory as the source of "installed" containers:
+   * only valid container-name entries with a loadable mirrored config count
+   * here. This keeps INFO aligned with the same installed-container view that
+   * the later LIST_IMAGES pass will expose.
+   */
+  while ((ent = readdir(containers_dir)) != NULL) {
+    if (ent->d_name[0] == '.')
+      continue;
+
+    if (!validate_container_name(ent->d_name))
+      continue;
+
+    struct ds_config cfg;
+    memset(&cfg, 0, sizeof(cfg));
+
+    if (ds_config_load_by_name(ent->d_name, &cfg) == 0 &&
+        cfg.config_file_existed) {
+      if (count < UINT32_MAX)
+        count++;
+    }
+
+    socketd_free_loaded_config(&cfg);
+  }
+
+  closedir(containers_dir);
+  *count_out = count;
+  return 0;
+}
+
 static void socketd_handle_conn(int conn) {
   struct ds_socketd_request_header req;
   memset(&req, 0, sizeof(req));
@@ -420,9 +471,51 @@ static void socketd_handle_conn(int conn) {
     uint32_t caps_be = htonl(DS_SOCKETD_CAP_PROTOCOL_V1 |
                              DS_SOCKETD_CAP_PING |
                              DS_SOCKETD_CAP_CAPABILITIES |
+                             DS_SOCKETD_CAP_INFO |
                              DS_SOCKETD_CAP_LIST_CONTAINERS);
     socketd_send_response(conn, DS_SOCKETD_STATUS_OK, &caps_be,
                           (uint32_t)sizeof(caps_be));
+    return;
+  }
+  
+    case DS_SOCKETD_OP_INFO: {
+    if (payload_len > 0 &&
+        socketd_discard_payload(conn, payload_len) < 0) {
+      socketd_send_response(conn, DS_SOCKETD_STATUS_BAD_REQUEST, NULL, 0);
+      return;
+    }
+
+    uint32_t installed_count = 0;
+    if (socketd_count_installed_containers(&installed_count) < 0) {
+      socketd_send_response(conn, DS_SOCKETD_STATUS_INTERNAL_ERROR, NULL, 0);
+      return;
+    }
+
+    int running_i = count_running_containers(NULL, 0);
+    uint32_t running_count =
+        running_i > 0 ? (uint32_t)running_i : 0u;
+
+    /*
+     * CONCERN(socketd-info):
+     * Running sidecar state and mirrored workspace-config state are maintained
+     * through separate recovery paths. Keep subtraction saturating so a
+     * transient metadata mismatch never underflows the wire-format stopped
+     * counter.
+     */
+    uint32_t stopped_count =
+        installed_count > running_count
+            ? installed_count - running_count
+            : 0u;
+
+    struct ds_socketd_info_payload info;
+    memset(&info, 0, sizeof(info));
+
+    info.containers_total_be = htonl(installed_count);
+    info.containers_running_be = htonl(running_count);
+    info.containers_stopped_be = htonl(stopped_count);
+
+    socketd_send_response(conn, DS_SOCKETD_STATUS_OK, &info,
+                          (uint32_t)sizeof(info));
     return;
   }
 
@@ -589,7 +682,6 @@ static void socketd_handle_conn(int conn) {
     return;
   }
 
-  case DS_SOCKETD_OP_INFO:
   case DS_SOCKETD_OP_INSPECT_CONTAINER:
   case DS_SOCKETD_OP_START_CONTAINER:
   case DS_SOCKETD_OP_STOP_CONTAINER:

--- a/src/socketd_bridge.c
+++ b/src/socketd_bridge.c
@@ -121,6 +121,9 @@ static uint64_t socketd_hton64(uint64_t value) {
          (uint64_t)htonl((uint32_t)(value >> 32));
 #endif
 }
+static uint64_t socketd_ntoh64(uint64_t value) {
+  return socketd_hton64(value); //The byte swap is symmetric. Could be an alias via __attribute__
+}
 
 static int socketd_read_proc_start_ticks(pid_t pid,
                                          unsigned long long *ticks_out) {
@@ -427,6 +430,44 @@ static int socketd_append_image_record(
   return 0;
 }
 
+static int socketd_append_core_event_record(
+    struct ds_socketd_core_event_record **records_inout,
+    size_t *count_inout,
+    size_t *capacity_inout,
+    const struct ds_socketd_core_event_record *record) {
+  if (!records_inout || !count_inout || !capacity_inout || !record)
+    return -1;
+
+  if (*count_inout >= *capacity_inout) {
+    size_t old_capacity = *capacity_inout;
+    size_t new_capacity = old_capacity == 0 ? 16u : old_capacity * 2u;
+
+    if (new_capacity < old_capacity)
+      return -1;
+
+    if (new_capacity >
+        DS_SOCKETD_MAX_PAYLOAD /
+            sizeof(struct ds_socketd_core_event_record)) {
+      return -1;
+    }
+
+    struct ds_socketd_core_event_record *grown =
+        realloc(*records_inout, new_capacity * sizeof(*grown));
+    if (!grown)
+      return -1;
+
+    memset(grown + old_capacity, 0,
+           (new_capacity - old_capacity) * sizeof(*grown));
+
+    *records_inout = grown;
+    *capacity_inout = new_capacity;
+  }
+
+  (*records_inout)[*count_inout] = *record;
+  (*count_inout)++;
+  return 0;
+}
+
 static int socketd_count_installed_containers(uint32_t *count_out) {
   if (!count_out)
     return -1;
@@ -476,6 +517,15 @@ static int socketd_count_installed_containers(uint32_t *count_out) {
   closedir(containers_dir);
   *count_out = count;
   return 0;
+}
+
+static int socketd_build_core_event_path(char *path, size_t path_size) {
+  if (!path || path_size == 0)
+    return -1;
+
+  int r = snprintf(path, path_size, "%.4076s/socketd-events.bin",
+                   get_logs_dir());
+  return (r > 0 && (size_t)r < path_size) ? 0 : -1;
 }
 
 static void socketd_handle_conn(int conn) {
@@ -544,7 +594,8 @@ static void socketd_handle_conn(int conn) {
                              DS_SOCKETD_CAP_CAPABILITIES |
                              DS_SOCKETD_CAP_INFO |
                              DS_SOCKETD_CAP_LIST_CONTAINERS |
-                             DS_SOCKETD_CAP_LIST_IMAGES);
+                             DS_SOCKETD_CAP_LIST_IMAGES |
+                             DS_SOCKETD_CAP_POLL_EVENTS);
     socketd_send_response(conn, DS_SOCKETD_STATUS_OK, &caps_be,
                           (uint32_t)sizeof(caps_be));
     return;
@@ -826,6 +877,88 @@ static void socketd_handle_conn(int conn) {
       socketd_send_response(conn, DS_SOCKETD_STATUS_INTERNAL_ERROR, NULL, 0);
       return;
     }
+
+    uint32_t payload_bytes =
+        (uint32_t)(record_count * sizeof(*records));
+
+    socketd_send_response(conn, DS_SOCKETD_STATUS_OK, records,
+                          payload_bytes);
+    free(records);
+    return;
+  }
+  
+    case DS_SOCKETD_OP_POLL_EVENTS: {
+    struct ds_socketd_poll_events_req poll_req;
+    memset(&poll_req, 0, sizeof(poll_req));
+
+    /*
+     * A zero-length request means "all events currently retained".
+     */
+    if (payload_len != 0 &&
+        socketd_read_payload(conn, &poll_req,
+                             (uint32_t)sizeof(poll_req),
+                             payload_len) < 0) {
+      socketd_send_response(conn, DS_SOCKETD_STATUS_BAD_REQUEST, NULL, 0);
+      return;
+    }
+
+    int64_t since =
+        (int64_t)socketd_ntoh64((uint64_t)poll_req.since_be);
+
+    char event_path[PATH_MAX];
+    if (socketd_build_core_event_path(event_path, sizeof(event_path)) < 0) {
+      socketd_send_response(conn, DS_SOCKETD_STATUS_INTERNAL_ERROR, NULL, 0);
+      return;
+    }
+
+    FILE *f = fopen(event_path, "re");
+    if (!f) {
+      if (errno == ENOENT) {
+        socketd_send_response(conn, DS_SOCKETD_STATUS_OK, NULL, 0);
+        return;
+      }
+
+      socketd_send_response(conn, DS_SOCKETD_STATUS_INTERNAL_ERROR, NULL, 0);
+      return;
+    }
+
+    size_t capacity = 16;
+    struct ds_socketd_core_event_record *records =
+        calloc(capacity, sizeof(*records));
+    if (!records) {
+      fclose(f);
+      socketd_send_response(conn, DS_SOCKETD_STATUS_INTERNAL_ERROR, NULL, 0);
+      return;
+    }
+
+    size_t record_count = 0;
+    struct ds_socketd_core_event_record record;
+
+    while (fread(&record, sizeof(record), 1, f) == 1) {
+      int64_t record_time =
+          (int64_t)socketd_ntoh64((uint64_t)record.time_be);
+
+      if (record_time < since)
+        continue;
+
+      if (socketd_append_core_event_record(&records, &record_count,
+                                           &capacity, &record) < 0) {
+        fclose(f);
+        free(records);
+        socketd_send_response(conn, DS_SOCKETD_STATUS_INTERNAL_ERROR,
+                              NULL, 0);
+        return;
+      }
+    }
+
+    if (ferror(f)) {
+      fclose(f);
+      free(records);
+      socketd_send_response(conn, DS_SOCKETD_STATUS_INTERNAL_ERROR, NULL, 0);
+      return;
+    }
+
+    fclose(f);
 
     uint32_t payload_bytes =
         (uint32_t)(record_count * sizeof(*records));

--- a/src/socketd_bridge.c
+++ b/src/socketd_bridge.c
@@ -356,6 +356,77 @@ static int socketd_append_container_record(
   return 0;
 }
 
+static void socketd_pack_image_record(
+    struct ds_socketd_image_record *record,
+    const struct ds_config *cfg,
+    int is_running) {
+  memset(record, 0, sizeof(*record));
+
+  safe_strncpy(record->name, cfg->container_name, sizeof(record->name));
+
+  /*
+   * The plan defines pseudo-images as the rootfs object associated with each
+   * installed container config. For image-backed containers, preserve the
+   * underlying image-file path; otherwise expose the configured rootfs path.
+   */
+  if (cfg->rootfs_img_path[0]) {
+    safe_strncpy(record->rootfs_path, cfg->rootfs_img_path,
+                 sizeof(record->rootfs_path));
+  } else {
+    safe_strncpy(record->rootfs_path, cfg->rootfs_path,
+                 sizeof(record->rootfs_path));
+  }
+
+  safe_strncpy(record->uuid, cfg->uuid, sizeof(record->uuid));
+
+  record->is_running_be = (int32_t)htonl(is_running ? 1u : 0u);
+
+  /*
+   * Droidspaces container configs do not currently persist an explicit
+   * creation timestamp. The wire contract reserves this field for later
+   * enrichment; Phase 2.5 intentionally reports "unknown" as zero.
+   */
+  record->created_at_be = (int64_t)socketd_hton64(0);
+}
+
+static int socketd_append_image_record(
+    struct ds_socketd_image_record **records_inout,
+    size_t *count_inout,
+    size_t *capacity_inout,
+    const struct ds_socketd_image_record *record) {
+  if (!records_inout || !count_inout || !capacity_inout || !record)
+    return -1;
+
+  if (*count_inout >= *capacity_inout) {
+    size_t old_capacity = *capacity_inout;
+    size_t new_capacity = old_capacity == 0 ? 16u : old_capacity * 2u;
+
+    if (new_capacity < old_capacity)
+      return -1;
+
+    if (new_capacity >
+        DS_SOCKETD_MAX_PAYLOAD /
+            sizeof(struct ds_socketd_image_record)) {
+      return -1;
+    }
+
+    struct ds_socketd_image_record *grown =
+        realloc(*records_inout, new_capacity * sizeof(*grown));
+    if (!grown)
+      return -1;
+
+    memset(grown + old_capacity, 0,
+           (new_capacity - old_capacity) * sizeof(*grown));
+
+    *records_inout = grown;
+    *capacity_inout = new_capacity;
+  }
+
+  (*records_inout)[*count_inout] = *record;
+  (*count_inout)++;
+  return 0;
+}
+
 static int socketd_count_installed_containers(uint32_t *count_out) {
   if (!count_out)
     return -1;
@@ -472,7 +543,8 @@ static void socketd_handle_conn(int conn) {
                              DS_SOCKETD_CAP_PING |
                              DS_SOCKETD_CAP_CAPABILITIES |
                              DS_SOCKETD_CAP_INFO |
-                             DS_SOCKETD_CAP_LIST_CONTAINERS);
+                             DS_SOCKETD_CAP_LIST_CONTAINERS |
+                             DS_SOCKETD_CAP_LIST_IMAGES);
     socketd_send_response(conn, DS_SOCKETD_STATUS_OK, &caps_be,
                           (uint32_t)sizeof(caps_be));
     return;
@@ -671,6 +743,88 @@ static void socketd_handle_conn(int conn) {
                               NULL, 0);
         return;
       }
+    }
+
+    uint32_t payload_bytes =
+        (uint32_t)(record_count * sizeof(*records));
+
+    socketd_send_response(conn, DS_SOCKETD_STATUS_OK, records,
+                          payload_bytes);
+    free(records);
+    return;
+  }
+  
+    case DS_SOCKETD_OP_LIST_IMAGES: {
+    if (payload_len > 0 &&
+        socketd_discard_payload(conn, payload_len) < 0) {
+      socketd_send_response(conn, DS_SOCKETD_STATUS_BAD_REQUEST, NULL, 0);
+      return;
+    }
+
+    size_t capacity = 16;
+    struct ds_socketd_image_record *records =
+        calloc(capacity, sizeof(*records));
+    if (!records) {
+      socketd_send_response(conn, DS_SOCKETD_STATUS_INTERNAL_ERROR, NULL, 0);
+      return;
+    }
+
+    size_t record_count = 0;
+
+    char containers_path[PATH_MAX];
+    snprintf(containers_path, sizeof(containers_path), "%s/Containers",
+             get_workspace_dir());
+
+    DIR *containers_dir = opendir(containers_path);
+    if (containers_dir) {
+      struct dirent *ent;
+
+      /*
+       * One pseudo-image record is emitted for each installed container config,
+       * as defined by the implementation plan. The bridge does not attempt to
+       * deduplicate configs that happen to reference the same rootfs object.
+       */
+      while ((ent = readdir(containers_dir)) != NULL) {
+        if (ent->d_name[0] == '.')
+          continue;
+
+        if (!validate_container_name(ent->d_name))
+          continue;
+
+        struct ds_config cfg;
+        memset(&cfg, 0, sizeof(cfg));
+
+        if (ds_config_load_by_name(ent->d_name, &cfg) < 0 ||
+            !cfg.config_file_existed) {
+          socketd_free_loaded_config(&cfg);
+          continue;
+        }
+
+        pid_t pid = 0;
+        int is_running =
+            is_container_running(&cfg, &pid) && pid > 0;
+
+        struct ds_socketd_image_record record;
+        socketd_pack_image_record(&record, &cfg, is_running);
+
+        if (socketd_append_image_record(&records, &record_count,
+                                        &capacity, &record) < 0) {
+          socketd_free_loaded_config(&cfg);
+          closedir(containers_dir);
+          free(records);
+          socketd_send_response(conn, DS_SOCKETD_STATUS_INTERNAL_ERROR,
+                                NULL, 0);
+          return;
+        }
+
+        socketd_free_loaded_config(&cfg);
+      }
+
+      closedir(containers_dir);
+    } else if (errno != ENOENT) {
+      free(records);
+      socketd_send_response(conn, DS_SOCKETD_STATUS_INTERNAL_ERROR, NULL, 0);
+      return;
     }
 
     uint32_t payload_bytes =

--- a/src/socketd_bridge.c
+++ b/src/socketd_bridge.c
@@ -99,6 +99,263 @@ static int socketd_discard_payload(int fd, uint32_t len) {
   return 0;
 }
 
+static int socketd_read_payload(int fd, void *buf, uint32_t expected_len,
+                                uint32_t actual_len) {
+  if (actual_len != expected_len)
+    return -1;
+  return socketd_read_exact(fd, buf, expected_len);
+}
+
+/*
+ * Wire-format 64-bit host -> network conversion.
+ *
+ * CONCERN(socketd-wire):
+ * The private protocol now carries several int64_t timestamp fields. Keep
+ * conversion explicit here rather than relying on a non-standard htonll().
+ */
+static uint64_t socketd_hton64(uint64_t value) {
+#if defined(__BYTE_ORDER__) && (__BYTE_ORDER__ == __ORDER_BIG_ENDIAN__)
+  return value;
+#else
+  return ((uint64_t)htonl((uint32_t)(value & 0xffffffffULL)) << 32) |
+         (uint64_t)htonl((uint32_t)(value >> 32));
+#endif
+}
+
+static int socketd_read_proc_start_ticks(pid_t pid,
+                                         unsigned long long *ticks_out) {
+  if (pid <= 0 || ticks_out == NULL)
+    return -1;
+
+  char path[PATH_MAX];
+  snprintf(path, sizeof(path), "/proc/%d/stat", pid);
+
+  FILE *f = fopen(path, "re");
+  if (!f)
+    return -1;
+
+  char stat_buf[4096];
+  size_t n = fread(stat_buf, 1, sizeof(stat_buf) - 1, f);
+  int read_failed = ferror(f);
+  fclose(f);
+
+  if (read_failed || n == 0)
+    return -1;
+
+  stat_buf[n] = '\0';
+
+  char *rparen = strrchr(stat_buf, ')');
+  if (!rparen || rparen[1] != ' ')
+    return -1;
+
+  /*
+   * /proc/<pid>/stat field 2 is the parenthesized command name and may
+   * contain spaces. Start tokenizing only after the final ')' so that field
+   * numbering remains aligned with procfs; starttime is field 22.
+   */
+  char *cursor = rparen + 2;
+  char *saveptr = NULL;
+  int field_no = 3;
+
+  for (char *tok = strtok_r(cursor, " \t\r\n", &saveptr);
+       tok != NULL;
+       tok = strtok_r(NULL, " \t\r\n", &saveptr), field_no++) {
+    if (field_no == 22) {
+      char *end = NULL;
+      errno = 0;
+      unsigned long long ticks = strtoull(tok, &end, 10);
+      if (errno != 0 || end == tok || *end != '\0')
+        return -1;
+
+      *ticks_out = ticks;
+      return 0;
+    }
+  }
+
+  return -1;
+}
+
+static int socketd_read_uptime_seconds(double *uptime_out) {
+  if (!uptime_out)
+    return -1;
+
+  FILE *f = fopen("/proc/uptime", "re");
+  if (!f)
+    return -1;
+
+  double uptime = 0.0;
+  int scanned = fscanf(f, "%lf", &uptime);
+  fclose(f);
+
+  if (scanned != 1 || uptime < 0.0)
+    return -1;
+
+  *uptime_out = uptime;
+  return 0;
+}
+
+static int64_t socketd_container_started_at_epoch(pid_t pid) {
+  unsigned long long start_ticks = 0;
+  double uptime_seconds = 0.0;
+
+  if (socketd_read_proc_start_ticks(pid, &start_ticks) < 0)
+    return 0;
+
+  if (socketd_read_uptime_seconds(&uptime_seconds) < 0)
+    return 0;
+
+  long ticks_per_second = sysconf(_SC_CLK_TCK);
+  if (ticks_per_second <= 0)
+    return 0;
+
+  struct timespec now;
+  if (clock_gettime(CLOCK_REALTIME, &now) < 0)
+    return 0;
+
+  double started_since_boot =
+      (double)start_ticks / (double)ticks_per_second;
+  double boot_epoch = (double)now.tv_sec - uptime_seconds;
+  double started_epoch = boot_epoch + started_since_boot;
+
+  if (started_epoch <= 0.0 || started_epoch > (double)INT64_MAX)
+    return 0;
+
+  return (int64_t)started_epoch;
+}
+
+static int socketd_pidfile_to_container_name(const char *filename,
+                                              char *name_out,
+                                              size_t name_size) {
+  if (!filename || !name_out || name_size == 0)
+    return -1;
+
+  size_t filename_len = strlen(filename);
+  size_t suffix_len = strlen(DS_EXT_PID);
+
+  if (filename_len <= suffix_len)
+    return -1;
+
+  if (strcmp(filename + filename_len - suffix_len, DS_EXT_PID) != 0)
+    return -1;
+
+  size_t name_len = filename_len - suffix_len;
+  if (name_len >= name_size)
+    return -1;
+
+  memcpy(name_out, filename, name_len);
+  name_out[name_len] = '\0';
+
+  return validate_container_name(name_out) ? 0 : -1;
+}
+
+static void socketd_free_loaded_config(struct ds_config *cfg) {
+  free_config_binds(cfg);
+  free_config_env_vars(cfg);
+  free_config_unknown_lines(cfg);
+}
+
+static void socketd_pack_container_record(
+    struct ds_socketd_container_record *record,
+    const struct ds_config *cfg,
+    pid_t pid) {
+  memset(record, 0, sizeof(*record));
+
+  safe_strncpy(record->name, cfg->container_name, sizeof(record->name));
+
+  /*
+   * CONCERN(socketd-identity):
+   * This private wire record follows the current plan and forwards the
+   * Droidspaces config UUID verbatim. Any public Docker-compatible identity
+   * policy remains the responsibility of the C++ JSON seam.
+   */
+  safe_strncpy(record->uuid, cfg->uuid, sizeof(record->uuid));
+
+  /*
+   * CONCERN(socketd-container-list):
+   * Phase 2.3 follows the implementation plan literally and exports
+   * cfg->rootfs_path here. Any later distinction between mounted rootfs paths
+   * and rootfs image source paths must be settled deliberately at the
+   * compatibility boundary.
+   */
+  safe_strncpy(record->rootfs_path, cfg->rootfs_path,
+               sizeof(record->rootfs_path));
+
+  safe_strncpy(record->hostname, cfg->hostname, sizeof(record->hostname));
+
+  if (cfg->net_mode == DS_NET_NAT) {
+    const char *nat_ip =
+        cfg->static_nat_ip[0] ? cfg->static_nat_ip : cfg->nat_container_ip;
+    safe_strncpy(record->nat_ip, nat_ip, sizeof(record->nat_ip));
+  }
+
+  safe_strncpy(record->custom_init, cfg->custom_init,
+               sizeof(record->custom_init));
+
+  record->pid_be = (int32_t)htonl((uint32_t)(pid > 0 ? pid : 0));
+  record->net_mode = (uint8_t)cfg->net_mode;
+
+  int port_count = cfg->port_forward_count;
+  if (port_count < 0)
+    port_count = 0;
+  if (port_count > DS_SOCKETD_RECORD_PORTS_MAX)
+    port_count = DS_SOCKETD_RECORD_PORTS_MAX;
+
+  record->port_count = (uint8_t)port_count;
+
+  for (int i = 0; i < port_count; i++) {
+    const struct ds_port_forward *src = &cfg->port_forwards[i];
+    struct ds_socketd_port_record *dst = &record->ports[i];
+
+    dst->host_port_be = htons(src->host_port);
+    dst->host_port_end_be = htons(src->host_port_end);
+    dst->container_port_be = htons(src->container_port);
+    dst->container_port_end_be = htons(src->container_port_end);
+    dst->proto = (strcmp(src->proto, "udp") == 0) ? 1u : 0u;
+  }
+
+  int64_t started_at = pid > 0 ? socketd_container_started_at_epoch(pid) : 0;
+  record->started_at_be =
+      (int64_t)socketd_hton64((uint64_t)started_at);
+}
+
+static int socketd_append_container_record(
+    struct ds_socketd_container_record **records_inout,
+    size_t *count_inout,
+    size_t *capacity_inout,
+    const struct ds_socketd_container_record *record) {
+  if (!records_inout || !count_inout || !capacity_inout || !record)
+    return -1;
+
+  if (*count_inout >= *capacity_inout) {
+    size_t old_capacity = *capacity_inout;
+    size_t new_capacity = old_capacity == 0 ? 16u : old_capacity * 2u;
+
+    if (new_capacity < old_capacity)
+      return -1;
+
+    if (new_capacity >
+        DS_SOCKETD_MAX_PAYLOAD /
+            sizeof(struct ds_socketd_container_record)) {
+      return -1;
+    }
+
+    struct ds_socketd_container_record *grown =
+        realloc(*records_inout, new_capacity * sizeof(*grown));
+    if (!grown)
+      return -1;
+
+    memset(grown + old_capacity, 0,
+           (new_capacity - old_capacity) * sizeof(*grown));
+
+    *records_inout = grown;
+    *capacity_inout = new_capacity;
+  }
+
+  (*records_inout)[*count_inout] = *record;
+  (*count_inout)++;
+  return 0;
+}
+
 static void socketd_handle_conn(int conn) {
   struct ds_socketd_request_header req;
   memset(&req, 0, sizeof(req));
@@ -132,13 +389,21 @@ static void socketd_handle_conn(int conn) {
    * The currently implemented opcodes do not consume payloads, but draining
    * a well-sized payload keeps the framing strict and future-proofs callers.
    */
+#if 0
   if (payload_len > 0 && socketd_discard_payload(conn, payload_len) < 0) {
     socketd_send_response(conn, DS_SOCKETD_STATUS_BAD_REQUEST, NULL, 0);
     return;
   }
+#endif //deprecated
 
   switch ((enum ds_socketd_opcode)opcode) {
   case DS_SOCKETD_OP_PING: {
+    if (payload_len > 0 &&
+        socketd_discard_payload(conn, payload_len) < 0) {
+      socketd_send_response(conn, DS_SOCKETD_STATUS_BAD_REQUEST, NULL, 0);
+      return;
+    }
+
     static const char pong[] = "PONG";
     socketd_send_response(conn, DS_SOCKETD_STATUS_OK, pong,
                           (uint32_t)(sizeof(pong) - 1));
@@ -146,16 +411,185 @@ static void socketd_handle_conn(int conn) {
   }
 
   case DS_SOCKETD_OP_CAPABILITIES: {
+    if (payload_len > 0 &&
+        socketd_discard_payload(conn, payload_len) < 0) {
+      socketd_send_response(conn, DS_SOCKETD_STATUS_BAD_REQUEST, NULL, 0);
+      return;
+    }
+
     uint32_t caps_be = htonl(DS_SOCKETD_CAP_PROTOCOL_V1 |
                              DS_SOCKETD_CAP_PING |
-                             DS_SOCKETD_CAP_CAPABILITIES);
+                             DS_SOCKETD_CAP_CAPABILITIES |
+                             DS_SOCKETD_CAP_LIST_CONTAINERS);
     socketd_send_response(conn, DS_SOCKETD_STATUS_OK, &caps_be,
                           (uint32_t)sizeof(caps_be));
     return;
   }
 
+  case DS_SOCKETD_OP_LIST_CONTAINERS: {
+    struct ds_socketd_list_containers_req list_req;
+    memset(&list_req, 0, sizeof(list_req));
+
+    /*
+     * A zero-length payload is accepted as the historical default:
+     * running containers only.
+     */
+    if (payload_len != 0 &&
+        socketd_read_payload(conn, &list_req,
+                             (uint32_t)sizeof(list_req),
+                             payload_len) < 0) {
+      socketd_send_response(conn, DS_SOCKETD_STATUS_BAD_REQUEST, NULL, 0);
+      return;
+    }
+
+    int running_hint = count_running_containers(NULL, 0);
+
+    size_t capacity = 16;
+    if (running_hint > 16)
+      capacity = (size_t)running_hint;
+
+    if (capacity >
+        DS_SOCKETD_MAX_PAYLOAD /
+            sizeof(struct ds_socketd_container_record)) {
+      socketd_send_response(conn, DS_SOCKETD_STATUS_INTERNAL_ERROR, NULL, 0);
+      return;
+    }
+
+    struct ds_socketd_container_record *records =
+        calloc(capacity, sizeof(*records));
+    if (!records) {
+      socketd_send_response(conn, DS_SOCKETD_STATUS_INTERNAL_ERROR, NULL, 0);
+      return;
+    }
+
+    size_t record_count = 0;
+
+    /*
+     * Pass 1: running containers from the Pids/ directory.
+     *
+     * This mirrors the runtime's own status/reporting scans and keeps the
+     * bridge anchored to the existing PID-sidecar authority.
+     */
+    DIR *pids_dir = opendir(get_pids_dir());
+    if (pids_dir) {
+      struct dirent *ent;
+
+      while ((ent = readdir(pids_dir)) != NULL) {
+        char name[256];
+        if (socketd_pidfile_to_container_name(ent->d_name, name,
+                                              sizeof(name)) < 0) {
+          continue;
+        }
+
+        struct ds_config cfg;
+        memset(&cfg, 0, sizeof(cfg));
+
+        if (ds_config_load_by_name(name, &cfg) < 0 ||
+            !cfg.config_file_existed) {
+          socketd_free_loaded_config(&cfg);
+          continue;
+        }
+
+        pid_t pid = 0;
+        if (!is_container_running(&cfg, &pid) || pid <= 0) {
+          socketd_free_loaded_config(&cfg);
+          continue;
+        }
+
+        struct ds_socketd_container_record record;
+        socketd_pack_container_record(&record, &cfg, pid);
+
+        if (socketd_append_container_record(&records, &record_count,
+                                            &capacity, &record) < 0) {
+          socketd_free_loaded_config(&cfg);
+          closedir(pids_dir);
+          free(records);
+          socketd_send_response(conn, DS_SOCKETD_STATUS_INTERNAL_ERROR,
+                                NULL, 0);
+          return;
+        }
+
+        socketd_free_loaded_config(&cfg);
+      }
+
+      closedir(pids_dir);
+    } else if (errno != ENOENT) {
+      free(records);
+      socketd_send_response(conn, DS_SOCKETD_STATUS_INTERNAL_ERROR, NULL, 0);
+      return;
+    }
+
+    /*
+     * Pass 2: when include_all is set, append stopped installed containers
+     * from Containers/. Running ones are skipped because they were already
+     * emitted by the PID-sidecar pass above.
+     */
+    if (list_req.include_all) {
+      char containers_path[PATH_MAX];
+      snprintf(containers_path, sizeof(containers_path), "%s/Containers",
+               get_workspace_dir());
+
+      DIR *containers_dir = opendir(containers_path);
+      if (containers_dir) {
+        struct dirent *ent;
+
+        while ((ent = readdir(containers_dir)) != NULL) {
+          if (ent->d_name[0] == '.')
+            continue;
+
+          if (!validate_container_name(ent->d_name))
+            continue;
+
+          struct ds_config cfg;
+          memset(&cfg, 0, sizeof(cfg));
+
+          if (ds_config_load_by_name(ent->d_name, &cfg) < 0 ||
+              !cfg.config_file_existed) {
+            socketd_free_loaded_config(&cfg);
+            continue;
+          }
+
+          pid_t pid = 0;
+          if (is_container_running(&cfg, &pid) && pid > 0) {
+            socketd_free_loaded_config(&cfg);
+            continue;
+          }
+
+          struct ds_socketd_container_record record;
+          socketd_pack_container_record(&record, &cfg, 0);
+
+          if (socketd_append_container_record(&records, &record_count,
+                                              &capacity, &record) < 0) {
+            socketd_free_loaded_config(&cfg);
+            closedir(containers_dir);
+            free(records);
+            socketd_send_response(conn, DS_SOCKETD_STATUS_INTERNAL_ERROR,
+                                  NULL, 0);
+            return;
+          }
+
+          socketd_free_loaded_config(&cfg);
+        }
+
+        closedir(containers_dir);
+      } else if (errno != ENOENT) {
+        free(records);
+        socketd_send_response(conn, DS_SOCKETD_STATUS_INTERNAL_ERROR,
+                              NULL, 0);
+        return;
+      }
+    }
+
+    uint32_t payload_bytes =
+        (uint32_t)(record_count * sizeof(*records));
+
+    socketd_send_response(conn, DS_SOCKETD_STATUS_OK, records,
+                          payload_bytes);
+    free(records);
+    return;
+  }
+
   case DS_SOCKETD_OP_INFO:
-  case DS_SOCKETD_OP_LIST_CONTAINERS:
   case DS_SOCKETD_OP_INSPECT_CONTAINER:
   case DS_SOCKETD_OP_START_CONTAINER:
   case DS_SOCKETD_OP_STOP_CONTAINER:

--- a/src/socketd_protocol.h
+++ b/src/socketd_protocol.h
@@ -148,6 +148,12 @@ struct DS_SOCKETD_PACKED ds_socketd_image_record {
   uint8_t _pad[4];
 };
 
+struct DS_SOCKETD_PACKED ds_socketd_info_payload {
+  uint32_t containers_total_be;
+  uint32_t containers_running_be;
+  uint32_t containers_stopped_be;
+};
+
 /*
  * CONCERN(socketd-wire):
  * created_at_be is likewise a 64-bit network-order field and needs the same

--- a/src/socketd_protocol.h
+++ b/src/socketd_protocol.h
@@ -12,6 +12,16 @@
 
 #include <stdint.h>
 
+#include "droidspace.h"
+
+/*
+ * CONCERN(socketd-wire):
+ * The Phase 1 protocol records intentionally reuse DS_UUID_LEN and
+ * INET_ADDRSTRLEN from the core runtime's public definitions. This keeps the
+ * wire format aligned with the current Droidspaces identity/address widths,
+ * but it also means this protocol header is no longer width-self-contained.
+ */
+
 #if defined(__GNUC__)
 #define DS_SOCKETD_PACKED __attribute__((packed))
 #else
@@ -34,6 +44,8 @@ enum ds_socketd_opcode {
   DS_SOCKETD_OP_START_CONTAINER = 6,
   DS_SOCKETD_OP_STOP_CONTAINER = 7,
   DS_SOCKETD_OP_RESTART_CONTAINER = 8,
+  DS_SOCKETD_OP_LIST_IMAGES = 9,
+  DS_SOCKETD_OP_POLL_EVENTS = 10,
 };
 
 enum ds_socketd_status {
@@ -53,7 +65,94 @@ enum ds_socketd_capability {
   DS_SOCKETD_CAP_LIST_CONTAINERS = 1u << 4,
   DS_SOCKETD_CAP_INSPECT_CONTAINER = 1u << 5,
   DS_SOCKETD_CAP_LIFECYCLE = 1u << 6,
+  DS_SOCKETD_CAP_LIST_IMAGES = 1u << 7,
+  DS_SOCKETD_CAP_POLL_EVENTS = 1u << 8,
 };
+
+#define DS_SOCKETD_RECORD_NAME_MAX   256
+#define DS_SOCKETD_RECORD_PATH_MAX  1024
+#define DS_SOCKETD_RECORD_PORTS_MAX   16
+
+/*
+ * CONCERN(socketd-wire):
+ * This protocol-visible port array width follows the current implementation
+ * plan literally. Any bridge serializer using it must keep truncation behavior
+ * explicit if a container config contains more entries than fit here.
+ */
+
+struct DS_SOCKETD_PACKED ds_socketd_list_containers_req {
+  uint8_t include_all; /* 0 = running only, 1 = include stopped */
+  uint8_t _pad[3];
+};
+
+struct DS_SOCKETD_PACKED ds_socketd_port_record {
+  uint16_t host_port_be;
+  uint16_t host_port_end_be;      /* 0 if not a range */
+  uint16_t container_port_be;
+  uint16_t container_port_end_be; /* 0 if not a range */
+  uint8_t proto;                  /* 0 = tcp, 1 = udp */
+  uint8_t _pad[3];
+};
+
+struct DS_SOCKETD_PACKED ds_socketd_container_record {
+  char name[DS_SOCKETD_RECORD_NAME_MAX];
+  char uuid[DS_UUID_LEN + 1];
+  char rootfs_path[DS_SOCKETD_RECORD_PATH_MAX];
+  char hostname[DS_SOCKETD_RECORD_NAME_MAX];
+  char nat_ip[INET_ADDRSTRLEN]; /* empty string if not NAT mode */
+  char custom_init[DS_SOCKETD_RECORD_PATH_MAX]; /* empty = /sbin/init */
+  int32_t pid_be; /* host-view PID 1; 0 = stopped */
+  uint8_t net_mode; /* 0=host 1=nat 2=none */
+  uint8_t port_count; /* entries used in ports[] */
+  uint8_t _pad[2];
+  struct ds_socketd_port_record ports[DS_SOCKETD_RECORD_PORTS_MAX];
+  int64_t started_at_be; /* CLOCK_REALTIME seconds; 0 if unknown */
+};
+
+/*
+ * CONCERN(socketd-wire):
+ * started_at_be is a 64-bit network-order value. Later bridge/client code must
+ * use explicit 64-bit byte-order helpers here, not htonl()/ntohl().
+ */
+
+struct DS_SOCKETD_PACKED ds_socketd_poll_events_req {
+  int64_t since_be; /* return events with time >= this unix timestamp;
+                       0 = return all events in the file */
+};
+
+#define DS_SOCKETD_EVENT_TYPE_MAX    32
+#define DS_SOCKETD_EVENT_ACTION_MAX  32
+
+struct DS_SOCKETD_PACKED ds_socketd_core_event_record {
+  int64_t time_be; /* unix seconds */
+  int64_t time_nano_be; /* unix nanoseconds */
+  char type[DS_SOCKETD_EVENT_TYPE_MAX]; /* e.g. "container" */
+  char action[DS_SOCKETD_EVENT_ACTION_MAX]; /* "start","stop","restart","die" */
+  char actor_id[DS_UUID_LEN + 1]; /* container UUID */
+  char actor_name[DS_SOCKETD_RECORD_NAME_MAX];
+};
+
+/*
+ * CONCERN(socketd-wire):
+ * time_be and time_nano_be are 64-bit network-order fields. Phase 2 bridge
+ * code and Phase 3 client code must deserialize them with 64-bit conversion
+ * helpers rather than 32-bit ntohl().
+ */
+
+struct DS_SOCKETD_PACKED ds_socketd_image_record {
+  char name[DS_SOCKETD_RECORD_NAME_MAX]; /* container name used as tag */
+  char rootfs_path[DS_SOCKETD_RECORD_PATH_MAX];
+  char uuid[DS_UUID_LEN + 1];
+  int32_t is_running_be; /* 1 if a container using this rootfs is running */
+  int64_t created_at_be; /* 0 if unknown */
+  uint8_t _pad[4];
+};
+
+/*
+ * CONCERN(socketd-wire):
+ * created_at_be is likewise a 64-bit network-order field and needs the same
+ * explicit conversion treatment in later phases.
+ */
 
 /*
  * Request frame:

--- a/src/utils.c
+++ b/src/utils.c
@@ -6,6 +6,7 @@
  */
 
 #include "droidspace.h"
+#include "socketd_protocol.h"
 #include <ftw.h>
 #include <sys/xattr.h>
 #include <time.h>
@@ -1904,3 +1905,162 @@ void ds_format_size(long long bytes, char *buf, size_t sz) {
   }
   snprintf(buf, sz, "%.2f %s", d, units[u]);
 }
+
+static uint64_t ds_socketd_hton64(uint64_t value) {
+#if defined(__BYTE_ORDER__) && (__BYTE_ORDER__ == __ORDER_BIG_ENDIAN__)
+  return value;
+#else
+  return ((uint64_t)htonl((uint32_t)(value & 0xffffffffULL)) << 32) |
+         (uint64_t)htonl((uint32_t)(value >> 32));
+#endif
+}
+
+static int ds_socketd_build_core_event_path(char *path, size_t path_size) {
+  if (!path || path_size == 0)
+    return -1;
+
+  int r = snprintf(path, path_size, "%.4076s/socketd-events.bin",
+                   get_logs_dir());
+  return (r > 0 && (size_t)r < path_size) ? 0 : -1;
+}
+
+static void ds_socketd_trim_core_event_file(const char *path) {
+  if (!path || path[0] == '\0')
+    return;
+
+  enum {
+    kSoftCapRecords = 128,
+    kRetainRecords = 64,
+  };
+
+  const size_t record_size = sizeof(struct ds_socketd_core_event_record);
+  const off_t soft_cap_bytes =
+      (off_t)(kSoftCapRecords * record_size);
+  const off_t retain_bytes =
+      (off_t)(kRetainRecords * record_size);
+
+  int fd = open(path, O_RDWR | O_CLOEXEC);
+  if (fd < 0)
+    return;
+
+  struct stat st;
+  if (fstat(fd, &st) < 0 || st.st_size <= soft_cap_bytes) {
+    close(fd);
+    return;
+  }
+
+  off_t complete_records = st.st_size / (off_t)record_size;
+  if (complete_records <= kRetainRecords) {
+    close(fd);
+    return;
+  }
+
+  off_t first_kept_record = complete_records - kRetainRecords;
+  off_t read_offset = first_kept_record * (off_t)record_size;
+
+  if (lseek(fd, read_offset, SEEK_SET) < 0) {
+    close(fd);
+    return;
+  }
+
+  struct ds_socketd_core_event_record keep[kRetainRecords];
+  memset(keep, 0, sizeof(keep));
+
+  size_t bytes_wanted = (size_t)retain_bytes;
+  size_t bytes_read = 0;
+
+  while (bytes_read < bytes_wanted) {
+    ssize_t n = read(fd, (uint8_t *)keep + bytes_read,
+                     bytes_wanted - bytes_read);
+    if (n < 0) {
+      if (errno == EINTR)
+        continue;
+      close(fd);
+      return;
+    }
+
+    if (n == 0)
+      break;
+
+    bytes_read += (size_t)n;
+  }
+
+  bytes_read -= bytes_read % record_size;
+  if (bytes_read == 0) {
+    close(fd);
+    return;
+  }
+
+  if (ftruncate(fd, 0) < 0 || lseek(fd, 0, SEEK_SET) < 0) {
+    close(fd);
+    return;
+  }
+
+  if (write_all(fd, keep, bytes_read) != (ssize_t)bytes_read) {
+    close(fd);
+    return;
+  }
+
+  close(fd);
+}
+
+void ds_socketd_record_core_event(const char *action,
+                                  const char *container_name,
+                                  const char *uuid) {
+  struct timespec ts;
+  if (clock_gettime(CLOCK_REALTIME, &ts) < 0)
+    return;
+
+  mkdir_p(get_logs_dir(), 0755);
+
+  char event_path[PATH_MAX];
+  if (ds_socketd_build_core_event_path(event_path, sizeof(event_path)) < 0)
+    return;
+
+  struct ds_socketd_core_event_record record;
+  memset(&record, 0, sizeof(record));
+
+  uint64_t time_seconds = (uint64_t)ts.tv_sec;
+  uint64_t time_nano =
+      (uint64_t)ts.tv_sec * 1000000000ULL + (uint64_t)ts.tv_nsec;
+
+  record.time_be = (int64_t)ds_socketd_hton64(time_seconds);
+  record.time_nano_be = (int64_t)ds_socketd_hton64(time_nano);
+
+  safe_strncpy(record.type, "container", sizeof(record.type));
+  safe_strncpy(record.action, action, sizeof(record.action));
+  safe_strncpy(record.actor_id, uuid, sizeof(record.actor_id));
+  safe_strncpy(record.actor_name, container_name, sizeof(record.actor_name));
+
+  int fd = open(event_path,
+                O_WRONLY | O_CREAT | O_APPEND | O_CLOEXEC,
+                0644);
+  if (fd < 0)
+    return;
+
+  if (write_all(fd, &record, sizeof(record)) != (ssize_t)sizeof(record)) {
+    close(fd);
+    return;
+  }
+
+  struct stat st;
+  int should_trim = 0;
+  if (fstat(fd, &st) == 0) {
+    off_t soft_cap =
+        (off_t)(128 * sizeof(struct ds_socketd_core_event_record));
+    should_trim = st.st_size > soft_cap;
+  }
+
+  close(fd);
+  
+  /*
+   * CONCERN(socketd-events):
+   * Event compaction is best-effort and intentionally unsynchronized. The
+   * file is small and local; a future hardening pass can add advisory locking
+   * if multiple event writers become materially concurrent in practice.
+   */
+
+  if (should_trim)
+    ds_socketd_trim_core_event_file(event_path);
+}
+


### PR DESCRIPTION
## Summary

This extends the experimental `droidspaces-socketd` Web API path so that the
Portainer-facing Docker-compatible snapshot endpoints are no longer dummy-only.

The previous socketd work established:

- TCP Docker-compatible discovery endpoints for Portainer probing
- placeholder snapshot responses for:
  - `/containers/json`
  - `/images/json`
  - `/volumes`
  - `/networks`
  - `/events`

This PR keeps the public HTTP compatibility layer in `src/socketd/`, but adds
the privileged backend protocol and typed client plumbing needed to expose
real Droidspaces runtime state through those endpoints.

## What changed

### Private backend protocol

Extended the private socketd backend protocol with opcodes and capabilities for:

- container inventory
- image-style inventory projection
- backend info counters
- lifecycle event polling

The protocol gains typed request/response records for:

- container listing
- pseudo-image listing
- event polling
- event records
- INFO counters

The bridge dispatch path was also adjusted so payload-bearing opcodes can read
their own request bodies instead of all payloads being discarded before opcode
handling.

### Backend bridge inventory

Implemented privileged backend handlers for:

- `LIST_CONTAINERS`
  - enumerates running containers from the PID sidecars
  - optionally includes stopped installed containers from mirrored workspace
    configs
  - exports container name, UUID, rootfs reference, hostname, networking mode,
    NAT IP, custom init, PID, forwarded ports, and start timestamp

- `INFO`
  - reports total / running / stopped container counts

- `LIST_IMAGES`
  - exposes one socketd-side pseudo-image record per installed Droidspaces
    container config

- `POLL_EVENTS`
  - returns retained lifecycle records from a core-side binary event journal

### Core lifecycle events

Added a small best-effort core event journal under the Droidspaces logs
workspace and record lifecycle events for:

- container start
- explicit stop / die
- internal restart loop

These records are later consumed by the socketd backend event poller.

### Typed C++ backend client

Extended `BackendClient` with typed methods for:

- `list_containers()`
- `info()`
- `list_images()`
- `poll_events()`

This keeps binary bridge parsing out of the HTTP/JSON code paths.

### Public socketd JSON projections

Replaced the snapshot dummy seams with backend-backed JSON generation:

- `/containers/json`
  - now renders Docker-compatible container summaries from real Droidspaces
    inventory

- `/volumes`
  - intentionally remains structurally valid but empty, since Droidspaces
    currently has bind mounts rather than Docker-managed named volumes

- `/networks`
  - now exposes fixed Docker-shaped compatibility descriptors for:
    - `droidspaces-bridge`
    - `host`
    - `none`

- `/events`
  - merges existing socketd-local daemon events with core lifecycle events
    fetched from the privileged backend

- `/info`
  - now uses backend container counts instead of fixed placeholder zeros

## Design notes

This continues the intended architecture for the WebUI daemon:

- **Droidspaces core remains C**
- **socketd remains the Docker/Portainer compatibility boundary**
- **JSON rendering remains entirely in the C++ socketd layer**
- **the privileged bridge uses small typed binary payloads instead of JSON**

The snapshot projections are deliberately compatibility-oriented. They are not
intended to turn Droidspaces into Docker internally; they provide enough
Docker-shaped surface for Portainer to represent Droidspaces state while keeping
the underlying runtime model intact.

## Current scope

This PR focuses on the snapshot/discovery surfaces Portainer requests during
environment loading and dashboard rendering.

It does **not** yet implement container lifecycle control routes such as:

- `POST /containers/{id}/start`
- `POST /containers/{id}/stop`

Those remain natural follow-up work once the inventory-facing WebUI path is
accepted and tested further.