### PR TITLE
socketd: preserve image-backed rootfs references in container summaries

### DIFF
--- a/src/socketd/api_server.cpp
+++ b/src/socketd/api_server.cpp
@@ -1,4 +1,5 @@
 #include "api_server.h"
+#include "backend_client.h"
 #include "container_list.h"
 #include "snapshot_lists.h"
 #include "event_log.h"
@@ -587,13 +588,19 @@ bool send_version_ok(int fd, bool suppress_body, std::string& error) {
                             error);
 }
 
-std::string build_info_json() {
+bool build_info_json(std::string& body, std::string& error) {
+  BackendClient backend;
+  InfoResult info;
+
+  if (!backend.info(info, error)) {
+    return false;
+  }
+
   /*
-   * TODO(socketd):
-   * This /info response is intentionally synthesized locally so that early
-   * Portainer integration can proceed and reveal the next compatibility
-   * requirements. Replace or enrich this with DS_SOCKETD_OP_INFO once the
-   * privileged backend bridge has a stable information payload.
+   * /info remains primarily a socketd-local Docker-shaped compatibility
+   * document: host facts such as kernel, architecture, CPU count, and memory
+   * are gathered in this process. Backend INFO contributes the live
+   * Droidspaces inventory counters.
    */
   const std::string arch = socketd_arch_name();
   const std::string kernel_version = socketd_kernel_version();
@@ -602,20 +609,33 @@ std::string build_info_json() {
   const unsigned int ncpu = socketd_ncpu();
   const std::uint64_t mem_total = socketd_mem_total_bytes();
 
-  std::string body;
+  body.clear();
   body.reserve(1400);
 
   body += "{";
 
-  /*
-   * Container and image counters are placeholders until INFO is backed by
-   * the privileged daemon.
-   */
   body += "\"ID\":\"\",";
-  body += "\"Containers\":0,";
-  body += "\"ContainersRunning\":0,";
+
+  body += "\"Containers\":";
+  body += std::to_string(info.containers_total);
+  body += ",";
+
+  body += "\"ContainersRunning\":";
+  body += std::to_string(info.containers_running);
+  body += ",";
+
   body += "\"ContainersPaused\":0,";
-  body += "\"ContainersStopped\":0,";
+
+  body += "\"ContainersStopped\":";
+  body += std::to_string(info.containers_stopped);
+  body += ",";
+
+  /*
+   * CONCERN(socketd-info):
+   * The current INFO backend payload carries container inventory counters only.
+   * Preserve the existing Images=0 field until the plan explicitly extends the
+   * INFO wire payload or chooses a socketd-side count source for pseudo-images.
+   */
   body += "\"Images\":0,";
 
   body += "\"Driver\":\"droidspaces\",";
@@ -701,11 +721,15 @@ std::string build_info_json() {
   body += "\"Warnings\":[]";
 
   body += "}\n";
-  return body;
+  return true;
 }
 
 bool send_info_ok(int fd, bool suppress_body, std::string& error) {
-  const std::string body = build_info_json();
+  std::string body;
+
+  if (!build_info_json(body, error)) {
+    return false;
+  }
 
   return send_http_response(fd,
                             200,

--- a/src/socketd_bridge.c
+++ b/src/socketd_bridge.c
@@ -273,14 +273,10 @@ static void socketd_pack_container_record(
    */
   safe_strncpy(record->uuid, cfg->uuid, sizeof(record->uuid));
 
-  /*
-   * CONCERN(socketd-container-list):
-   * Phase 2.3 follows the implementation plan literally and exports
-   * cfg->rootfs_path here. Any later distinction between mounted rootfs paths
-   * and rootfs image source paths must be settled deliberately at the
-   * compatibility boundary.
-   */
-  safe_strncpy(record->rootfs_path, cfg->rootfs_path,
+  const char *rootfs_ref =
+      cfg->rootfs_img_path[0] ? cfg->rootfs_img_path : cfg->rootfs_path;
+
+  safe_strncpy(record->rootfs_path, rootfs_ref,
                sizeof(record->rootfs_path));
 
   safe_strncpy(record->hostname, cfg->hostname, sizeof(record->hostname));


### PR DESCRIPTION
Container inventory records were exporting directly as the Docker-compatible Image field source.

For directory-backed containers this works as expected, but Droidspaces loads regular-file and block-device rootfs_path entries into cfg->rootfs_img_path and clears cfg->rootfs_path. As a result, Portainer showed an empty Image column for image-backed containers, including sparse-image containers created by the Android app.

Prefer cfg->rootfs_img_path when present, falling back to cfg->rootfs_path for directory-backed containers. This keeps /containers/json aligned with the pseudo-image inventory and restores the visible image/rootfs reference in Portainer.

`<img width="2545" height="1395" alt="Debug API via Portainer" src="https://github.com/user-attachments/assets/0468b05d-84d7-45b8-9bf6-f525903bb99d" />`

A bug in api_server.cpp causing incomplete information being sent has also been addressed.