### PR TITLE
android: fallback to high-minor losetup scan when sparse loop attach fails

### DIFF
--- a/Android/app/src/main/assets/mount_loop_scan.sh
+++ b/Android/app/src/main/assets/mount_loop_scan.sh
@@ -1,0 +1,93 @@
+#!/system/bin/sh
+# Sparse ext4 mount: busybox/system mount -o loop first, then high-minor loop-scan fallback.
+# Android APEX-heavy pools: keep upstream mount order; scan upper pool after failure.
+set -eu
+
+IMG="${1:?img path}"
+MNT="${2:?mount point}"
+OPTS_NO_LOOP="${3:-rw,nodelalloc,noatime,nodiratime,init_itable=0}"
+
+if [ -n "${BUSYBOX_PATH:-}" ] && [ -x "$BUSYBOX_PATH" ]; then
+  BB="$BUSYBOX_PATH"
+else
+  BB="/data/local/Droidspaces/bin/busybox"
+fi
+
+LOOP_OPTS="loop,$OPTS_NO_LOOP"
+
+# 1. Upstream order: busybox mount -o loop, then system mount -o loop
+if [ -x "$BB" ] && "$BB" mount -t ext4 -o "$LOOP_OPTS" "$IMG" "$MNT" 2>/dev/null; then
+  exit 0
+fi
+if mount -t ext4 -o "$LOOP_OPTS" "$IMG" "$MNT" 2>/dev/null; then
+  exit 0
+fi
+
+# 2. Fallback: explicit losetup — scan upper pool (relative floor, not OEM-specific)
+# Skip lowest max(16, max_loop/4) minors; APEX/OEM modules usually bind low slots.
+loop_scan_start() {
+  local max_loop="$1"
+  local skip=$((max_loop / 4))
+  [ "$skip" -lt 16 ] && skip=16
+  [ "$skip" -gt "$max_loop" ] && skip=$max_loop
+  local s=$((max_loop - skip))
+  [ "$s" -lt 0 ] && s=0
+  echo "$s"
+}
+
+effective_max_loop() {
+  local sysfs=64 block_max=0 n p
+  if [ -r /sys/module/loop/parameters/max_loop ]; then
+    sysfs=$(cat /sys/module/loop/parameters/max_loop 2>/dev/null) || sysfs=64
+    [ -z "$sysfs" ] && sysfs=64
+  fi
+  for p in /sys/block/loop[0-9]* /sys/block/loop[0-9][0-9]*; do
+    [ -e "$p" ] || continue
+    n=${p##*/loop}
+    case $n in ''|*[!0-9]*) continue ;; esac
+    [ "$n" -gt "$block_max" ] && block_max=$n
+  done
+  if [ $((block_max + 1)) -gt "$sysfs" ]; then
+    echo $((block_max + 1))
+  else
+    echo "$sysfs"
+  fi
+}
+
+max_used_minor() {
+  awk 'NR>1 {if ($2+0 > m) m=$2+0} END {print m+0}' /proc/loops 2>/dev/null || echo 0
+}
+
+max_loop=$(effective_max_loop)
+used_max=$(max_used_minor)
+
+start=$(loop_scan_start "$max_loop")
+if [ "$used_max" -ge "$start" ]; then
+  start=$((used_max + 1))
+fi
+[ "$start" -ge "$max_loop" ] && start=$((max_loop - 1))
+
+end=$((max_loop - 1))
+if [ "$used_max" -gt "$end" ]; then
+  end=$used_max
+fi
+[ "$end" -gt 255 ] && end=255
+
+i=$end
+while [ "$i" -ge "$start" ]; do
+  loop_dev="/dev/block/loop$i"
+  if losetup "$loop_dev" 2>/dev/null; then
+    i=$((i - 1))
+    continue
+  fi
+  if losetup "$loop_dev" "$IMG" 2>/dev/null; then
+    if mount -t ext4 -o "$OPTS_NO_LOOP" "$loop_dev" "$MNT" 2>/dev/null; then
+      exit 0
+    fi
+    umount "$MNT" 2>/dev/null || true
+    losetup -d "$loop_dev" 2>/dev/null || true
+  fi
+  i=$((i - 1))
+done
+
+exit 1

