### PR TITLE
socketd: implement minimal Docker-compatible container lifecycle API

### DIFF
--- a/src/container.c
+++ b/src/container.c
@@ -1415,7 +1415,11 @@ cleanup:
   return -1;
 }
 
-int stop_rootfs(struct ds_config *cfg, int skip_unmount) {
+int stop_rootfs_with_timeout(struct ds_config *cfg, int skip_unmount,
+                             int timeout_seconds) {
+  if (timeout_seconds < 0)
+    timeout_seconds = DS_STOP_TIMEOUT;
+
   /* Acquire external command lock FIRST */
   if (acquire_external_lock(cfg->container_name) != 0) {
     ds_error("Cannot stop '%s': another command is managing this container",
@@ -1521,12 +1525,12 @@ int stop_rootfs(struct ds_config *cfg, int skip_unmount) {
     }
 
     ds_log("Waiting for graceful shutdown (this may take up to %d seconds)...",
-           DS_STOP_TIMEOUT);
+           timeout_seconds);
   }
 
   /* 2. Wait for exit */
   int stopped = 0;
-  for (int i = 0; i < DS_STOP_TIMEOUT * 5; i++) {
+  for (int i = 0; i < timeout_seconds * 5; i++) {
     if (kill(pid, 0) < 0) {
       if (errno == ESRCH) {
         stopped = 1;
@@ -1587,6 +1591,10 @@ int stop_rootfs(struct ds_config *cfg, int skip_unmount) {
   }
 
   return 0;
+}
+
+int stop_rootfs(struct ds_config *cfg, int skip_unmount) {
+  return stop_rootfs_with_timeout(cfg, skip_unmount, DS_STOP_TIMEOUT);
 }
 
 /* ---------------------------------------------------------------------------
@@ -2512,17 +2520,21 @@ int show_info(struct ds_config *cfg, int trust_cfg_pid) {
   return 0;
 }
 
-int restart_rootfs(struct ds_config *cfg) {
+int restart_rootfs_with_timeout(struct ds_config *cfg, int timeout_seconds) {
   pid_t pid = 0;
   if (!is_container_running(cfg, &pid) || pid <= 0) {
     ds_error("Container '%s' is not running or invalid.", cfg->container_name);
     return -1;
   }
   ds_log("Restarting container %s...", cfg->container_name);
-  if (stop_rootfs(cfg, 1) < 0) {
+  if (stop_rootfs_with_timeout(cfg, 1, timeout_seconds) < 0) {
     return -1;
   }
   putchar('\n');
   print_ds_banner();
   return start_rootfs(cfg);
+}
+
+int restart_rootfs(struct ds_config *cfg) {
+  return restart_rootfs_with_timeout(cfg, DS_STOP_TIMEOUT);
 }

--- a/src/droidspace.h
+++ b/src/droidspace.h
@@ -764,6 +764,8 @@ void parse_env_file_to_config(const char *path, struct ds_config *cfg);
 int is_valid_container_pid(pid_t pid);
 int start_rootfs(struct ds_config *cfg);
 int stop_rootfs(struct ds_config *cfg, int skip_unmount);
+int stop_rootfs_with_timeout(struct ds_config *cfg, int skip_unmount,
+                             int timeout_seconds);
 int enter_namespace(pid_t pid, struct ds_config *cfg);
 int enter_rootfs(struct ds_config *cfg, const char *user);
 int run_in_rootfs(struct ds_config *cfg, int argc, char **argv,
@@ -771,6 +773,7 @@ int run_in_rootfs(struct ds_config *cfg, int argc, char **argv,
 int show_info(struct ds_config *cfg, int trust_cfg_pid);
 int show_container_usage(struct ds_config *cfg);
 int restart_rootfs(struct ds_config *cfg);
+int restart_rootfs_with_timeout(struct ds_config *cfg, int timeout_seconds);
 
 /* ---------------------------------------------------------------------------
  * documentation.c

--- a/src/socketd/api_server.cpp
+++ b/src/socketd/api_server.cpp
@@ -28,7 +28,7 @@ namespace droidspaces::socketd {
 namespace {
 
 constexpr std::size_t kMaxRequestHeaderBytes = 16 * 1024;
-constexpr const char* kSocketApiVersion = "1.40";
+constexpr const char* kSocketApiVersion = "1.41";
 constexpr const char* kSocketMinApiVersion = "1.40";
 constexpr const char* kSocketOsType = "linux";
 
@@ -280,6 +280,33 @@ bool send_http_response(int fd,
   return true;
 }
 
+
+bool send_empty_http_response(int fd,
+                              int status_code,
+                              const char* reason_phrase,
+                              std::string& error) {
+  std::string header;
+  header.reserve(192);
+
+  header += "HTTP/1.1 ";
+  header += std::to_string(status_code);
+  header += ' ';
+  header += reason_phrase;
+  header += "\r\n";
+  header += "Content-Length: 0\r\n";
+  header += "Server: Droidspaces/6 (Container, like Docker)\r\n";
+  header += "Api-Version: ";
+  header += kSocketApiVersion;
+  header += "\r\n";
+  header += "Ostype: ";
+  header += kSocketOsType;
+  header += "\r\n";
+  header += "Connection: close\r\n";
+  header += "\r\n";
+
+  return send_all(fd, header.data(), header.size(), error);
+}
+
 bool send_bad_request(int fd, bool suppress_body, std::string& error) {
   const std::string body = "{\"message\":\"bad request\"}\n";
   return send_http_response(fd,
@@ -311,6 +338,32 @@ bool send_not_found(int fd, bool suppress_body, std::string& error) {
                             body,
                             suppress_body,
                             error);
+}
+
+
+bool send_internal_server_error(int fd,
+                                const std::string& message,
+                                bool suppress_body,
+                                std::string& error) {
+  std::string body = "{\"message\":\"";
+  body += json_escape(message.empty() ? "internal server error" : message);
+  body += "\"}\n";
+
+  return send_http_response(fd,
+                            500,
+                            "Internal Server Error",
+                            "application/json",
+                            body,
+                            suppress_body,
+                            error);
+}
+
+bool send_no_content(int fd, std::string& error) {
+  return send_empty_http_response(fd, 204, "No Content", error);
+}
+
+bool send_not_modified(int fd, std::string& error) {
+  return send_empty_http_response(fd, 304, "Not Modified", error);
 }
 
 bool send_ping_ok(int fd, bool suppress_body, std::string& error) {
@@ -439,8 +492,9 @@ bool strip_api_version_prefix(const std::string& path,
   return true;
 }
 
-bool parse_container_inspect_ref(const std::string& target,
-                                 std::string& ref_out) {
+bool parse_container_ref_with_suffix(const std::string& target,
+                                     const char* suffix,
+                                     std::string& ref_out) {
   const std::size_t query_pos = target.find('?');
   const std::string path =
       query_pos == std::string::npos ? target : target.substr(0, query_pos);
@@ -451,15 +505,14 @@ bool parse_container_inspect_ref(const std::string& target,
   }
 
   constexpr const char* kPrefix = "/containers/";
-  constexpr const char* kSuffix = "/json";
   const std::size_t prefix_len = std::strlen(kPrefix);
-  const std::size_t suffix_len = std::strlen(kSuffix);
+  const std::size_t suffix_len = std::strlen(suffix);
 
   if (unversioned_path.size() <= prefix_len + suffix_len ||
       unversioned_path.compare(0, prefix_len, kPrefix) != 0 ||
       unversioned_path.compare(unversioned_path.size() - suffix_len,
                                suffix_len,
-                               kSuffix) != 0) {
+                               suffix) != 0) {
     return false;
   }
 
@@ -468,6 +521,17 @@ bool parse_container_inspect_ref(const std::string& target,
       unversioned_path.size() - prefix_len - suffix_len);
 
   return !ref_out.empty() && ref_out.find('/') == std::string::npos;
+}
+
+bool parse_container_inspect_ref(const std::string& target,
+                                 std::string& ref_out) {
+  return parse_container_ref_with_suffix(target, "/json", ref_out);
+}
+
+bool parse_container_action_ref(const std::string& target,
+                                const char* action_suffix,
+                                std::string& ref_out) {
+  return parse_container_ref_with_suffix(target, action_suffix, ref_out);
 }
 
 bool is_truthy_query_value(const std::string& value) {
@@ -564,6 +628,72 @@ EventsRequest parse_events_request(const std::string& target) {
   }
 
   return request;
+}
+
+
+struct ContainerLifecycleRequest {
+  int timeout_seconds = -1;
+};
+
+bool parse_nonnegative_int(const std::string& value,
+                           int& out,
+                           std::string& error) {
+  if (value.empty()) {
+    error = "empty integer value";
+    return false;
+  }
+
+  errno = 0;
+  char* end = nullptr;
+  const long parsed = std::strtol(value.c_str(), &end, 10);
+  if (errno != 0 || end == value.c_str() || *end != '\0' || parsed < 0 ||
+      parsed > std::numeric_limits<int>::max()) {
+    error = "invalid non-negative integer: ";
+    error += value;
+    return false;
+  }
+
+  out = static_cast<int>(parsed);
+  return true;
+}
+
+bool parse_container_lifecycle_request(const std::string& target,
+                                       ContainerLifecycleRequest& request,
+                                       std::string& error) {
+  request = ContainerLifecycleRequest {};
+
+  const std::size_t query_pos = target.find('?');
+  if (query_pos == std::string::npos || query_pos + 1 >= target.size()) {
+    return true;
+  }
+
+  std::size_t pos = query_pos + 1;
+  while (pos <= target.size()) {
+    const std::size_t amp = target.find('&', pos);
+    const std::size_t end =
+        amp == std::string::npos ? target.size() : amp;
+
+    const std::string item = target.substr(pos, end - pos);
+    const std::size_t eq = item.find('=');
+    const std::string key =
+        eq == std::string::npos ? item : item.substr(0, eq);
+    const std::string value =
+        eq == std::string::npos ? "" : item.substr(eq + 1);
+
+    if (key == "t") {
+      if (!parse_nonnegative_int(value, request.timeout_seconds, error)) {
+        error = "invalid lifecycle timeout query parameter: " + value;
+        return false;
+      }
+    }
+
+    if (amp == std::string::npos) {
+      break;
+    }
+    pos = amp + 1;
+  }
+
+  return true;
 }
 
 bool parse_port(const std::string& value,
@@ -855,6 +985,84 @@ bool send_container_inspect_ok(int fd,
                             error);
 }
 
+bool send_container_start_ok(int fd,
+                             const std::string& ref,
+                             std::string& error) {
+  BackendClient backend;
+  LifecycleResult result;
+  std::string backend_error;
+
+  if (backend.start_container(ref, result, backend_error)) {
+    return send_no_content(fd, error);
+  }
+
+  if (result.not_found) {
+    return send_not_found(fd, false, error);
+  }
+
+  if (result.already_running) {
+    return send_not_modified(fd, error);
+  }
+
+  return send_internal_server_error(fd, backend_error, false, error);
+}
+
+bool send_container_stop_ok(int fd,
+                            const std::string& target,
+                            const std::string& ref,
+                            std::string& error) {
+  ContainerLifecycleRequest request;
+  std::string parse_error;
+  if (!parse_container_lifecycle_request(target, request, parse_error)) {
+    return send_bad_request(fd, false, error);
+  }
+
+  BackendClient backend;
+  LifecycleResult result;
+  std::string backend_error;
+
+  if (backend.stop_container(ref, request.timeout_seconds, result,
+                             backend_error)) {
+    return send_no_content(fd, error);
+  }
+
+  if (result.not_found) {
+    return send_not_found(fd, false, error);
+  }
+
+  if (result.already_stopped) {
+    return send_not_modified(fd, error);
+  }
+
+  return send_internal_server_error(fd, backend_error, false, error);
+}
+
+bool send_container_restart_ok(int fd,
+                               const std::string& target,
+                               const std::string& ref,
+                               std::string& error) {
+  ContainerLifecycleRequest request;
+  std::string parse_error;
+  if (!parse_container_lifecycle_request(target, request, parse_error)) {
+    return send_bad_request(fd, false, error);
+  }
+
+  BackendClient backend;
+  LifecycleResult result;
+  std::string backend_error;
+
+  if (backend.restart_container(ref, request.timeout_seconds, result,
+                                backend_error)) {
+    return send_no_content(fd, error);
+  }
+
+  if (result.not_found) {
+    return send_not_found(fd, false, error);
+  }
+
+  return send_internal_server_error(fd, backend_error, false, error);
+}
+
 bool send_image_list_ok(int fd,
                         bool suppress_body,
                         std::string& error) {
@@ -1079,6 +1287,7 @@ bool ApiServer::handle_client(int client_fd, std::string& error) const {
 
   const bool is_head = method == "HEAD";
   const bool is_get = method == "GET";
+  const bool is_post = method == "POST";
 
   if ((is_get || is_head) && is_api_target(target, "/_ping")) {
     return send_ping_ok(client_fd, is_head, error);
@@ -1100,6 +1309,19 @@ bool ApiServer::handle_client(int client_fd, std::string& error) const {
   std::string inspect_ref;
   if (is_get && parse_container_inspect_ref(target, inspect_ref)) {
     return send_container_inspect_ok(client_fd, inspect_ref, false, error);
+  }
+
+  std::string lifecycle_ref;
+  if (is_post && parse_container_action_ref(target, "/start", lifecycle_ref)) {
+    return send_container_start_ok(client_fd, lifecycle_ref, error);
+  }
+
+  if (is_post && parse_container_action_ref(target, "/stop", lifecycle_ref)) {
+    return send_container_stop_ok(client_fd, target, lifecycle_ref, error);
+  }
+
+  if (is_post && parse_container_action_ref(target, "/restart", lifecycle_ref)) {
+    return send_container_restart_ok(client_fd, target, lifecycle_ref, error);
   }
 
   if (is_get && is_api_target(target, "/images/json")) {

--- a/src/socketd/backend_client.cpp
+++ b/src/socketd/backend_client.cpp
@@ -610,6 +610,92 @@ bool BackendClient::list_images(
   return true;
 }
 
+
+
+bool BackendClient::lifecycle_request(std::uint16_t opcode,
+                                      const std::string& ref,
+                                      int timeout_seconds,
+                                      LifecycleResult& out,
+                                      std::string& error) const {
+  out = LifecycleResult {};
+
+  if (ref.empty() || ref.size() >= DS_SOCKETD_RECORD_NAME_MAX) {
+    error = "container reference is empty or too long";
+    return false;
+  }
+
+  if (timeout_seconds < -1) {
+    error = "container lifecycle timeout is invalid";
+    return false;
+  }
+
+  ds_socketd_lifecycle_req req {};
+  std::memcpy(req.target, ref.c_str(), ref.size());
+  req.timeout_seconds_be = static_cast<std::int32_t>(
+      htonl(static_cast<std::uint32_t>(timeout_seconds)));
+
+  std::uint16_t status = DS_SOCKETD_STATUS_INTERNAL_ERROR;
+  std::string payload;
+
+  if (!request(opcode,
+               &req,
+               static_cast<std::uint32_t>(sizeof(req)),
+               status,
+               payload,
+               error)) {
+    return false;
+  }
+
+  if (status == DS_SOCKETD_STATUS_OK) {
+    return true;
+  }
+
+  switch (status) {
+    case DS_SOCKETD_STATUS_NOT_FOUND:
+      out.not_found = true;
+      error = "container not found";
+      return false;
+    case DS_SOCKETD_STATUS_ALREADY_RUNNING:
+      out.already_running = true;
+      error = "container already running";
+      return false;
+    case DS_SOCKETD_STATUS_ALREADY_STOPPED:
+      out.already_stopped = true;
+      error = "container already stopped";
+      return false;
+    default:
+      return expect_ok_status(status, "LIFECYCLE", error);
+  }
+}
+
+bool BackendClient::start_container(const std::string& ref,
+                                    LifecycleResult& out,
+                                    std::string& error) const {
+  return lifecycle_request(DS_SOCKETD_OP_START_CONTAINER, ref, -1, out, error);
+}
+
+bool BackendClient::stop_container(const std::string& ref,
+                                   int timeout_seconds,
+                                   LifecycleResult& out,
+                                   std::string& error) const {
+  return lifecycle_request(DS_SOCKETD_OP_STOP_CONTAINER,
+                           ref,
+                           timeout_seconds,
+                           out,
+                           error);
+}
+
+bool BackendClient::restart_container(const std::string& ref,
+                                      int timeout_seconds,
+                                      LifecycleResult& out,
+                                      std::string& error) const {
+  return lifecycle_request(DS_SOCKETD_OP_RESTART_CONTAINER,
+                           ref,
+                           timeout_seconds,
+                           out,
+                           error);
+}
+
 bool BackendClient::poll_events(
     std::int64_t since,
     std::vector<CoreEventResult>& out,

--- a/src/socketd/backend_client.h
+++ b/src/socketd/backend_client.h
@@ -101,6 +101,12 @@ struct CoreEventResult {
   std::string actor_name;
 };
 
+struct LifecycleResult {
+  bool not_found = false;
+  bool already_running = false;
+  bool already_stopped = false;
+};
+
 class BackendClient {
 public:
   BackendClient() = default;
@@ -125,7 +131,18 @@ public:
   bool poll_events(std::int64_t since, std::vector<CoreEventResult> &out,
                    std::string &error) const;
 
+  bool start_container(const std::string &ref, LifecycleResult &out,
+                       std::string &error) const;
+  bool stop_container(const std::string &ref, int timeout_seconds,
+                      LifecycleResult &out, std::string &error) const;
+  bool restart_container(const std::string &ref, int timeout_seconds,
+                         LifecycleResult &out, std::string &error) const;
+
 private:
+  bool lifecycle_request(std::uint16_t opcode, const std::string &ref,
+                         int timeout_seconds, LifecycleResult &out,
+                         std::string &error) const;
+
   bool request(std::uint16_t opcode, const void *payload,
                std::uint32_t payload_len, std::uint16_t &status_out,
                std::string &payload_out, std::string &error) const;

--- a/src/socketd_bridge.c
+++ b/src/socketd_bridge.c
@@ -702,6 +702,227 @@ static int socketd_count_installed_containers(uint32_t *count_out) {
   return 0;
 }
 
+static int socketd_validate_kernel_version(void) {
+  int major = 0;
+  int minor = 0;
+
+  if (get_kernel_version(&major, &minor) < 0)
+    return -1;
+
+  if (major < DS_MIN_KERNEL_MAJOR ||
+      (major == DS_MIN_KERNEL_MAJOR && minor < DS_MIN_KERNEL_MINOR)) {
+    ds_error("Droidspaces requires at least Linux %d.%d.0; detected %d.%d",
+             DS_MIN_KERNEL_MAJOR, DS_MIN_KERNEL_MINOR, major, minor);
+    return -1;
+  }
+
+  return 0;
+}
+
+static int socketd_validate_start_config(struct ds_config *cfg) {
+  if (!cfg)
+    return -1;
+
+  if (!cfg->container_name[0] || reject_container_name(cfg->container_name) < 0)
+    return -1;
+
+  if (cfg->rootfs_path[0] && cfg->rootfs_img_path[0]) {
+    ds_error("Container '%s' has both rootfs directory and image configured",
+             cfg->container_name);
+    return -1;
+  }
+
+  if (!cfg->rootfs_path[0] && !cfg->rootfs_img_path[0]) {
+    ds_error("Container '%s' has no rootfs target configured",
+             cfg->container_name);
+    return -1;
+  }
+
+  if (cfg->rootfs_path[0] && access(cfg->rootfs_path, F_OK) != 0) {
+    ds_error("Rootfs directory not found for '%s': %s", cfg->container_name,
+             cfg->rootfs_path);
+    return -1;
+  }
+
+  if (cfg->rootfs_img_path[0] && access(cfg->rootfs_img_path, F_OK) != 0) {
+    ds_error("Rootfs image not found for '%s': %s", cfg->container_name,
+             cfg->rootfs_img_path);
+    return -1;
+  }
+
+  if (cfg->custom_init[0]) {
+    if (cfg->custom_init[0] != '/' || strchr(cfg->custom_init, ' ')) {
+      ds_error("Invalid custom init for '%s': %s", cfg->container_name,
+               cfg->custom_init);
+      return -1;
+    }
+  }
+
+  if (socketd_validate_kernel_version() < 0)
+    return -1;
+
+  if (check_requirements_hw(cfg->hw_access) < 0)
+    return -1;
+
+  if ((cfg->net_mode == DS_NET_NAT || cfg->net_mode == DS_NET_NONE) &&
+      !check_ns(CLONE_NEWNET, "net")) {
+    ds_error("Container '%s' requires network namespaces for its net mode",
+             cfg->container_name);
+    return -1;
+  }
+
+  return 0;
+}
+
+static enum ds_socketd_status
+socketd_read_lifecycle_request(int conn,
+                               uint32_t payload_len,
+                               struct ds_socketd_lifecycle_req *req_out,
+                               char *target_out,
+                               size_t target_size,
+                               int *timeout_seconds_out) {
+  if (!req_out || !target_out || target_size == 0 || !timeout_seconds_out)
+    return DS_SOCKETD_STATUS_BAD_REQUEST;
+
+  memset(req_out, 0, sizeof(*req_out));
+  if (socketd_read_payload(conn, req_out, (uint32_t)sizeof(*req_out),
+                           payload_len) < 0) {
+    return DS_SOCKETD_STATUS_BAD_REQUEST;
+  }
+
+  safe_strncpy(target_out, req_out->target, target_size);
+  if (!target_out[0])
+    return DS_SOCKETD_STATUS_BAD_REQUEST;
+
+  int32_t timeout =
+      (int32_t)ntohl((uint32_t)req_out->timeout_seconds_be);
+  if (timeout < -1)
+    return DS_SOCKETD_STATUS_BAD_REQUEST;
+
+  *timeout_seconds_out = (int)timeout;
+  return DS_SOCKETD_STATUS_OK;
+}
+
+static void socketd_prepare_runtime_for_container(struct ds_config *cfg) {
+  if (!cfg)
+    return;
+
+  safe_strncpy(ds_log_container_name, cfg->container_name,
+               sizeof(ds_log_container_name));
+  ds_cgroup_host_bootstrap(cfg->force_cgroupv1);
+}
+
+static enum ds_socketd_status socketd_lifecycle_start(struct ds_config *cfg) {
+  pid_t pid = 0;
+  if (is_container_running(cfg, &pid) && pid > 0)
+    return DS_SOCKETD_STATUS_ALREADY_RUNNING;
+
+  if (socketd_validate_start_config(cfg) < 0)
+    return DS_SOCKETD_STATUS_INTERNAL_ERROR;
+
+  socketd_prepare_runtime_for_container(cfg);
+
+  if (start_rootfs(cfg) < 0)
+    return DS_SOCKETD_STATUS_INTERNAL_ERROR;
+
+  pid = 0;
+  if (!is_container_running(cfg, &pid) || pid <= 0)
+    return DS_SOCKETD_STATUS_INTERNAL_ERROR;
+
+  return DS_SOCKETD_STATUS_OK;
+}
+
+static enum ds_socketd_status socketd_lifecycle_stop(struct ds_config *cfg,
+                                                     int timeout_seconds) {
+  pid_t pid = 0;
+  if (!is_container_running(cfg, &pid) || pid <= 0)
+    return DS_SOCKETD_STATUS_ALREADY_STOPPED;
+
+  socketd_prepare_runtime_for_container(cfg);
+
+  if (stop_rootfs_with_timeout(cfg, 0, timeout_seconds) < 0)
+    return DS_SOCKETD_STATUS_INTERNAL_ERROR;
+
+  pid = 0;
+  if (is_container_running(cfg, &pid) && pid > 0)
+    return DS_SOCKETD_STATUS_INTERNAL_ERROR;
+
+  return DS_SOCKETD_STATUS_OK;
+}
+
+static enum ds_socketd_status socketd_lifecycle_restart(struct ds_config *cfg,
+                                                        int timeout_seconds) {
+  pid_t pid = 0;
+  int was_running = is_container_running(cfg, &pid) && pid > 0;
+
+  if (socketd_validate_start_config(cfg) < 0)
+    return DS_SOCKETD_STATUS_INTERNAL_ERROR;
+
+  socketd_prepare_runtime_for_container(cfg);
+
+  if (was_running) {
+    if (restart_rootfs_with_timeout(cfg, timeout_seconds) < 0)
+      return DS_SOCKETD_STATUS_INTERNAL_ERROR;
+  } else {
+    if (start_rootfs(cfg) < 0)
+      return DS_SOCKETD_STATUS_INTERNAL_ERROR;
+  }
+
+  pid = 0;
+  if (!is_container_running(cfg, &pid) || pid <= 0)
+    return DS_SOCKETD_STATUS_INTERNAL_ERROR;
+
+  if (was_running)
+    ds_socketd_record_core_event("restart", cfg->container_name, cfg->uuid);
+
+  return DS_SOCKETD_STATUS_OK;
+}
+
+static int socketd_handle_lifecycle_request(int conn,
+                                            uint32_t payload_len,
+                                            enum ds_socketd_opcode opcode) {
+  struct ds_socketd_lifecycle_req req;
+  char target[DS_SOCKETD_RECORD_NAME_MAX];
+  int timeout_seconds = -1;
+
+  enum ds_socketd_status status =
+      socketd_read_lifecycle_request(conn, payload_len, &req, target,
+                                     sizeof(target), &timeout_seconds);
+  if (status != DS_SOCKETD_STATUS_OK) {
+    socketd_send_response(conn, status, NULL, 0);
+    return 0;
+  }
+
+  struct ds_config cfg;
+  memset(&cfg, 0, sizeof(cfg));
+
+  int load_status = socketd_load_config_by_ref(target, &cfg);
+  if (load_status != DS_SOCKETD_STATUS_OK) {
+    socketd_free_loaded_config(&cfg);
+    socketd_send_response(conn, (enum ds_socketd_status)load_status, NULL, 0);
+    return 0;
+  }
+
+  switch (opcode) {
+  case DS_SOCKETD_OP_START_CONTAINER:
+    status = socketd_lifecycle_start(&cfg);
+    break;
+  case DS_SOCKETD_OP_STOP_CONTAINER:
+    status = socketd_lifecycle_stop(&cfg, timeout_seconds);
+    break;
+  case DS_SOCKETD_OP_RESTART_CONTAINER:
+    status = socketd_lifecycle_restart(&cfg, timeout_seconds);
+    break;
+  default:
+    status = DS_SOCKETD_STATUS_UNSUPPORTED;
+    break;
+  }
+
+  socketd_free_loaded_config(&cfg);
+  socketd_send_response(conn, status, NULL, 0);
+  return 0;
+}
+
 static int socketd_build_core_event_path(char *path, size_t path_size) {
   if (!path || path_size == 0)
     return -1;
@@ -774,7 +995,8 @@ static void socketd_handle_conn(int conn) {
         htonl(DS_SOCKETD_CAP_PROTOCOL_V1 | DS_SOCKETD_CAP_PING |
               DS_SOCKETD_CAP_CAPABILITIES | DS_SOCKETD_CAP_INFO |
               DS_SOCKETD_CAP_LIST_CONTAINERS | DS_SOCKETD_CAP_INSPECT_CONTAINER |
-              DS_SOCKETD_CAP_LIST_IMAGES | DS_SOCKETD_CAP_POLL_EVENTS);
+              DS_SOCKETD_CAP_LIFECYCLE | DS_SOCKETD_CAP_LIST_IMAGES |
+              DS_SOCKETD_CAP_POLL_EVENTS);
 
     socketd_send_response(conn, DS_SOCKETD_STATUS_OK, &caps_be,
                           (uint32_t)sizeof(caps_be));
@@ -1176,7 +1398,8 @@ static void socketd_handle_conn(int conn) {
   case DS_SOCKETD_OP_START_CONTAINER:
   case DS_SOCKETD_OP_STOP_CONTAINER:
   case DS_SOCKETD_OP_RESTART_CONTAINER:
-    socketd_send_response(conn, DS_SOCKETD_STATUS_UNSUPPORTED, NULL, 0);
+    socketd_handle_lifecycle_request(conn, payload_len,
+                                     (enum ds_socketd_opcode)opcode);
     return;
 
   default:

--- a/src/socketd_protocol.h
+++ b/src/socketd_protocol.h
@@ -55,6 +55,8 @@ enum ds_socketd_status {
   DS_SOCKETD_STATUS_NOT_FOUND = 3,
   DS_SOCKETD_STATUS_INTERNAL_ERROR = 4,
   DS_SOCKETD_STATUS_FORBIDDEN = 5,
+  DS_SOCKETD_STATUS_ALREADY_RUNNING = 6,
+  DS_SOCKETD_STATUS_ALREADY_STOPPED = 7,
 };
 
 enum ds_socketd_capability {
@@ -125,6 +127,13 @@ struct DS_SOCKETD_PACKED ds_socketd_container_record {
 struct DS_SOCKETD_PACKED ds_socketd_inspect_container_req {
   /* Container name, UUID, or UUID prefix. Empty is invalid. */
   char target[DS_SOCKETD_RECORD_NAME_MAX];
+};
+
+struct DS_SOCKETD_PACKED ds_socketd_lifecycle_req {
+  /* Container name, UUID, or UUID prefix. Empty is invalid. */
+  char target[DS_SOCKETD_RECORD_NAME_MAX];
+  /* -1 = Droidspaces runtime default; 0 = no graceful wait. */
+  int32_t timeout_seconds_be;
 };
 
 struct DS_SOCKETD_PACKED ds_socketd_env_record {


### PR DESCRIPTION
Implemented POST /containers/{id}/start, /stop, and /restart.