### PR TITLE
android: add OpenWrt procd service management

### DIFF
--- a/Android/app/src/main/assets/chkprocd.sh
+++ b/Android/app/src/main/assets/chkprocd.sh
@@ -1,0 +1,86 @@
+#!/bin/sh
+# chkprocd.sh - OpenWrt/procd service query tool
+# Output format for --all:
+#   name|description|enabled|running
+# where enabled is enabled/disabled and running is running/stopped/unknown.
+
+INITD_DIR="/etc/init.d"
+
+_is_safe_name() {
+    echo "$1" | grep -Eq '^[A-Za-z0-9_.+@-]+$'
+}
+
+_all_services() {
+    [ -d "$INITD_DIR" ] || return 0
+    for path in "$INITD_DIR"/*; do
+        [ -f "$path" ] || continue
+        [ -x "$path" ] || continue
+        name="${path##*/}"
+        _is_safe_name "$name" || continue
+        case "$name" in
+            .*) continue ;;
+        esac
+        echo "$name"
+    done | sort -u
+}
+
+_get_desc() {
+    svc="$1"
+    script="$INITD_DIR/$svc"
+
+    # Some init scripts define DESCRIPTION/description. Most OpenWrt scripts do
+    # not, so empty description is a valid result.
+    # Keep this parser deliberately conservative to avoid shell-quoting
+    # complexity on BusyBox ash. Descriptions are optional in the UI.
+    grep -m1 -E '^(DESCRIPTION|description)=' "$script" 2>/dev/null \
+        | sed 's/^[^=]*=//;s/^"//;s/"$//' \
+        | head -n 1
+}
+
+_is_enabled() {
+    "$INITD_DIR/$1" enabled >/dev/null 2>&1
+}
+
+_running_state() {
+    svc="$1"
+
+    if "$INITD_DIR/$svc" running >/dev/null 2>&1; then
+        echo running
+        return 0
+    fi
+
+    # procd init scripts generally implement status; one-shot/boot scripts may
+    # not. Treat unsupported status as unknown rather than pretending stopped.
+    output=$("$INITD_DIR/$svc" status 2>&1)
+    rc=$?
+    if [ $rc -eq 0 ]; then
+        echo running
+        return 0
+    fi
+
+    echo "$output" | grep -Eiq 'inactive|not running|stopped|disabled|dead' && {
+        echo stopped
+        return 0
+    }
+
+    echo unknown
+}
+
+case "$1" in
+    --all)
+        for svc in $(_all_services); do
+            desc=$(_get_desc "$svc")
+            if _is_enabled "$svc"; then
+                enabled="enabled"
+            else
+                enabled="disabled"
+            fi
+            running=$(_running_state "$svc")
+            echo "${svc}|${desc}|${enabled}|${running}"
+        done
+        ;;
+    *)
+        echo "usage: $0 --all" >&2
+        exit 2
+        ;;
+esac

--- a/Android/app/src/main/java/com/droidspaces/app/ui/navigation/DroidspacesNavigation.kt
+++ b/Android/app/src/main/java/com/droidspaces/app/ui/navigation/DroidspacesNavigation.kt
@@ -34,6 +34,7 @@ import com.droidspaces.app.ui.screen.InstallationProgressScreen
 import com.droidspaces.app.ui.screen.EditContainerScreen
 import com.droidspaces.app.ui.screen.ContainerDetailsScreen
 import com.droidspaces.app.ui.screen.SystemdScreen
+import com.droidspaces.app.ui.screen.ProcdScreen
 import com.droidspaces.app.ui.screen.OpenRCScreen
 import com.droidspaces.app.ui.screen.ContainerTerminalScreen
 import com.droidspaces.app.ui.viewmodel.ContainerInstallationViewModel