--- a/Android/app/src/main/assets/sparsemgr.sh
+++ b/Android/app/src/main/assets/sparsemgr.sh
@@ -54,6 +54,93 @@ _mount() {
     return 1
 }
 
+# Android: upstream mount -o loop first (_mount: system then busybox); loop-scan fallback.
+_mount_loop_img() {
+    local img="$1"
+    local mnt="$2"
+    shift 2
+    local extra_opts="$*"
+
+    if [ -n "$extra_opts" ]; then
+        if mount -t ext4 -o loop,"$extra_opts" "$img" "$mnt" 2>/dev/null; then
+            return 0
+        elif [ -n "$BB" ] && "$BB" mount -t ext4 -o loop,"$extra_opts" "$img" "$mnt" 2>/dev/null; then
+            return 0
+        fi
+    else
+        if mount -t ext4 -o loop,ro "$img" "$mnt" 2>/dev/null; then
+            return 0
+        elif [ -n "$BB" ] && "$BB" mount -t ext4 -o loop,ro "$img" "$mnt" 2>/dev/null; then
+            return 0
+        fi
+    fi
+
+    _loop_scan_start() {
+        local max_loop="$1"
+        local skip=$((max_loop / 4))
+        [ "$skip" -lt 16 ] && skip=16
+        [ "$skip" -gt "$max_loop" ] && skip=$max_loop
+        local s=$((max_loop - skip))
+        [ "$s" -lt 0 ] && s=0
+        echo "$s"
+    }
+
+    local max_loop start end i loop_dev used_max sysfs=64 block_max=0 n p
+    if [ -r /sys/module/loop/parameters/max_loop ]; then
+        sysfs=$(cat /sys/module/loop/parameters/max_loop 2>/dev/null) || sysfs=64
+        [ -z "$sysfs" ] && sysfs=64
+    fi
+    for p in /sys/block/loop[0-9]* /sys/block/loop[0-9][0-9]*; do
+        [ -e "$p" ] || continue
+        n=${p##*/loop}
+        case $n in ''|*[!0-9]*) continue ;; esac
+        [ "$n" -gt "$block_max" ] && block_max=$n
+    done
+    if [ $((block_max + 1)) -gt "$sysfs" ]; then
+        max_loop=$((block_max + 1))
+    else
+        max_loop=$sysfs
+    fi
+
+    used_max=0
+    if [ -r /proc/loops ]; then
+        used_max=$(awk 'NR>1 {if ($2+0 > m) m=$2+0} END {print m+0}' /proc/loops 2>/dev/null)
+        [ -z "$used_max" ] && used_max=0
+    fi
+    start=$(_loop_scan_start "$max_loop")
+    if [ "$used_max" -ge "$start" ]; then
+        start=$((used_max + 1))
+    fi
+    [ "$start" -ge "$max_loop" ] && start=$((max_loop - 1))
+    end=$((max_loop - 1))
+    if [ "$used_max" -gt "$end" ]; then
+        end=$used_max
+    fi
+    [ "$end" -gt 255 ] && end=255
+
+    i=$end
+    while [ "$i" -ge "$start" ]; do
+        loop_dev="/dev/block/loop$i"
+        if losetup "$loop_dev" 2>/dev/null; then
+            i=$((i - 1))
+            continue
+        fi
+        if losetup "$loop_dev" "$img" 2>/dev/null; then
+            if [ -n "$extra_opts" ]; then
+                mount -t ext4 -o "$extra_opts" "$loop_dev" "$mnt" 2>/dev/null && return 0
+            else
+                mount -t ext4 "$loop_dev" "$mnt" 2>/dev/null && return 0
+            fi
+            umount "$mnt" 2>/dev/null || true
+            losetup -d "$loop_dev" 2>/dev/null || true
+        fi
+        i=$((i - 1))
+    done
+
+    error "mount: loop and high-minor losetup both failed for $img"
+    return 1
+}
+
 # umount wrapper
 _umount() {
     if umount "$@" 2>/dev/null; then
@@ -301,8 +388,8 @@ cmd_migrate() {
     log "[3/5] Mounting sparse image..."
     _mkdir "$ROOTFS_SPARSE"
     chcon u:object_r:vold_data_file:s0 "$ROOTFS_IMG" 2>/dev/null || true
-    if ! _mount -t ext4 -o loop,rw,noatime,nodiratime,data=ordered,commit=30 \
-            "$ROOTFS_IMG" "$ROOTFS_SPARSE"; then
+    if ! _mount_loop_img "$ROOTFS_IMG" "$ROOTFS_SPARSE" \
+            rw,noatime,nodiratime,data=ordered,commit=30; then
         exit 1
     fi
     log "    Mounted at $ROOTFS_SPARSE ✓"
@@ -499,7 +586,7 @@ cmd_resize() {
     local verify_dir
     verify_dir="$(dirname "$RESIZE_IMG")/.resize_verify_$$"
     _mkdir "$verify_dir"
-    if _mount -t ext4 -o loop,ro "$RESIZE_IMG" "$verify_dir" 2>/dev/null; then
+    if _mount_loop_img "$RESIZE_IMG" "$verify_dir" ro 2>/dev/null; then
         _umount "$verify_dir" 2>/dev/null
         _rm -rf "$verify_dir"
         log "    Mount verification passed ✓"

--- a/Android/app/src/main/java/com/droidspaces/app/util/ContainerInstaller.kt
+++ b/Android/app/src/main/java/com/droidspaces/app/util/ContainerInstaller.kt
@@ -150,6 +150,14 @@ object ContainerInstaller {
             logger.i("Container configuration saved")
             createdPaths.add(configFilePath)
 
+            if (config.useSparseImage) {
+                SparseImageInstaller.unmountSparseImage(
+                    mountPoint = "$containerPath/rootfs",
+                    imgPath = rootfsPath,
+                    logger = logger
+                )
+            }
+
             // Step 5.1: Write .env file if content exists
             if (!config.envFileContent.isNullOrBlank()) {
                 logger.i("Writing environment variables (.env)...")

--- a/Android/app/src/main/java/com/droidspaces/app/util/SparseImageInstaller.kt
+++ b/Android/app/src/main/java/com/droidspaces/app/util/SparseImageInstaller.kt
@@ -76,53 +76,71 @@ object SparseImageInstaller {
             logger.i("[SPARSE] Applying SELinux context (vold_data_file)...")
             runRootCommand("chcon u:object_r:vold_data_file:s0 \"$imgPath\"", logger) ?: throw Exception("Failed to apply SELinux context to image")
 
-            // 4. Mount Image (Minimal options for Max compatibility)
-            logger.i("[SPARSE] Mounting sparse image (Minimal loop,rw)...")
-            val mountOptions = "loop,rw,nodelalloc,noatime,nodiratime,init_itable=0"
-            val mountCmd = "${Constants.BUSYBOX_BINARY_PATH} mount -t ext4 -o $mountOptions \"$imgPath\" \"$mountPoint\" || " +
-                          "mount -t ext4 -o $mountOptions \"$imgPath\" \"$mountPoint\""
-
+            // 4. Mount Image - upstream busybox mount -o loop first; loop-scan fallback on failure
+            logger.i("[SPARSE] Mounting sparse image (busybox loop,rw; loop-scan fallback)...")
+            val mountOptions = "rw,nodelalloc,noatime,nodiratime,init_itable=0"
+            val mountScript = prepareAssetScript(context, "mount_loop_scan.sh", logger)
+            val mountCmd = "BUSYBOX_PATH=${Constants.BUSYBOX_BINARY_PATH} \"${mountScript.absolutePath}\" \"$imgPath\" \"$mountPoint\" \"$mountOptions\""
             runRootCommand(mountCmd, logger) ?: throw Exception("Failed to mount sparse image. Your kernel might not support loop mounts here.")
 
-            try {
-                // 5. Extract Tarball
-                logger.i("[SPARSE] Extracting tarball to mount point...")
-                val isXz = tarball.name.lowercase().endsWith(".xz")
-                val extractCmd = if (isXz) {
-                    "cd \"$mountPoint\" && ${Constants.BUSYBOX_BINARY_PATH} xzcat \"${tarball.absolutePath}\" | ${Constants.BUSYBOX_BINARY_PATH} tar -xpf - 2>&1"
-                } else {
-                    "cd \"$mountPoint\" && ${Constants.BUSYBOX_BINARY_PATH} tar -xzpf \"${tarball.absolutePath}\" 2>&1"
-                }
-
-                // For extraction, we stream the output to the logger's debug level
-                val extractResult = Shell.cmd(extractCmd).exec()
-                if (!extractResult.isSuccess) {
-                    throw Exception("Tarball extraction failed: ${extractResult.err.joinToString("\n")}")
-                }
-                logger.i("[SPARSE] Extraction completed successfully")
-
-                // 6. Apply Post-Extraction Fixes (using script as requested)
-                applyScriptFixes(context, mountPoint, logger)
-
-            } finally {
-                // 7. Unmount (Always attempt)
-                logger.i("[SPARSE] Unmounting sparse image...")
-                Shell.cmd("${Constants.BUSYBOX_BINARY_PATH} sync").exec()
-                delay(1000)
-
-                val umountCmd = "${Constants.BUSYBOX_BINARY_PATH} umount -l \"$mountPoint\" || umount -l \"$mountPoint\""
-                Shell.cmd(umountCmd).exec()
-
-                // Cleanup mount point directory
-                Shell.cmd("rmdir \"$mountPoint\"").exec()
+            // 5. Extract Tarball (large xz rootfs may take 5-15 minutes)
+            logger.i("[SPARSE] Extracting tarball to mount point (may take 5-15 min for large images)...")
+            val isXz = tarball.name.lowercase().endsWith(".xz")
+            val extractCmd = if (isXz) {
+                "cd \"$mountPoint\" && ${Constants.BUSYBOX_BINARY_PATH} xzcat \"${tarball.absolutePath}\" | ${Constants.BUSYBOX_BINARY_PATH} tar -xpf - 2>&1"
+            } else {
+                "cd \"$mountPoint\" && ${Constants.BUSYBOX_BINARY_PATH} tar -xzpf \"${tarball.absolutePath}\" 2>&1"
             }
+
+            val extractResult = Shell.cmd(extractCmd).exec()
+            if (!extractResult.isSuccess) {
+                throw Exception("Tarball extraction failed: ${extractResult.err.joinToString("\n")}")
+            }
+            logger.i("[SPARSE] Extraction completed successfully")
+
+            // 6. Apply Post-Extraction Fixes (using script as requested)
+            applyScriptFixes(context, mountPoint, logger)
 
         } catch (e: Exception) {
             logger.e("[SPARSE] Error: ${e.message}")
-            // Cleanup incomplete image on failure
+            unmountSparseImage(mountPoint, imgPath, logger)
             Shell.cmd("rm -f \"$imgPath\"").exec()
             throw e
         }
+    }
+
+    /**
+     * Unmount sparse image after container.config is written (success path).
+     * Caller must invoke this; extract() leaves the mount active on success.
+     */
+    suspend fun unmountSparseImage(
+        mountPoint: String,
+        imgPath: String,
+        logger: ContainerLogger
+    ) = withContext(Dispatchers.IO) {
+        logger.i("[SPARSE] Unmounting sparse image...")
+        val umountCmd = "${Constants.BUSYBOX_BINARY_PATH} umount -l \"$mountPoint\" || umount -l \"$mountPoint\""
+        Shell.cmd(umountCmd).exec()
+        Shell.cmd(buildLoopDetachCmd(imgPath)).exec()
+        Shell.cmd("rmdir \"$mountPoint\"").exec()
+    }
+
+    private suspend fun prepareAssetScript(
+        context: Context,
+        assetName: String,
+        logger: ContainerLogger
+    ): File {
+        val out = File(context.cacheDir, assetName)
+        context.assets.open(assetName).use { input ->
+            FileOutputStream(out).use { output -> input.copyTo(output) }
+        }
+        Shell.cmd("chmod 755 \"${out.absolutePath}\"").exec()
+        logger.d("[SPARSE] Prepared $assetName at ${out.absolutePath}")
+        return out
+    }
+
+    private fun buildLoopDetachCmd(imgPath: String): String {
+        return "losetup -a 2>/dev/null | grep -F \"$imgPath\" | sed -n 's/:.*//p' | while read dev; do losetup -d \"\$dev\" 2>/dev/null; done"
     }
 
     /**

--- a/src/mount.c
+++ b/src/mount.c
@@ -870,7 +870,123 @@ out:
 }
 
 /*
- * Resolve loop device node path after LOOP_CTL_GET_FREE.
+ * Android: APEX may occupy low loop minors; LOOP_CTL_GET_FREE can return busy slots.
+ * Fallback: scan upper pool minors when attaching rootfs images.
+ */
+
+static long scan_block_loop_max(void) {
+  long max = 0;
+  DIR *d = opendir("/sys/block");
+  if (!d)
+    return 0;
+  struct dirent *de;
+  while ((de = readdir(d)) != NULL) {
+    if (strncmp(de->d_name, "loop", 4) != 0)
+      continue;
+    char *end;
+    long n = strtol(de->d_name + 4, &end, 10);
+    if (end != de->d_name + 4 && *end == '\0' && n >= 0 && n > max)
+      max = n;
+  }
+  closedir(d);
+  return max;
+}
+
+static long read_max_loop(void) {
+  long max_loop = 64;
+  FILE *f = fopen("/sys/module/loop/parameters/max_loop", "r");
+  if (f) {
+    if (fscanf(f, "%ld", &max_loop) != 1 || max_loop <= 0)
+      max_loop = 64;
+    fclose(f);
+  }
+  /* sysfs max_loop may be lower than existing /sys/block/loopN nodes */
+  if (is_android()) {
+    long block_max = scan_block_loop_max();
+    if (block_max + 1 > max_loop)
+      max_loop = block_max + 1;
+  }
+  return max_loop;
+}
+
+/*
+ * First minor to scan: skip lowest max(16, max_loop/4) slots (APEX uses low minors).
+ * Relative to pool size — not an OEM-specific constant.
+ */
+static long loop_scan_start(long max_loop) {
+  long skip = max_loop / 4;
+  if (skip < 16)
+    skip = 16;
+  if (skip > max_loop)
+    skip = max_loop;
+  long start = max_loop - skip;
+  return start > 0 ? start : 0;
+}
+
+static long loop_scan_used_max(void) {
+  FILE *f = fopen("/proc/loops", "r");
+  if (!f)
+    return 0;
+  char line[256];
+  if (!fgets(line, sizeof(line), f)) {
+    fclose(f);
+    return 0;
+  }
+  long used_max = 0;
+  while (fgets(line, sizeof(line), f)) {
+    long dev = -1;
+    if (sscanf(line, "%*s %ld", &dev) == 1 && dev > used_max)
+      used_max = dev;
+  }
+  fclose(f);
+  return used_max;
+}
+
+static int loop_status_fd(long devnr) {
+  char path[64];
+  if (is_android())
+    snprintf(path, sizeof(path), "/dev/block/loop%ld", devnr);
+  else
+    snprintf(path, sizeof(path), "/dev/loop%ld", devnr);
+
+  int fd = open(path, O_RDWR | O_CLOEXEC);
+  if (fd < 0) {
+    if (is_android())
+      snprintf(path, sizeof(path), "/dev/loop%ld", devnr);
+    else
+      snprintf(path, sizeof(path), "/dev/block/loop%ld", devnr);
+    fd = open(path, O_RDWR | O_CLOEXEC);
+  }
+  return fd;
+}
+
+static int loop_is_free(long devnr) {
+  int fd = loop_status_fd(devnr);
+  if (fd < 0)
+    return 0;
+
+  struct loop_info64 li;
+  int ret = ioctl(fd, LOOP_GET_STATUS64, &li);
+  int err = errno;
+  close(fd);
+  return (ret < 0 && err == ENXIO);
+}
+
+static long loop_find_free_devnr(void) {
+  int ctl_fd = open("/dev/loop-control", O_RDWR | O_CLOEXEC);
+  if (ctl_fd < 0) {
+    ds_error("open /dev/loop-control: %s", strerror(errno));
+    return -1;
+  }
+  long devnr = ioctl(ctl_fd, LOOP_CTL_GET_FREE);
+  close(ctl_fd);
+  if (devnr < 0)
+    ds_error("LOOP_CTL_GET_FREE: %s", strerror(errno));
+  return devnr;
+}
+
+/*
+ * Resolve loop device node path for a specific minor.
  *
  * Android userspace (vold): /dev/block/loopN
  * Android recovery + desktop Linux: /dev/loopN
@@ -915,57 +1031,90 @@ static int open_loop_dev(long devnr, char *path_out, size_t path_size) {
   return -1;
 }
 
-/*
- * Attach img_path to a free loop device via ioctls.
- * Sets LO_FLAGS_AUTOCLEAR so the kernel auto-releases the loop after umount.
- * Returns the open loop_fd on success (caller must close after mount()).
- * loop_path_out is filled with the device node path for the mount() call.
- */
-static int loop_attach(const char *img_path, char *loop_path_out,
-                       size_t path_size) {
-  int ctl_fd = open("/dev/loop-control", O_RDWR | O_CLOEXEC);
-  if (ctl_fd < 0) {
-    ds_error("open /dev/loop-control: %s", strerror(errno));
-    return -1;
-  }
-
-  long devnr = ioctl(ctl_fd, LOOP_CTL_GET_FREE);
-  close(ctl_fd);
-  if (devnr < 0) {
-    ds_error("LOOP_CTL_GET_FREE: %s", strerror(errno));
-    return -1;
-  }
-
+static int loop_attach_one(long devnr, int img_fd, const char *img_path,
+                           char *loop_path_out, size_t path_size) {
   int loop_fd = open_loop_dev(devnr, loop_path_out, path_size);
   if (loop_fd < 0) {
-    ds_error("Failed to open loop%ld: %s", devnr, strerror(errno));
-    return -1;
-  }
-
-  int img_fd = open(img_path, O_RDWR | O_CLOEXEC);
-  if (img_fd < 0) {
-    ds_error("open image %s: %s", img_path, strerror(errno));
-    close(loop_fd);
+    ds_warn("Failed to open loop%ld: %s", devnr, strerror(errno));
     return -1;
   }
 
   if (ioctl(loop_fd, LOOP_SET_FD, img_fd) < 0) {
-    ds_error("LOOP_SET_FD: %s", strerror(errno));
-    close(img_fd);
+    int err = errno;
+    if (err == EBUSY) {
+      ioctl(loop_fd, LOOP_CLR_FD, 0);
+      if (ioctl(loop_fd, LOOP_SET_FD, img_fd) == 0)
+        goto set_status;
+    }
+    ds_warn("LOOP_SET_FD on loop%ld: %s", devnr, strerror(err));
     close(loop_fd);
     return -1;
   }
-  close(img_fd); /* kernel holds a ref; we're done with this fd */
+
+set_status:
 
   struct loop_info64 li;
   memset(&li, 0, sizeof(li));
-  /* AUTOCLEAR: kernel auto-releases loop device after umount + all fds closed
-   */
   li.lo_flags = LO_FLAGS_AUTOCLEAR;
   snprintf((char *)li.lo_file_name, LO_NAME_SIZE, "%.63s", img_path);
 
   if (ioctl(loop_fd, LOOP_SET_STATUS64, &li) < 0)
     ds_warn("LOOP_SET_STATUS64: %s (continuing)", strerror(errno));
+
+  return loop_fd;
+}
+
+/*
+ * Attach img_path to a free loop device via ioctls.
+ * Android: scan high minors first; desktop: LOOP_CTL_GET_FREE.
+ */
+static int loop_attach(const char *img_path, char *loop_path_out,
+                       size_t path_size) {
+  int img_fd = open(img_path, O_RDWR | O_CLOEXEC);
+  if (img_fd < 0) {
+    ds_error("open image %s: %s", img_path, strerror(errno));
+    return -1;
+  }
+
+  int loop_fd = -1;
+
+  if (is_android()) {
+    long max_loop = read_max_loop();
+    long start = loop_scan_start(max_loop);
+    long used_max = loop_scan_used_max();
+    if (used_max >= start)
+      start = used_max + 1;
+    if (start >= max_loop)
+      start = max_loop > 0 ? max_loop - 1 : 0;
+
+    for (long i = max_loop - 1; i >= start; i--) {
+      if (!loop_is_free(i))
+        continue;
+      loop_fd = loop_attach_one(i, img_fd, img_path, loop_path_out, path_size);
+      if (loop_fd >= 0)
+        break;
+    }
+    if (loop_fd < 0) {
+      for (long i = start - 1; i >= 0; i--) {
+        if (!loop_is_free(i))
+          continue;
+        loop_fd =
+            loop_attach_one(i, img_fd, img_path, loop_path_out, path_size);
+        if (loop_fd >= 0)
+          break;
+      }
+    }
+  } else {
+    long devnr = loop_find_free_devnr();
+    if (devnr >= 0)
+      loop_fd =
+          loop_attach_one(devnr, img_fd, img_path, loop_path_out, path_size);
+  }
+
+  close(img_fd);
+
+  if (loop_fd < 0)
+    ds_error("Failed to attach %s to any free loop device", img_path);
 
   return loop_fd;
 }


### PR DESCRIPTION
Fixes #214

This PR adds a high-minor `losetup` scan fallback when the stock `busybox || mount` chain fails on devices with many pre-bound loop devices (Lenovo TB520FU etc.). No OEM-specific branching.

### Summary

Stock mount chain (unchanged order):

```text
busybox mount -o loop,...  ||  system mount -o loop,...
```

After **both** fail, add high-minor `losetup` scan fallback. No OEM model branching.

`ContainerInstaller.kt`: on successful sparse install, write `container.config` **before** unmounting the sparse rootfs.

Scan start: `max(0, max_loop - max(16, max_loop/4))`.

### Commits / files

| # | File | Scenario |
|---|------|----------|
| 1 | `src/mount.c` | CLI: `LOOP_CTL_GET_FREE` / attach failure |
| 2 | `SparseImageInstaller.kt`, `sparsemgr.sh`, `mount_loop_scan.sh` | App sparse install mount |
| 3 | `ContainerInstaller.kt` | config write + umount order |

Patches (base `76cbd21`): https://github.com/da-ai-xian-zun/tb520fu-droidspaces-gki/tree/main/patches

### Tested

**Lenovo TB520FU**, Android 16, `max_loop=64`:

| Build | App sparse create | `busybox \|\| mount` | manual `losetup loop48+` | stop/start |
|-------|-------------------|----------------------|---------------------------|------------|
| stock v6.3.x | FAIL | FAIL | PASS | PASS after reboot; FAIL without reboot on dirty loop pool |
| this PR | PASS | (fallback used) | PASS | PASS |

**OnePlus PKR110** (`6.6.89-Gold_bug`): stock behavior is PASS; this PR was not separately regression-tested on it.