### PR TITLE
build: prepare in-house BusyBox for WebUI daemon

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "external/busybox"]
+	path = external/busybox
+	url = https://github.com/Droidspaces/busybox-droidspaces.git

--- a/Makefile
+++ b/Makefile
@@ -18,9 +18,9 @@ NPROC := $(shell nproc 2>/dev/null || sysctl -n hw.logicalcpu 2>/dev/null || ech
 # Verbose control - V=1 shows full commands, V=0 (default) shows kernel-style short logs
 V ?= 0
 
-# Optional private control bridge for the external C++ droidspaces-socketd.
-# Keep this off by default so the stock static Droidspaces binary stays unchanged.
-ENABLE_SOCKETD_BACKEND ?= 0
+# Optional private control bridge used by API-capable WebUI daemons.
+# Enabled by default for WebUI-ready builds; set to 0 for minimal CLI-only builds.
+ENABLE_SOCKETD_BACKEND ?= 1
 
 ifeq ($(V),1)
   Q       =
@@ -122,8 +122,8 @@ help:
 	@echo ""
 	@echo "Options:"
 	@echo "  V=1            - Show full compiler commands"
-	@echo "  ENABLE_SOCKETD_BACKEND=1"
-	@echo "                 - Compile the private droidspaces-socketd backend bridge"
+	@echo "  ENABLE_SOCKETD_BACKEND=0"
+	@echo "                 - Disable the private API backend bridge for minimal builds"
 	@echo ""
 	@echo "Other:"
 	@echo "  make clean     - Remove build artifacts"


### PR DESCRIPTION
## Summary

This PR makes two small build-system changes in preparation for the WebUI daemon work:

1. Adds `Droidspaces/busybox-droidspaces` as a git submodule under `external/busybox`.
2. Enables the socketd backend bridge by default for WebUI-ready builds.

## Details

* Adds the patched BusyBox source as a submodule:

  * `external/busybox`
  * source: [Droidspaces/busybox-droidspaces](https://github.com/Droidspaces/busybox-droidspaces.git)
* Changes `ENABLE_SOCKETD_BACKEND` default from disabled to enabled.
* Updates the Makefile comment/help text so the backend bridge is no longer described as being specifically for the external C++ `droidspaces-socketd`.

## Scope

This PR intentionally does **not** yet:

* build BusyBox in CI,
* bundle WebUI assets,
* install files under `/data/local/Droidspaces/www/html`,
* add Android app controls for starting/stopping the WebUI daemon.

Those should be handled in follow-up PRs if this direction is accepted.