@@ -91,6 +92,9 @@ sealed class Screen(val route: String) {
     }
     data object Systemd : Screen("systemd/{containerName}") {
         fun createRoute(containerName: String) = "systemd/${Uri.encode(containerName)}"
+    }
+    data object Procd : Screen("procd/{containerName}") {
+        fun createRoute(containerName: String) = "procd/${Uri.encode(containerName)}"
     }
     data object OpenRC : Screen("openrc/{containerName}") {
         fun createRoute(containerName: String) = "openrc/${Uri.encode(containerName)}"
@@ -574,6 +578,8 @@ fun DroidspacesNavigation(
                         when (initSystem) {
                             com.droidspaces.app.ui.screen.InitSystem.SYSTEMD ->
                                 navController.navigate(Screen.Systemd.createRoute(containerName))
+                            com.droidspaces.app.ui.screen.InitSystem.PROCD ->
+                                navController.navigate(Screen.Procd.createRoute(containerName))
                             com.droidspaces.app.ui.screen.InitSystem.OPENRC ->
                                 navController.navigate(Screen.OpenRC.createRoute(containerName))
                         }
@@ -597,6 +603,21 @@ fun DroidspacesNavigation(
         ) { backStackEntry ->
             val containerName = backStackEntry.arguments?.getString("containerName") ?: ""
             SystemdScreen(
+                containerName = containerName,
+                onNavigateBack = { navController.popBackStack() }
+            )
+        }
+
+        composable(
+            route = Screen.Procd.route,
+            arguments = listOf(
+                navArgument("containerName") { type = NavType.StringType }
+            ),
+            enterTransition = defaultEnterTransition,
+            exitTransition = defaultExitTransition
+        ) { backStackEntry ->
+            val containerName = backStackEntry.arguments?.getString("containerName") ?: ""
+            ProcdScreen(
                 containerName = containerName,
                 onNavigateBack = { navController.popBackStack() }
             )

--- a/Android/app/src/main/java/com/droidspaces/app/ui/screen/ContainerDetailsScreen.kt
+++ b/Android/app/src/main/java/com/droidspaces/app/ui/screen/ContainerDetailsScreen.kt
@@ -24,6 +24,7 @@ import com.droidspaces.app.ui.component.ContainerUsersCard
 import com.droidspaces.app.util.ContainerInfo
 import com.droidspaces.app.util.ContainerOSInfoManager
 import com.droidspaces.app.util.ContainerSystemdManager
+import com.droidspaces.app.util.ContainerProcdManager
 import com.droidspaces.app.util.ContainerOpenRCManager
 import com.droidspaces.app.util.ContainerManager
 import kotlinx.coroutines.Dispatchers
@@ -72,13 +73,15 @@ fun ContainerDetailsScreen(
         mutableStateOf(ContainerOSInfoManager.getCachedOSInfo(container.name, context))
     }
 
-    // Init system state - detect systemd first, then OpenRC
+    // Init system state - detect systemd first, then OpenWrt/procd, then OpenRC
     var initSystemState by remember { mutableStateOf<InitSystemCardState>(InitSystemCardState.Checking) }
 
     LaunchedEffect(container.name) {
         initSystemState = when {
             ContainerSystemdManager.isSystemdAvailable(container.name) ->
                 InitSystemCardState.Available(InitSystem.SYSTEMD)
+            ContainerProcdManager.isProcdAvailable(container.name) ->
+                InitSystemCardState.Available(InitSystem.PROCD)
             ContainerOpenRCManager.isOpenRCAvailable(container.name) ->
                 InitSystemCardState.Available(InitSystem.OPENRC)
             else ->
@@ -244,7 +247,7 @@ fun ContainerDetailsScreen(
 /**
  * Which init system is available in the container.
  */
-enum class InitSystem { SYSTEMD, OPENRC }
+enum class InitSystem { SYSTEMD, PROCD, OPENRC }
 
 /**
  * Init system card state - sealed for type safety and stability
@@ -437,7 +440,7 @@ private fun TerminalCard(
 }
 
 /**
- * PREMIUM INIT SYSTEM CARD - handles Systemd, OpenRC, and unavailable states.
+ * PREMIUM INIT SYSTEM CARD - handles Systemd, OpenWrt/procd, OpenRC, and unavailable states.
  */
 @Composable
 private fun PremiumInitSystemCard(
@@ -458,6 +461,7 @@ private fun PremiumInitSystemCard(
     val cardTitle = when (state) {
         is InitSystemCardState.Available -> when (state.initSystem) {
             InitSystem.SYSTEMD -> context.getString(R.string.systemd)
+            InitSystem.PROCD -> context.getString(R.string.openwrt)
             InitSystem.OPENRC -> context.getString(R.string.openrc)
         }
         else -> context.getString(R.string.init_system)

--- a/Android/app/src/main/java/com/droidspaces/app/ui/screen/ProcdScreen.kt
+++ b/Android/app/src/main/java/com/droidspaces/app/ui/screen/ProcdScreen.kt
@@ -1,0 +1,89 @@
+package com.droidspaces.app.ui.screen
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Settings
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import com.droidspaces.app.R
+import androidx.compose.ui.platform.LocalContext
+
+/**
+ * Placeholder screen for OpenWrt/procd service management.
+ *
+ * This proves detection and navigation before adding service listing/actions.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun ProcdScreen(
+    containerName: String,
+    onNavigateBack: () -> Unit
+) {
+    val context = LocalContext.current
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text(context.getString(R.string.openwrt_services)) },
+                navigationIcon = {
+                    IconButton(onClick = onNavigateBack) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = null)
+                    }
+                }
+            )
+        }
+    ) { paddingValues ->
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(paddingValues)
+                .padding(24.dp),
+            contentAlignment = Alignment.Center
+        ) {
+            Column(
+                horizontalAlignment = Alignment.CenterHorizontally,
+                verticalArrangement = Arrangement.Center
+            ) {
+                Icon(
+                    imageVector = Icons.Default.Settings,
+                    contentDescription = null,
+                    modifier = Modifier.size(48.dp),
+                    tint = MaterialTheme.colorScheme.primary
+                )
+                Spacer(Modifier.height(16.dp))
+                Text(
+                    text = context.getString(R.string.procd_detected),
+                    style = MaterialTheme.typography.titleMedium,
+                    fontWeight = FontWeight.Bold,
+                    textAlign = TextAlign.Center
+                )
+                Spacer(Modifier.height(8.dp))
+                Text(
+                    text = context.getString(R.string.procd_services_placeholder_desc, containerName),
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    textAlign = TextAlign.Center
+                )
+            }
+        }
+    }
+}

--- a/Android/app/src/main/java/com/droidspaces/app/ui/screen/ProcdScreen.kt
+++ b/Android/app/src/main/java/com/droidspaces/app/ui/screen/ProcdScreen.kt
@@ -1,37 +1,55 @@
 package com.droidspaces.app.ui.screen
 
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
+import androidx.compose.animation.animateColorAsState
+import androidx.compose.animation.animateContentSize
+import androidx.compose.foundation.*
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.interaction.collectIsFocusedAsState
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
-import androidx.compose.material.icons.filled.Settings
-import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
-import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Scaffold
-import androidx.compose.material3.Text
-import androidx.compose.material3.TopAppBar
-import androidx.compose.runtime.Composable
+import androidx.compose.material.icons.filled.*
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.font.Font
+import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import com.droidspaces.app.R
-import androidx.compose.ui.platform.LocalContext
+import com.droidspaces.app.ui.util.*
+import com.droidspaces.app.util.AnimationUtils
+import com.droidspaces.app.util.ContainerProcdManager
+import com.droidspaces.app.util.ContainerProcdManager.ServiceFilter
+import com.droidspaces.app.util.ContainerProcdManager.ServiceInfo
+import com.droidspaces.app.util.ContainerProcdManager.ServiceStatus
+import kotlinx.coroutines.launch
 
-/**
- * Placeholder screen for OpenWrt/procd service management.
- *
- * This proves detection and navigation before adding service listing/actions.
- */
+private val JetBrainsMono = FontFamily(
+    Font(R.font.jetbrains_mono_regular, FontWeight.Normal),
+    Font(R.font.jetbrains_mono_bold, FontWeight.Bold)
+)
+
+private sealed class ProcdScreenState {
+    data object Loading : ProcdScreenState()
+    data object ProcdNotAvailable : ProcdScreenState()
+    data class Ready(val services: List<ServiceInfo>) : ProcdScreenState()
+}
+
+private sealed class ProcdActionState {
+    data object Idle : ProcdActionState()
+    data class InProgress(val serviceName: String, val actionName: String) : ProcdActionState()
+}
+
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun ProcdScreen(
@@ -39,51 +57,407 @@ fun ProcdScreen(
     onNavigateBack: () -> Unit
 ) {
     val context = LocalContext.current
+    val scope = rememberCoroutineScope()
+    val snackbarHostState = remember { SnackbarHostState() }
 
-    Scaffold(
-        topBar = {
-            TopAppBar(
-                title = { Text(context.getString(R.string.openwrt_services)) },
-                navigationIcon = {
-                    IconButton(onClick = onNavigateBack) {
-                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = null)
+    LaunchedEffect(Unit) { ContainerProcdManager.initialize(context) }
+
+    var screenState by remember { mutableStateOf<ProcdScreenState>(ProcdScreenState.Loading) }
+    var actionState by remember { mutableStateOf<ProcdActionState>(ProcdActionState.Idle) }
+    var selectedFilter by remember { mutableStateOf(ServiceFilter.RUNNING) }
+    var logsDialogContent by remember { mutableStateOf<List<String>?>(null) }
+    var searchQuery by remember { mutableStateOf("") }
+
+    var fetchJob by remember { mutableStateOf<kotlinx.coroutines.Job?>(null) }
+    var actionJob by remember { mutableStateOf<kotlinx.coroutines.Job?>(null) }
+
+    fun fetchServices() {
+        fetchJob?.cancel()
+        screenState = ProcdScreenState.Loading
+        fetchJob = scope.launch {
+            try {
+                val available = ContainerProcdManager.isProcdAvailable(containerName)
+                if (!available) {
+                    screenState = ProcdScreenState.ProcdNotAvailable
+                    return@launch
+                }
+                val services = ContainerProcdManager.getAllServices(containerName)
+                screenState = ProcdScreenState.Ready(services)
+            } catch (e: Exception) {
+                if (e is kotlinx.coroutines.CancellationException) throw e
+                screenState = ProcdScreenState.ProcdNotAvailable
+            }
+        }
+    }
+
+    fun executeAction(serviceName: String, actionName: String, action: suspend () -> ContainerProcdManager.CommandResult) {
+        actionJob?.cancel()
+        fetchJob?.cancel()
+        actionState = ProcdActionState.InProgress(serviceName, actionName)
+        actionJob = scope.launch {
+            try {
+                val result = action()
+                actionState = ProcdActionState.Idle
+                if (result.isSuccess) {
+                    screenState = ProcdScreenState.Loading
+                    scope.showSuccess(snackbarHostState, context.getString(R.string.action_successful, actionName, serviceName))
+                    fetchServices()
+                } else {
+                    val allLogs = result.output + result.error
+                    if (allLogs.isNotEmpty()) logsDialogContent = allLogs
+                    else scope.showError(snackbarHostState, context.getString(R.string.failed_to_action, actionName, serviceName))
+                }
+            } catch (e: Exception) {
+                actionState = ProcdActionState.Idle
+                if (e is kotlinx.coroutines.CancellationException) throw e
+                scope.showError(snackbarHostState, context.getString(R.string.error_unknown, e.message ?: context.getString(R.string.unknown)))
+            }
+        }
+    }
+
+    LaunchedEffect(containerName) { fetchServices() }
+
+    val allServices = (screenState as? ProcdScreenState.Ready)?.services ?: emptyList()
+    val filteredServices = remember(allServices, selectedFilter, searchQuery) {
+        if (searchQuery.isBlank()) ContainerProcdManager.filterServices(allServices, selectedFilter)
+        else allServices.filter { it.name.contains(searchQuery, ignoreCase = true) }
+    }
+
+    val serviceCounts = remember(allServices) {
+        mapOf(
+            ServiceFilter.RUNNING to allServices.count { it.isRunning && it.isEnabled },
+            ServiceFilter.ENABLED to allServices.count { it.isEnabled && !it.isRunning && it.status != ServiceStatus.UNKNOWN },
+            ServiceFilter.DISABLED to allServices.count { !it.isEnabled && !it.isRunning && it.status != ServiceStatus.UNKNOWN },
+            ServiceFilter.ABNORMAL to allServices.count { it.isRunning && !it.isEnabled },
+            ServiceFilter.UNKNOWN to allServices.count { it.status == ServiceStatus.UNKNOWN },
+            ServiceFilter.ALL to allServices.size
+        )
+    }
+
+    val clearFocus = rememberClearFocus()
+
+    Surface(modifier = Modifier.fillMaxSize(), color = MaterialTheme.colorScheme.background) {
+        Scaffold(
+            topBar = {
+                CenterAlignedTopAppBar(
+                    title = { Text(context.getString(R.string.openwrt_services), style = MaterialTheme.typography.titleLarge, fontWeight = FontWeight.Bold) },
+                    navigationIcon = { IconButton(onClick = onNavigateBack) { Icon(Icons.AutoMirrored.Filled.ArrowBack, context.getString(R.string.back)) } },
+                    actions = { IconButton(onClick = { fetchServices() }, enabled = screenState !is ProcdScreenState.Loading && actionState is ProcdActionState.Idle) { Icon(Icons.Default.Refresh, context.getString(R.string.refresh)) } },
+                    colors = TopAppBarDefaults.centerAlignedTopAppBarColors(containerColor = Color.Transparent, scrolledContainerColor = MaterialTheme.colorScheme.surface.copy(alpha = 0.95f))
+                )
+            },
+            snackbarHost = { SnackbarHost(snackbarHostState) },
+            containerColor = Color.Transparent
+        ) { padding ->
+            ClearFocusOnClickOutside(modifier = Modifier.padding(padding).fillMaxSize()) {
+                Box(modifier = Modifier.fillMaxSize()) {
+                    when (screenState) {
+                        is ProcdScreenState.Loading -> FullScreenLoading(message = context.getString(R.string.fetching_services))
+                        is ProcdScreenState.ProcdNotAvailable -> ProcdNotAvailable()
+                        is ProcdScreenState.Ready -> {
+                            Column(modifier = Modifier.fillMaxSize()) {
+                                ProcdSearchBar(query = searchQuery, onQueryChange = { searchQuery = it })
+                                ProcdFilterChipsRow(selectedFilter = selectedFilter, serviceCounts = serviceCounts, onFilterSelected = { selectedFilter = it; clearFocus() })
+                                if (filteredServices.isEmpty()) {
+                                    ProcdEmptyServicesState(filter = selectedFilter, modifier = Modifier.weight(1f))
+                                } else {
+                                    LazyColumn(modifier = Modifier.weight(1f), contentPadding = PaddingValues(16.dp), verticalArrangement = Arrangement.spacedBy(16.dp)) {
+                                        items(filteredServices) { service ->
+                                            ProcdServiceCard(service = service, containerName = containerName, onAction = { name, act -> executeAction(service.name, name, act) })
+                                        }
+                                    }
+                                }
+                            }
+                        }
                     }
                 }
+            }
+        }
+    }
+
+    (actionState as? ProcdActionState.InProgress)?.let { state -> ProgressDialog(message = context.getString(R.string.actioning_service, state.actionName, state.serviceName)) }
+    logsDialogContent?.let { logs -> ErrorLogsDialog(logs = logs, onDismiss = { logsDialogContent = null }) }
+}
+
+@Composable
+private fun ProcdSearchBar(query: String, onQueryChange: (String) -> Unit) {
+    val context = LocalContext.current
+    val interactionSource = remember { MutableInteractionSource() }
+    val isFocused by interactionSource.collectIsFocusedAsState()
+    val borderColor by animateColorAsState(
+        targetValue = if (isFocused) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.2f),
+        animationSpec = AnimationUtils.fastSpec()
+    )
+
+    Surface(
+        modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp, vertical = 8.dp),
+        color = MaterialTheme.colorScheme.surfaceContainer,
+        shape = RoundedCornerShape(16.dp),
+        border = BorderStroke(1.dp, borderColor)
+    ) {
+        TextField(
+            value = query,
+            onValueChange = onQueryChange,
+            modifier = Modifier.fillMaxWidth(),
+            interactionSource = interactionSource,
+            placeholder = { Text(context.getString(R.string.search_services), color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.6f)) },
+            leadingIcon = { Icon(Icons.Default.Search, null, tint = if (isFocused) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.6f)) },
+            trailingIcon = { if (query.isNotEmpty()) { IconButton(onClick = { onQueryChange("") }) { Icon(Icons.Default.Clear, null) } } },
+            colors = TextFieldDefaults.colors(
+                focusedContainerColor = Color.Transparent,
+                unfocusedContainerColor = Color.Transparent,
+                focusedIndicatorColor = Color.Transparent,
+                unfocusedIndicatorColor = Color.Transparent,
+                cursorColor = MaterialTheme.colorScheme.primary
+            ),
+            singleLine = true,
+            textStyle = MaterialTheme.typography.bodyLarge,
+            keyboardOptions = FocusUtils.searchKeyboardOptions,
+            keyboardActions = FocusUtils.clearFocusKeyboardActions()
+        )
+    }
+}
+
+@Composable
+private fun ProcdFilterChipsRow(
+    selectedFilter: ServiceFilter,
+    serviceCounts: Map<ServiceFilter, Int>,
+    onFilterSelected: (ServiceFilter) -> Unit
+) {
+    val context = LocalContext.current
+    // procd has no masked/static concepts; UNKNOWN covers scripts without reliable status.
+    val filters = listOf(
+        Triple(ServiceFilter.RUNNING, R.string.running, Color(0xFF4CAF50)),
+        Triple(ServiceFilter.ENABLED, R.string.enabled_legend, Color(0xFFFFCA28)),
+        Triple(ServiceFilter.DISABLED, R.string.disabled_legend, Color(0xFFEF5350)),
+        Triple(ServiceFilter.ABNORMAL, R.string.abnormal_legend, Color(0xFFFF7043)),
+        Triple(ServiceFilter.UNKNOWN, R.string.unknown_legend, Color(0xFF90A4AE)),
+        Triple(ServiceFilter.ALL, R.string.all_legend, null)
+    )
+
+    Row(
+        modifier = Modifier.fillMaxWidth().horizontalScroll(rememberScrollState()).padding(horizontal = 16.dp, vertical = 8.dp),
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        filters.forEach { (filter, labelRes, dotColor) ->
+            val count = serviceCounts[filter] ?: 0
+            val isSelected = selectedFilter == filter
+
+            FilterChip(
+                selected = isSelected,
+                onClick = { onFilterSelected(filter) },
+                label = {
+                    Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(6.dp)) {
+                        if (dotColor != null) {
+                            Surface(modifier = Modifier.size(6.dp), shape = CircleShape, color = dotColor) {}
+                        }
+                        Text("${context.getString(labelRes)} ($count)", style = MaterialTheme.typography.labelLarge)
+                    }
+                },
+                shape = RoundedCornerShape(12.dp),
+                colors = FilterChipDefaults.filterChipColors(selectedContainerColor = MaterialTheme.colorScheme.primaryContainer),
+                border = FilterChipDefaults.filterChipBorder(selected = isSelected, enabled = true,
+                    borderColor = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.4f),
+                    selectedBorderColor = MaterialTheme.colorScheme.primary)
             )
         }
-    ) { paddingValues ->
-        Box(
-            modifier = Modifier
-                .fillMaxSize()
-                .padding(paddingValues)
-                .padding(24.dp),
-            contentAlignment = Alignment.Center
-        ) {
-            Column(
-                horizontalAlignment = Alignment.CenterHorizontally,
-                verticalArrangement = Arrangement.Center
+    }
+}
+
+@Composable
+private fun ProcdServiceCard(
+    service: ServiceInfo,
+    containerName: String,
+    onAction: (String, suspend () -> ContainerProcdManager.CommandResult) -> Unit
+) {
+    val context = LocalContext.current
+    var showMenu by remember { mutableStateOf(false) }
+
+    val statusColor = when (service.status) {
+        ServiceStatus.ENABLED_RUNNING -> Color(0xFF4CAF50)
+        ServiceStatus.ENABLED_STOPPED -> Color(0xFFFFCA28)
+        ServiceStatus.DISABLED_STOPPED -> Color(0xFFEF5350)
+        ServiceStatus.ABNORMAL -> Color(0xFFFF7043)
+        ServiceStatus.UNKNOWN -> Color(0xFF90A4AE)
+    }
+
+    Surface(
+        modifier = Modifier.fillMaxWidth().animateContentSize(AnimationUtils.mediumSpec()),
+        shape = RoundedCornerShape(20.dp),
+        color = MaterialTheme.colorScheme.surfaceContainer,
+        border = BorderStroke(1.dp, MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.35f))
+    ) {
+        Column {
+            Row(
+                modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp, vertical = 14.dp).height(32.dp),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically
             ) {
-                Icon(
-                    imageVector = Icons.Default.Settings,
-                    contentDescription = null,
-                    modifier = Modifier.size(48.dp),
-                    tint = MaterialTheme.colorScheme.primary
-                )
-                Spacer(Modifier.height(16.dp))
                 Text(
-                    text = context.getString(R.string.procd_detected),
-                    style = MaterialTheme.typography.titleMedium,
+                    text = service.name,
+                    style = MaterialTheme.typography.titleMedium.copy(
+                        fontFamily = JetBrainsMono,
+                        fontSize = if (service.name.length > 25) 13.sp else 16.sp
+                    ),
                     fontWeight = FontWeight.Bold,
-                    textAlign = TextAlign.Center
+                    modifier = Modifier.weight(1f),
+                    maxLines = 1,
+                    overflow = androidx.compose.ui.text.style.TextOverflow.Ellipsis
                 )
-                Spacer(Modifier.height(8.dp))
-                Text(
-                    text = context.getString(R.string.procd_services_placeholder_desc, containerName),
-                    style = MaterialTheme.typography.bodyMedium,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    textAlign = TextAlign.Center
-                )
+
+                Surface(
+                    color = statusColor.copy(alpha = 0.1f),
+                    shape = RoundedCornerShape(8.dp),
+                    border = BorderStroke(1.dp, statusColor.copy(alpha = 0.2f))
+                ) {
+                    Row(
+                        modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
+                        verticalAlignment = Alignment.CenterVertically,
+                        horizontalArrangement = Arrangement.spacedBy(6.dp)
+                    ) {
+                        Surface(modifier = Modifier.size(6.dp), shape = CircleShape, color = statusColor) {}
+                        Text(
+                            text = when (service.status) {
+                                ServiceStatus.ENABLED_RUNNING -> context.getString(R.string.running)
+                                ServiceStatus.ENABLED_STOPPED -> context.getString(R.string.enabled_legend)
+                                ServiceStatus.DISABLED_STOPPED -> context.getString(R.string.disabled_legend)
+                                ServiceStatus.ABNORMAL -> context.getString(R.string.abnormal_legend)
+                                ServiceStatus.UNKNOWN -> context.getString(R.string.unknown_legend)
+                            }.uppercase(),
+                            style = MaterialTheme.typography.labelSmall,
+                            fontWeight = FontWeight.Black,
+                            letterSpacing = 0.5.sp,
+                            color = statusColor
+                        )
+                    }
+                }
             }
+
+            HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.3f))
+
+            Column(modifier = Modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(16.dp)) {
+                if (service.description.isNotEmpty()) {
+                    Text(
+                        text = service.description,
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.8f)
+                    )
+                }
+
+                Surface(
+                    modifier = Modifier.fillMaxWidth(),
+                    color = MaterialTheme.colorScheme.surfaceContainerHigh,
+                    shape = RoundedCornerShape(12.dp),
+                    border = BorderStroke(1.dp, MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.2f))
+                ) {
+                    Row(modifier = Modifier.fillMaxWidth().padding(4.dp), horizontalArrangement = Arrangement.spacedBy(4.dp)) {
+                        val btnColor = if (service.isRunning) MaterialTheme.colorScheme.errorContainer.copy(alpha = 0.4f) else MaterialTheme.colorScheme.primaryContainer.copy(alpha = 0.4f)
+                        val accentColor = if (service.isRunning) MaterialTheme.colorScheme.error else MaterialTheme.colorScheme.primary
+
+                        // Start / Stop
+                        Surface(
+                            onClick = {
+                                if (service.isRunning) onAction(context.getString(R.string.stop)) { ContainerProcdManager.stopService(containerName, service.name) }
+                                else onAction(context.getString(R.string.start)) { ContainerProcdManager.startService(containerName, service.name) }
+                            },
+                            modifier = Modifier.weight(1f).height(48.dp),
+                            shape = RoundedCornerShape(16.dp),
+                            color = btnColor,
+                            border = BorderStroke(1.dp, accentColor.copy(alpha = 0.2f))
+                        ) {
+                            Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                                Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                                    Icon(if (service.isRunning) Icons.Default.Stop else Icons.Default.PlayArrow, null, Modifier.size(18.dp), tint = accentColor)
+                                    Text(if (service.isRunning) context.getString(R.string.stop) else context.getString(R.string.start), style = MaterialTheme.typography.labelLarge, fontWeight = FontWeight.Bold, color = accentColor)
+                                }
+                            }
+                        }
+
+                        // Enable / Disable
+                        Surface(
+                            onClick = {
+                                if (service.isEnabled) onAction(context.getString(R.string.disable_service)) { ContainerProcdManager.disableService(containerName, service.name) }
+                                else onAction(context.getString(R.string.enable_service)) { ContainerProcdManager.enableService(containerName, service.name) }
+                            },
+                            modifier = Modifier.weight(1f).height(48.dp),
+                            shape = RoundedCornerShape(16.dp),
+                            color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.05f),
+                            border = BorderStroke(1.dp, MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.2f))
+                        ) {
+                            Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                                Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                                    Icon(if (service.isEnabled) Icons.Default.Block else Icons.Default.CheckCircle, null, Modifier.size(18.dp))
+                                    Text(if (service.isEnabled) context.getString(R.string.disable_service) else context.getString(R.string.enable_service), style = MaterialTheme.typography.labelLarge, fontWeight = FontWeight.Bold)
+                                }
+                            }
+                        }
+
+                        // More (Restart / Reload)
+                        Box {
+                            Surface(
+                                onClick = { showMenu = true },
+                                modifier = Modifier.size(48.dp),
+                                shape = RoundedCornerShape(16.dp),
+                                color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.05f),
+                                border = BorderStroke(1.dp, MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.2f))
+                            ) {
+                                Box(contentAlignment = Alignment.Center) { Icon(Icons.Default.MoreVert, null, tint = MaterialTheme.colorScheme.onSurfaceVariant) }
+                            }
+                            DropdownMenu(expanded = showMenu, onDismissRequest = { showMenu = false }) {
+                                DropdownMenuItem(
+                                    text = { Text(context.getString(R.string.restart_service)) },
+                                    leadingIcon = { Icon(Icons.Default.Refresh, null) },
+                                    onClick = { showMenu = false; onAction(context.getString(R.string.restart_service)) { ContainerProcdManager.restartService(containerName, service.name) } }
+                                )
+                                DropdownMenuItem(
+                                    text = { Text(context.getString(R.string.reload_service)) },
+                                    leadingIcon = { Icon(Icons.Default.Refresh, null) },
+                                    onClick = { showMenu = false; onAction(context.getString(R.string.reload_service)) { ContainerProcdManager.reloadService(containerName, service.name) } }
+                                )
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun ProcdNotAvailable() {
+    val context = LocalContext.current
+    Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+        Column(horizontalAlignment = Alignment.CenterHorizontally, verticalArrangement = Arrangement.spacedBy(24.dp), modifier = Modifier.padding(32.dp)) {
+            Surface(shape = CircleShape, color = MaterialTheme.colorScheme.errorContainer.copy(alpha = 0.2f), modifier = Modifier.size(120.dp), border = BorderStroke(2.dp, MaterialTheme.colorScheme.error.copy(alpha = 0.2f))) {
+                Box(contentAlignment = Alignment.Center) { Icon(Icons.Default.Warning, null, modifier = Modifier.size(56.dp), tint = MaterialTheme.colorScheme.error) }
+            }
+            Column(horizontalAlignment = Alignment.CenterHorizontally, verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                Text(context.getString(R.string.init_system_not_available), style = MaterialTheme.typography.titleLarge, fontWeight = FontWeight.Bold, textAlign = TextAlign.Center)
+                Text(context.getString(R.string.init_system_not_available_desc), style = MaterialTheme.typography.bodyMedium, color = MaterialTheme.colorScheme.onSurfaceVariant, textAlign = TextAlign.Center)
+            }
+        }
+    }
+}
+
+@Composable
+private fun ProcdEmptyServicesState(filter: ServiceFilter, modifier: Modifier = Modifier) {
+    val context = LocalContext.current
+    Box(modifier = modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+        Column(horizontalAlignment = Alignment.CenterHorizontally, verticalArrangement = Arrangement.spacedBy(16.dp)) {
+            Icon(Icons.Default.SearchOff, null, modifier = Modifier.size(64.dp), tint = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.3f))
+            Text(
+                text = when (filter) {
+                    ServiceFilter.RUNNING -> context.getString(R.string.no_running_services)
+                    ServiceFilter.ENABLED -> context.getString(R.string.no_enabled_services)
+                    ServiceFilter.DISABLED -> context.getString(R.string.no_disabled_services)
+                    ServiceFilter.ABNORMAL -> context.getString(R.string.no_abnormal_services)
+                    ServiceFilter.UNKNOWN -> context.getString(R.string.no_unknown_services)
+                    ServiceFilter.ALL -> context.getString(R.string.no_services_found)
+                },
+                style = MaterialTheme.typography.bodyLarge,
+                color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.7f)
+            )
         }
     }
 }

--- a/Android/app/src/main/java/com/droidspaces/app/util/ContainerProcdManager.kt
+++ b/Android/app/src/main/java/com/droidspaces/app/util/ContainerProcdManager.kt
@@ -1,0 +1,33 @@
+package com.droidspaces.app.util
+
+import android.util.Log
+import com.topjohnwu.superuser.Shell
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+
+/**
+ * OpenWrt/procd service manager for containers.
+ *
+ * This initial manager only detects OpenWrt/procd availability. Service listing
+ * and actions are added separately so detection/navigation can be tested first.
+ */
+object ContainerProcdManager {
+    private const val TAG = "ContainerProcdManager"
+
+    /**
+     * Check if the container looks like an OpenWrt/procd system.
+     *
+     * Do not use /etc/init.d alone: OpenRC and SysV-style systems also expose
+     * that directory. /etc/openwrt_release is the distro-level discriminator;
+     * procd/ubus/service binaries confirm that the OpenWrt service stack exists.
+     */
+    suspend fun isProcdAvailable(containerName: String): Boolean = withContext(Dispatchers.IO) {
+        try {
+            val cmd = "${Constants.DROIDSPACES_BINARY_PATH} --name=${ContainerCommandBuilder.quote(containerName)} run '[ -f /etc/openwrt_release ] && { [ -x /sbin/procd ] || [ -x /sbin/ubusd ] || command -v ubus >/dev/null 2>&1 || command -v service >/dev/null 2>&1; }'"
+            Shell.cmd(cmd).exec().isSuccess
+        } catch (e: Exception) {
+            Log.e(TAG, "Error checking procd availability", e)
+            false
+        }
+    }
+}

--- a/Android/app/src/main/java/com/droidspaces/app/util/ContainerProcdManager.kt
+++ b/Android/app/src/main/java/com/droidspaces/app/util/ContainerProcdManager.kt
@@ -1,18 +1,90 @@
 package com.droidspaces.app.util
 
+import android.content.Context
+import android.util.Base64
 import android.util.Log
 import com.topjohnwu.superuser.Shell
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.TimeoutException
 
 /**
  * OpenWrt/procd service manager for containers.
  *
- * This initial manager only detects OpenWrt/procd availability. Service listing
- * and actions are added separately so detection/navigation can be tested first.
+ * Uses a base64-encoded chkprocd.sh helper for service discovery and
+ * /etc/init.d/<service> for procd-compatible service actions.
  */
 object ContainerProcdManager {
     private const val TAG = "ContainerProcdManager"
+    private const val COMMAND_TIMEOUT_MS = 15_000L
+
+    private val safeServiceName = Regex("^[A-Za-z0-9_.+@-]+$")
+    private val safeActions = setOf("start", "stop", "restart", "reload", "enable", "disable", "status")
+
+    private var scriptBase64: String? = null
+
+    /**
+     * procd does not expose systemd's masked/static concepts. Runtime state can
+     * also be unavailable for some init scripts, so UNKNOWN is explicit.
+     */
+    enum class ServiceStatus {
+        ENABLED_RUNNING,
+        ENABLED_STOPPED,
+        DISABLED_STOPPED,
+        ABNORMAL,
+        UNKNOWN
+    }
+
+    data class ServiceInfo(
+        val name: String,
+        val description: String,
+        val status: ServiceStatus,
+        val isEnabled: Boolean,
+        val isRunning: Boolean
+    )
+
+    enum class ServiceFilter {
+        RUNNING,
+        ENABLED,
+        DISABLED,
+        ABNORMAL,
+        UNKNOWN,
+        ALL
+    }
+
+    data class CommandResult(
+        val exitCode: Int,
+        val output: List<String>,
+        val error: List<String>
+    ) {
+        val isSuccess: Boolean get() = exitCode == 0
+    }
+
+    fun initialize(context: Context) {
+        if (scriptBase64 == null) {
+            try {
+                val script = context.assets.open("chkprocd.sh").bufferedReader().readText()
+                scriptBase64 = Base64.encodeToString(script.toByteArray(), Base64.NO_WRAP)
+            } catch (e: Exception) {
+                Log.e(TAG, "Failed to load chkprocd.sh from assets", e)
+            }
+        }
+    }
+
+    private suspend fun runScript(containerName: String, flag: String): Pair<Boolean, List<String>> =
+        withContext(Dispatchers.IO) {
+            val b64 = scriptBase64 ?: return@withContext Pair(false, emptyList())
+            try {
+                val cmd = "${Constants.DROIDSPACES_BINARY_PATH} --name=${ContainerCommandBuilder.quote(containerName)} run 'echo $b64 | base64 -d | sh -s -- $flag'"
+                val result = Shell.cmd(cmd).exec()
+                Pair(result.isSuccess, result.out)
+            } catch (e: Exception) {
+                Log.e(TAG, "Error running procd query script", e)
+                Pair(false, emptyList())
+            }
+        }
 
     /**
      * Check if the container looks like an OpenWrt/procd system.
@@ -30,4 +102,124 @@ object ContainerProcdManager {
             false
         }
     }
+
+    suspend fun getAllServices(containerName: String): List<ServiceInfo> = withContext(Dispatchers.IO) {
+        try {
+            val (success, lines) = runScript(containerName, "--all")
+            if (!success) return@withContext emptyList()
+
+            lines.mapNotNull { line ->
+                val parts = line.split("|", limit = 4)
+                if (parts.size < 4) return@mapNotNull null
+
+                val name = parts[0].trim()
+                if (!isSafeServiceName(name)) return@mapNotNull null
+
+                val description = parts[1].trim()
+                val enabled = parts[2].trim() == "enabled"
+                val runningState = parts[3].trim()
+                val running = runningState == "running"
+
+                val status = when {
+                    runningState == "unknown" -> ServiceStatus.UNKNOWN
+                    enabled && running -> ServiceStatus.ENABLED_RUNNING
+                    enabled && !running -> ServiceStatus.ENABLED_STOPPED
+                    !enabled && running -> ServiceStatus.ABNORMAL
+                    else -> ServiceStatus.DISABLED_STOPPED
+                }
+
+                ServiceInfo(
+                    name = name,
+                    description = description,
+                    status = status,
+                    isEnabled = enabled,
+                    isRunning = running
+                )
+            }.sortedBy { it.name }
+        } catch (e: Exception) {
+            Log.e(TAG, "Error fetching procd services", e)
+            emptyList()
+        }
+    }
+
+    fun filterServices(services: List<ServiceInfo>, filter: ServiceFilter): List<ServiceInfo> {
+        return when (filter) {
+            ServiceFilter.ALL -> services
+            ServiceFilter.RUNNING -> services.filter { it.isRunning && it.isEnabled }
+            ServiceFilter.ENABLED -> services.filter { it.isEnabled && !it.isRunning && it.status != ServiceStatus.UNKNOWN }
+            ServiceFilter.DISABLED -> services.filter { !it.isEnabled && !it.isRunning && it.status != ServiceStatus.UNKNOWN }
+            ServiceFilter.ABNORMAL -> services.filter { it.isRunning && !it.isEnabled }
+            ServiceFilter.UNKNOWN -> services.filter { it.status == ServiceStatus.UNKNOWN }
+        }.sortedWith(compareByDescending<ServiceInfo> { it.isRunning }.thenBy { it.name })
+    }
+
+    private fun isSafeServiceName(serviceName: String): Boolean = safeServiceName.matches(serviceName)
+
+    private fun validateServiceAction(serviceName: String, action: String): CommandResult? {
+        if (!isSafeServiceName(serviceName)) {
+            return CommandResult(
+                exitCode = 2,
+                output = emptyList(),
+                error = listOf("Invalid OpenWrt service name: $serviceName")
+            )
+        }
+        if (action !in safeActions) {
+            return CommandResult(
+                exitCode = 2,
+                output = emptyList(),
+                error = listOf("Unsupported OpenWrt service action: $action")
+            )
+        }
+        return null
+    }
+
+    private suspend fun executeProcdCommand(
+        containerName: String,
+        serviceName: String,
+        action: String
+    ): CommandResult = withContext(Dispatchers.IO) {
+        validateServiceAction(serviceName, action)?.let { return@withContext it }
+
+        val command = "/etc/init.d/$serviceName $action"
+        val fullCmd = "${Constants.DROIDSPACES_BINARY_PATH} --name=${ContainerCommandBuilder.quote(containerName)} run '$command 2>&1'"
+        val executor = Executors.newSingleThreadExecutor()
+        try {
+            val future = executor.submit<Shell.Result> { Shell.cmd(fullCmd).exec() }
+            try {
+                val result = future.get(COMMAND_TIMEOUT_MS, TimeUnit.MILLISECONDS)
+                CommandResult(exitCode = result.code, output = result.out, error = result.err)
+            } catch (e: TimeoutException) {
+                future.cancel(true)
+                Log.e(TAG, "Command timed out: $command")
+                CommandResult(
+                    exitCode = 124,
+                    output = listOf("Command timed out after ${COMMAND_TIMEOUT_MS / 1000} seconds"),
+                    error = emptyList()
+                )
+            }
+        } catch (e: Exception) {
+            Log.e(TAG, "Error executing: $command", e)
+            CommandResult(exitCode = 1, output = emptyList(), error = listOf(e.message ?: "Unknown error"))
+        } finally {
+            executor.shutdownNow()
+        }
+    }
+
+    suspend fun startService(containerName: String, serviceName: String) =
+        executeProcdCommand(containerName, serviceName, "start")
+
+    suspend fun stopService(containerName: String, serviceName: String) =
+        executeProcdCommand(containerName, serviceName, "stop")
+
+    suspend fun restartService(containerName: String, serviceName: String) =
+        executeProcdCommand(containerName, serviceName, "restart")
+
+    suspend fun reloadService(containerName: String, serviceName: String) =
+        executeProcdCommand(containerName, serviceName, "reload")
+
+    suspend fun enableService(containerName: String, serviceName: String) =
+        executeProcdCommand(containerName, serviceName, "enable")
+
+    suspend fun disableService(containerName: String, serviceName: String) =
+        executeProcdCommand(containerName, serviceName, "disable")
 }

--- a/Android/app/src/main/res/values/strings.xml
+++ b/Android/app/src/main/res/values/strings.xml
@@ -13,7 +13,7 @@
     <string name="feat_overhead_desc">Talks to the host Linux kernel directly. No hypervisor, no virtual machine layer.</string>
     <string name="feat_unkillable_title">Unkillable by design</string>
     <string name="feat_unkillable_desc">Supports native init.rc integration and 2-layer userspace daemons. Completely unkillable.</string>
-    <string name="feat_init_title">systemd / OpenRC as PID 1</string>
+    <string name="feat_init_title">systemd / OpenWrt procd / OpenRC as PID 1</string>
     <string name="feat_init_desc">Full init system support. Real service management, not a simulated environment.</string>
     <string name="feat_isolation_title">Complete isolation</string>
     <string name="feat_isolation_desc">Private PID tree, mount table, hostname, IPC, and cgroup hierarchy per container.</string>
@@ -376,11 +376,15 @@
 
     <!-- Systemd Screen -->
     <string name="systemd_services">Systemd Services</string>
+    <string name="openwrt_services">OpenWrt Services</string>
+    <string name="openwrt">OpenWrt</string>
+    <string name="procd_detected">OpenWrt/procd detected</string>
+    <string name="procd_services_placeholder_desc">Service management for %1$s will be added in the next patch.</string>
     <string name="openrc_services">OpenRC Services</string>
     <string name="openrc">OpenRC</string>
     <string name="init_system">Init System</string>
-    <string name="init_system_not_available">Systemd/OpenRC Not Available</string>
-    <string name="init_system_not_available_desc">This container does not have systemd or OpenRC installed</string>
+    <string name="init_system_not_available">Systemd/OpenWrt/OpenRC Not Available</string>
+    <string name="init_system_not_available_desc">This container does not have systemd, OpenWrt/procd, or OpenRC installed</string>
     <string name="fetching_services">Fetching services...</string>
 
     <string name="search_services">Search services...</string>

--- a/Android/app/src/main/res/values/strings.xml
+++ b/Android/app/src/main/res/values/strings.xml
@@ -392,12 +392,14 @@
     <string name="disabled_legend">Disabled</string>
     <string name="static_legend">Static</string>
     <string name="abnormal_legend">Abnormal</string>
+    <string name="unknown_legend">Unknown</string>
     <string name="masked_legend">Masked</string>
     <string name="all_legend">All</string>
     <string name="unmask">Unmask</string>
     <string name="enable_service">Enable</string>
     <string name="disable_service">Disable</string>
     <string name="restart_service">Restart service</string>
+    <string name="reload_service">Reload service</string>
     <string name="mask_service">Mask service</string>
     <string name="action_successful">%1$s %2$s successful</string>
     <string name="failed_to_action">Failed to %1$s %2$s</string>
@@ -410,6 +412,7 @@
     <string name="no_disabled_services">No disabled services</string>
     <string name="no_static_services">No static services</string>
     <string name="no_abnormal_services">No abnormal services</string>
+    <string name="no_unknown_services">No services with unknown state</string>
     <string name="no_masked_services">No masked services</string>
 
     <!-- System Info Card -->


### PR DESCRIPTION
## Summary

Adds OpenWrt/procd support to the Android app's container init/service management UI.

OpenWrt containers use procd rather than systemd or OpenRC, so the app now detects OpenWrt/procd containers and exposes a dedicated OpenWrt services screen.

This is a preliminary proposal.

## Changes

- Add `InitSystem.PROCD`
- Detect OpenWrt/procd containers via OpenWrt/procd-specific markers
- Add `ContainerProcdManager`
- Add `chkprocd.sh` helper script
- Add OpenWrt services screen

## Testing

- Built Android debug APK successfully with gradle.