### PR TITLE
Integrated Anland Wayland display bridge

### DIFF
--- a/Android/app/src/main/AndroidManifest.xml
+++ b/Android/app/src/main/AndroidManifest.xml
@@ -13,6 +13,12 @@
     <uses-permission android:name="android.permission.WAKE_LOCK" />
     <uses-permission android:name="android.permission.REQUEST_IGNORE_BATTERY_OPTIMIZATIONS" />
 
+    <!-- Package visibility (Android 11+): allow launching the anland consumer
+         app for the "Launch Anland Window" action. -->
+    <queries>
+        <package android:name="com.anland.consumer" />
+    </queries>
+
     <application
         android:name=".DroidspacesApplication"
         android:allowBackup="true"

--- a/Android/app/src/main/assets/boot-module/sepolicy.rule
+++ b/Android/app/src/main/assets/boot-module/sepolicy.rule
@@ -74,3 +74,15 @@ allow mediaserver droidspacesd fd use
 
 # fix permission denied when read/write mounted storage (#213)
 allow mediaprovider_app droidspacesd fd use
+
+# for anland
+allow untrusted_app droidspacesd fd use
+allow droidspacesd untrusted_app fd use
+allow droidspacesd untrusted_app unix_stream_socket { read write }
+allow droidspacesd device chr_file { open read write ioctl map }
+allow droidspacesd droidspacesd unix_stream_socket { create connect listen accept bind getattr getopt setopt shutdown read write }
+allow droidspacesd hal_graphics_allocator_default fd use
+allow surfaceflinger droidspacesd fd use
+allow hal_graphics_composer_default droidspacesd fd use
+allow untrusted_app su unix_stream_socket { read write }
+

--- a/Android/app/src/main/java/com/droidspaces/app/ui/component/RunningContainerCard.kt
+++ b/Android/app/src/main/java/com/droidspaces/app/ui/component/RunningContainerCard.kt
@@ -32,6 +32,8 @@ fun RunningContainerCard(
     container: ContainerInfo,
     onEnter: () -> Unit = {},
     onTerminalClick: () -> Unit = {},
+    anlandEnabled: Boolean = false,
+    onLaunchAnland: () -> Unit = {},
     osInfo: ContainerOSInfoManager.OSInfo? = null,
     modifier: Modifier = Modifier
 ) {
@@ -184,6 +186,37 @@ fun RunningContainerCard(
                                 )
                             }
                         }
+                    }
+                }
+            }
+
+            // Launch the anland desktop window, shown only when this container has
+            // the anland display daemon enabled and a live socket recorded.
+            if (anlandEnabled) {
+                Surface(
+                    onClick = onLaunchAnland,
+                    modifier = Modifier.fillMaxWidth().height(44.dp),
+                    shape = RoundedCornerShape(12.dp),
+                    color = MaterialTheme.colorScheme.secondaryContainer,
+                    contentColor = MaterialTheme.colorScheme.onSecondaryContainer,
+                    tonalElevation = 0.dp
+                ) {
+                    Row(
+                        modifier = Modifier.fillMaxSize(),
+                        verticalAlignment = Alignment.CenterVertically,
+                        horizontalArrangement = Arrangement.Center
+                    ) {
+                        Icon(
+                            imageVector = Icons.Default.OpenInNew,
+                            contentDescription = null,
+                            modifier = Modifier.size(18.dp)
+                        )
+                        Spacer(Modifier.width(8.dp))
+                        Text(
+                            text = context.getString(R.string.launch_anland_window),
+                            style = MaterialTheme.typography.labelLarge,
+                            fontWeight = FontWeight.Bold
+                        )
                     }
                 }
             }

--- a/Android/app/src/main/java/com/droidspaces/app/ui/component/RunningContainerCard.kt
+++ b/Android/app/src/main/java/com/droidspaces/app/ui/component/RunningContainerCard.kt
@@ -75,6 +75,39 @@ fun RunningContainerCard(
                     modifier = Modifier.weight(1f)
                 )
 
+                // Small "anland" pill next to the terminal button, shown only when
+                // this container has the anland display daemon enabled and a live
+                // socket recorded.
+                if (anlandEnabled) {
+                    Surface(
+                        onClick = onLaunchAnland,
+                        shape = RoundedCornerShape(12.dp),
+                        color = MaterialTheme.colorScheme.secondaryContainer,
+                        contentColor = MaterialTheme.colorScheme.onSecondaryContainer,
+                        modifier = Modifier.height(30.dp).clip(RoundedCornerShape(12.dp)),
+                        tonalElevation = 0.dp
+                    ) {
+                        Row(
+                            modifier = Modifier.padding(horizontal = 10.dp),
+                            verticalAlignment = Alignment.CenterVertically,
+                            horizontalArrangement = Arrangement.Center
+                        ) {
+                            Icon(
+                                imageVector = Icons.Default.DesktopWindows,
+                                contentDescription = null,
+                                modifier = Modifier.size(14.dp)
+                            )
+                            Spacer(Modifier.width(6.dp))
+                            Text(
+                                text = "anland",
+                                style = MaterialTheme.typography.labelMedium,
+                                fontWeight = FontWeight.Bold
+                            )
+                        }
+                    }
+                    Spacer(Modifier.width(8.dp))
+                }
+
                 val sessionCount by remember {
                     derivedStateOf {
                         TerminalSessionService.globalSessionList.values.count {
@@ -186,37 +219,6 @@ fun RunningContainerCard(
                                 )
                             }
                         }
-                    }
-                }
-            }
-
-            // Launch the anland desktop window, shown only when this container has
-            // the anland display daemon enabled and a live socket recorded.
-            if (anlandEnabled) {
-                Surface(
-                    onClick = onLaunchAnland,
-                    modifier = Modifier.fillMaxWidth().height(44.dp),
-                    shape = RoundedCornerShape(12.dp),
-                    color = MaterialTheme.colorScheme.secondaryContainer,
-                    contentColor = MaterialTheme.colorScheme.onSecondaryContainer,
-                    tonalElevation = 0.dp
-                ) {
-                    Row(
-                        modifier = Modifier.fillMaxSize(),
-                        verticalAlignment = Alignment.CenterVertically,
-                        horizontalArrangement = Arrangement.Center
-                    ) {
-                        Icon(
-                            imageVector = Icons.Default.OpenInNew,
-                            contentDescription = null,
-                            modifier = Modifier.size(18.dp)
-                        )
-                        Spacer(Modifier.width(8.dp))
-                        Text(
-                            text = context.getString(R.string.launch_anland_window),
-                            style = MaterialTheme.typography.labelLarge,
-                            fontWeight = FontWeight.Bold
-                        )
                     }
                 }
             }

--- a/Android/app/src/main/java/com/droidspaces/app/ui/screen/ContainerDetailsScreen.kt
+++ b/Android/app/src/main/java/com/droidspaces/app/ui/screen/ContainerDetailsScreen.kt
@@ -28,6 +28,7 @@ import com.droidspaces.app.util.ContainerProcdManager
 import com.droidspaces.app.util.ContainerOpenRCManager
 import com.droidspaces.app.util.ContainerDiskUsageManager
 import com.droidspaces.app.util.ContainerManager
+import com.droidspaces.app.util.AnlandUtils
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import kotlinx.coroutines.delay
@@ -72,6 +73,14 @@ fun ContainerDetailsScreen(
     // Uses persistent cache that survives app restarts
     var osInfo by remember {
         mutableStateOf(ContainerOSInfoManager.getCachedOSInfo(container.name, context))
+    }
+
+    // anland display socket (recorded by the native runtime in Pids/<name>.anland);
+    // presence gates the "Launch Anland Window" action in the terminal card.
+    var anlandSocket by remember { mutableStateOf<String?>(null) }
+    LaunchedEffect(container.name, container.enableAnland, refreshTrigger) {
+        anlandSocket = if (container.enableAnland)
+            ContainerManager.getAnlandSocket(container.name) else null
     }
 
     // Init system state - detect systemd first, then OpenWrt/procd, then OpenRC
@@ -255,7 +264,11 @@ fun ContainerDetailsScreen(
             item(key = "terminal_${container.name}") {
                 TerminalCard(
                     containerName = container.name,
-                    onOpenTerminal = onNavigateToTerminal
+                    onOpenTerminal = onNavigateToTerminal,
+                    anlandEnabled = container.enableAnland && anlandSocket != null,
+                    onLaunchAnland = {
+                        anlandSocket?.let { AnlandUtils.launchWindow(context, container.name, it) }
+                    }
                 )
             }
 
@@ -373,6 +386,8 @@ private fun IdentityToken(
 private fun TerminalCard(
     containerName: String,
     onOpenTerminal: () -> Unit,
+    anlandEnabled: Boolean = false,
+    onLaunchAnland: () -> Unit = {},
     modifier: Modifier = Modifier,
 ) {
     val context = LocalContext.current
@@ -402,10 +417,12 @@ private fun TerminalCard(
         color = MaterialTheme.colorScheme.surfaceContainerHigh,
         border = androidx.compose.foundation.BorderStroke(1.dp, MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.5f))
     ) {
+      Column(
+          modifier = Modifier.fillMaxWidth().padding(20.dp),
+          verticalArrangement = Arrangement.spacedBy(14.dp)
+      ) {
         Row(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(20.dp),
+            modifier = Modifier.fillMaxWidth(),
             horizontalArrangement = Arrangement.SpaceBetween,
             verticalAlignment = Alignment.CenterVertically
         ) {
@@ -461,6 +478,31 @@ private fun TerminalCard(
                 )
             }
         }
+
+        // Launch the anland desktop window, shown only when this container has
+        // the anland display daemon enabled and a live socket recorded.
+        if (anlandEnabled) {
+            Button(
+                onClick = onLaunchAnland,
+                modifier = Modifier.fillMaxWidth(),
+                colors = ButtonDefaults.buttonColors(
+                    containerColor = MaterialTheme.colorScheme.secondaryContainer,
+                    contentColor = MaterialTheme.colorScheme.onSecondaryContainer
+                )
+            ) {
+                Icon(
+                    Icons.Default.DesktopWindows,
+                    contentDescription = null,
+                    modifier = Modifier.size(16.dp)
+                )
+                Spacer(Modifier.width(6.dp))
+                Text(
+                    context.getString(R.string.launch_anland_window),
+                    fontWeight = FontWeight.SemiBold
+                )
+            }
+        }
+      }
     }
 }
 

--- a/Android/app/src/main/java/com/droidspaces/app/ui/screen/ControlPanelScreen.kt
+++ b/Android/app/src/main/java/com/droidspaces/app/ui/screen/ControlPanelScreen.kt
@@ -23,6 +23,12 @@ import com.droidspaces.app.ui.component.PullToRefreshWrapper
 import com.droidspaces.app.ui.component.RunningContainerCard
 import com.droidspaces.app.ui.viewmodel.ContainerViewModel
 import com.droidspaces.app.ui.viewmodel.SystemStatsViewModel
+import com.droidspaces.app.util.ContainerManager
+import android.content.ActivityNotFoundException
+import android.content.ComponentName
+import android.content.Context
+import android.content.Intent
+import android.widget.Toast
 import androidx.compose.ui.platform.LocalContext
 import com.droidspaces.app.R
 
@@ -64,6 +70,17 @@ fun ControlPanelScreen(
 
     val containerUsageMap = systemStatsViewModel.containerUsageMap
 
+    // Per-container anland display socket (recorded by the native runtime in
+    // Pids/<name>.anland). Refreshed whenever the running-container set changes;
+    // presence gates the "Launch Anland Window" button.
+    val anlandSockets = remember { mutableStateMapOf<String, String>() }
+    LaunchedEffect(runningContainers) {
+        anlandSockets.clear()
+        runningContainers.filter { it.enableAnland }.forEach { c ->
+            ContainerManager.getAnlandSocket(c.name)?.let { anlandSockets[c.name] = it }
+        }
+    }
+
     Box(modifier = Modifier.fillMaxSize()) {
         // Show content based on root and backend availability
         // Using when instead of early return to prevent UI glitches during recomposition
@@ -94,6 +111,7 @@ fun ControlPanelScreen(
                         verticalArrangement = Arrangement.spacedBy(16.dp)
                     ) {
                         runningContainers.forEach { container ->
+                            val anlandSock = anlandSockets[container.name]
                             RunningContainerCard(
                                 container = container,
                                 onEnter = {
@@ -101,6 +119,10 @@ fun ControlPanelScreen(
                                 },
                                 onTerminalClick = {
                                     onNavigateToTerminal(container.name)
+                                },
+                                anlandEnabled = container.enableAnland && anlandSock != null,
+                                onLaunchAnland = {
+                                    anlandSock?.let { launchAnland(context, container.name, it) }
                                 },
                                 osInfo = containerUsageMap[container.name],
                             )
@@ -115,6 +137,33 @@ fun ControlPanelScreen(
             hostState = snackbarHostState,
             modifier = Modifier.align(Alignment.BottomCenter)
         )
+    }
+}
+
+/**
+ * Launch the anland consumer app's multi-window activity, pointed at this
+ * container's display socket and titled with the container name. Uses
+ * SecondaryActivity (the consumer's parametrized entry, which dedups by socket
+ * path). No-op with a toast if the consumer app isn't installed.
+ */
+private fun launchAnland(context: Context, containerName: String, socketPath: String) {
+    val intent = Intent(Intent.ACTION_MAIN).apply {
+        component = ComponentName(
+            "com.anland.consumer",
+            "com.anland.consumer.SecondaryActivity"
+        )
+        putExtra("socket_path", socketPath)
+        putExtra("window_name", containerName)
+        addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_MULTIPLE_TASK)
+    }
+    try {
+        context.startActivity(intent)
+    } catch (e: ActivityNotFoundException) {
+        Toast.makeText(
+            context,
+            context.getString(R.string.anland_not_installed),
+            Toast.LENGTH_SHORT
+        ).show()
     }
 }
 

--- a/Android/app/src/main/java/com/droidspaces/app/ui/screen/ControlPanelScreen.kt
+++ b/Android/app/src/main/java/com/droidspaces/app/ui/screen/ControlPanelScreen.kt
@@ -23,12 +23,8 @@ import com.droidspaces.app.ui.component.PullToRefreshWrapper
 import com.droidspaces.app.ui.component.RunningContainerCard
 import com.droidspaces.app.ui.viewmodel.ContainerViewModel
 import com.droidspaces.app.ui.viewmodel.SystemStatsViewModel
+import com.droidspaces.app.util.AnlandUtils
 import com.droidspaces.app.util.ContainerManager
-import android.content.ActivityNotFoundException
-import android.content.ComponentName
-import android.content.Context
-import android.content.Intent
-import android.widget.Toast
 import androidx.compose.ui.platform.LocalContext
 import com.droidspaces.app.R
 
@@ -122,7 +118,7 @@ fun ControlPanelScreen(
                                 },
                                 anlandEnabled = container.enableAnland && anlandSock != null,
                                 onLaunchAnland = {
-                                    anlandSock?.let { launchAnland(context, container.name, it) }
+                                    anlandSock?.let { AnlandUtils.launchWindow(context, container.name, it) }
                                 },
                                 osInfo = containerUsageMap[container.name],
                             )
@@ -137,33 +133,6 @@ fun ControlPanelScreen(
             hostState = snackbarHostState,
             modifier = Modifier.align(Alignment.BottomCenter)
         )
-    }
-}
-
-/**
- * Launch the anland consumer app's multi-window activity, pointed at this
- * container's display socket and titled with the container name. Uses
- * SecondaryActivity (the consumer's parametrized entry, which dedups by socket
- * path). No-op with a toast if the consumer app isn't installed.
- */
-private fun launchAnland(context: Context, containerName: String, socketPath: String) {
-    val intent = Intent(Intent.ACTION_MAIN).apply {
-        component = ComponentName(
-            "com.anland.consumer",
-            "com.anland.consumer.SecondaryActivity"
-        )
-        putExtra("socket_path", socketPath)
-        putExtra("window_name", containerName)
-        addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_MULTIPLE_TASK)
-    }
-    try {
-        context.startActivity(intent)
-    } catch (e: ActivityNotFoundException) {
-        Toast.makeText(
-            context,
-            context.getString(R.string.anland_not_installed),
-            Toast.LENGTH_SHORT
-        ).show()
     }
 }
 

--- a/Android/app/src/main/java/com/droidspaces/app/ui/screen/EditContainerScreen.kt
+++ b/Android/app/src/main/java/com/droidspaces/app/ui/screen/EditContainerScreen.kt
@@ -106,6 +106,7 @@ fun EditContainerScreen(
     var bindMounts by remember { mutableStateOf(container.bindMounts) }
     var dnsServers by remember { mutableStateOf(container.dnsServers) }
     var runAtBoot by remember { mutableStateOf(container.runAtBoot) }
+    var enableAnland by remember { mutableStateOf(container.enableAnland) }
     var envFileContent by remember { mutableStateOf(container.envFileContent ?: "") }
     var upstreamInterfaces by remember { mutableStateOf(container.upstreamInterfaces) }
     var portForwards by remember { mutableStateOf(container.portForwards) }
@@ -146,6 +147,7 @@ fun EditContainerScreen(
     var savedBindMounts by remember { mutableStateOf(container.bindMounts) }
     var savedDnsServers by remember { mutableStateOf(container.dnsServers) }
     var savedRunAtBoot by remember { mutableStateOf(container.runAtBoot) }
+    var savedEnableAnland by remember { mutableStateOf(container.enableAnland) }
     var savedEnvFileContent by remember { mutableStateOf(container.envFileContent ?: "") }
     var savedUpstreamInterfaces by remember { mutableStateOf(container.upstreamInterfaces) }
     var savedPortForwards by remember { mutableStateOf(container.portForwards) }
@@ -188,6 +190,7 @@ fun EditContainerScreen(
             bindMounts != savedBindMounts ||
             dnsServers != savedDnsServers ||
             runAtBoot != savedRunAtBoot ||
+            enableAnland != savedEnableAnland ||
             envFileContent != savedEnvFileContent ||
             upstreamInterfaces != savedUpstreamInterfaces ||
             portForwards != savedPortForwards ||
@@ -236,6 +239,7 @@ fun EditContainerScreen(
                     bindMounts = bindMounts,
                     dnsServers = dnsServers,
                     runAtBoot = runAtBoot,
+                    enableAnland = enableAnland,
                     envFileContent = if (envFileContent.isBlank()) null else envFileContent,
                     upstreamInterfaces = upstreamInterfaces,
                     portForwards = portForwards,
@@ -275,6 +279,7 @@ fun EditContainerScreen(
                         savedBindMounts = bindMounts
                         savedDnsServers = dnsServers
                         savedRunAtBoot = runAtBoot
+                        savedEnableAnland = enableAnland
                         savedEnvFileContent = envFileContent
                         savedUpstreamInterfaces = upstreamInterfaces
                         savedPortForwards = portForwards
@@ -1020,6 +1025,17 @@ fun EditContainerScreen(
                 onCheckedChange = {
                     clearFocus()
                     runAtBoot = it
+                }
+            )
+
+            ToggleCard(
+                icon = Icons.Default.DesktopWindows,
+                title = context.getString(R.string.enable_anland),
+                description = context.getString(R.string.enable_anland_description),
+                checked = enableAnland,
+                onCheckedChange = {
+                    clearFocus()
+                    enableAnland = it
                 }
             )
 

--- a/Android/app/src/main/java/com/droidspaces/app/ui/screen/EditContainerScreen.kt
+++ b/Android/app/src/main/java/com/droidspaces/app/ui/screen/EditContainerScreen.kt
@@ -926,6 +926,18 @@ fun EditContainerScreen(
             )
 
             ToggleCard(
+                icon = Icons.Default.DesktopWindows,
+                title = context.getString(R.string.enable_anland),
+                description = context.getString(R.string.enable_anland_description),
+                checked = enableAnland,
+                onCheckedChange = {
+                    clearFocus()
+                    enableAnland = it
+                },
+                enabled = true
+            )
+
+            ToggleCard(
                 icon = Icons.Default.Layers,
                 title = context.getString(R.string.enable_virgl),
                 description = context.getString(R.string.enable_virgl_description),
@@ -1025,17 +1037,6 @@ fun EditContainerScreen(
                 onCheckedChange = {
                     clearFocus()
                     runAtBoot = it
-                }
-            )
-
-            ToggleCard(
-                icon = Icons.Default.DesktopWindows,
-                title = context.getString(R.string.enable_anland),
-                description = context.getString(R.string.enable_anland_description),
-                checked = enableAnland,
-                onCheckedChange = {
-                    clearFocus()
-                    enableAnland = it
                 }
             )
 

--- a/Android/app/src/main/java/com/droidspaces/app/util/AnlandUtils.kt
+++ b/Android/app/src/main/java/com/droidspaces/app/util/AnlandUtils.kt
@@ -1,0 +1,44 @@
+package com.droidspaces.app.util
+
+import android.content.ActivityNotFoundException
+import android.content.ComponentName
+import android.content.Context
+import android.content.Intent
+import android.widget.Toast
+import com.droidspaces.app.R
+
+/**
+ * Helpers for the anland display integration on the app side.
+ */
+object AnlandUtils {
+
+    private const val CONSUMER_PACKAGE = "com.anland.consumer"
+    private const val CONSUMER_ACTIVITY = "com.anland.consumer.SecondaryActivity"
+    // Matches MainActivity.EXTRA_SOCKET_PATH / EXTRA_WINDOW_NAME in the consumer app.
+    private const val EXTRA_SOCKET_PATH = "socket_path"
+    private const val EXTRA_WINDOW_NAME = "window_name"
+
+    /**
+     * Launch the anland consumer app's multi-window activity, pointed at this
+     * container's display socket and titled with the container name. The consumer
+     * dedups by socket path, so re-launching focuses the existing window. Shows a
+     * toast and does nothing if the consumer app isn't installed.
+     */
+    fun launchWindow(context: Context, containerName: String, socketPath: String) {
+        val intent = Intent(Intent.ACTION_MAIN).apply {
+            component = ComponentName(CONSUMER_PACKAGE, CONSUMER_ACTIVITY)
+            putExtra(EXTRA_SOCKET_PATH, socketPath)
+            putExtra(EXTRA_WINDOW_NAME, containerName)
+            addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_MULTIPLE_TASK)
+        }
+        try {
+            context.startActivity(intent)
+        } catch (e: ActivityNotFoundException) {
+            Toast.makeText(
+                context,
+                context.getString(R.string.anland_not_installed),
+                Toast.LENGTH_SHORT
+            ).show()
+        }
+    }
+}

--- a/Android/app/src/main/java/com/droidspaces/app/util/Constants.kt
+++ b/Android/app/src/main/java/com/droidspaces/app/util/Constants.kt
@@ -15,6 +15,7 @@ object Constants {
 
     // Container paths
     const val CONTAINERS_BASE_PATH = "/data/local/Droidspaces/Containers"
+    const val PIDS_BASE_PATH = "/data/local/Droidspaces/Pids"
     const val MODULE_SYSTEM_BIN_PATH = "$MAGISK_MODULE_PATH/system/bin"
     const val SYSTEM_BIN_SYMLINK_PATH = "$MODULE_SYSTEM_BIN_PATH/$DROIDSPACES_BINARY_NAME"
     const val KEY_SYMLINK_ENABLED = "symlink_enabled"

--- a/Android/app/src/main/java/com/droidspaces/app/util/ContainerManager.kt
+++ b/Android/app/src/main/java/com/droidspaces/app/util/ContainerManager.kt
@@ -45,6 +45,7 @@ data class ContainerInfo(
     val dnsServers: String = "",
     val runAtBoot: Boolean = false,
     val runAtBootPriority: Int = 0,
+    val enableAnland: Boolean = false,
     val status: ContainerStatus = ContainerStatus.STOPPED,
     val pid: Int? = null,
     val useSparseImage: Boolean = false,
@@ -104,6 +105,7 @@ data class ContainerInfo(
         if (runAtBoot && runAtBootPriority > 0) {
             appendLine("run_at_boot_priority=$runAtBootPriority")
         }
+        appendLine("enable_anland=${if (enableAnland) "1" else "0"}")
         appendLine("force_cgroupv1=${if (forceCgroupv1) "1" else "0"}")
         appendLine("block_nested_ns=${if (blockNestedNs) "1" else "0"}")
         if (netMode == "nat" && staticNatIp.isNotEmpty()) {
@@ -326,6 +328,7 @@ object ContainerManager {
                 dnsServers = configMap["dns_servers"] ?: "",
                 runAtBoot = configMap["run_at_boot"] == "1",
                 runAtBootPriority = configMap["run_at_boot_priority"]?.toIntOrNull() ?: 0,
+                enableAnland = configMap["enable_anland"] == "1",
                 status = ContainerStatus.STOPPED,
                 useSparseImage = useSparseImage,
                 sparseImageSizeGB = sparseImageSizeGB,
@@ -391,6 +394,24 @@ object ContainerManager {
         }
 
         Pair(false, null)
+    }
+
+    /**
+     * Return the anland display-daemon socket path for a running container, or
+     * null if it isn't running / anland isn't active. The native runtime records
+     * the generated per-container socket path in Pids/<name>.anland at start and
+     * removes it on stop, so the presence of a non-empty path also signals that
+     * the anland window can be launched.
+     */
+    suspend fun getAnlandSocket(containerName: String): String? = withContext(Dispatchers.IO) {
+        try {
+            val path = "${Constants.PIDS_BASE_PATH}/$containerName.anland"
+            val result = Shell.cmd("cat \"$path\" 2>/dev/null").exec()
+            val sock = result.out.firstOrNull()?.trim()
+            if (result.isSuccess && !sock.isNullOrEmpty()) sock else null
+        } catch (e: Exception) {
+            null
+        }
     }
 
     /**

--- a/Android/app/src/main/res/values/strings.xml
+++ b/Android/app/src/main/res/values/strings.xml
@@ -205,6 +205,10 @@
     <string name="selinux_permissive_description">Set SELinux permissive</string>
     <string name="run_at_boot">Run at Boot</string>
     <string name="run_at_boot_description">Start container on boot</string>
+    <string name="enable_anland">Anland Display</string>
+    <string name="enable_anland_description">Run the anland display daemon so you can open a desktop window</string>
+    <string name="launch_anland_window">启动 Anland 窗口</string>
+    <string name="anland_not_installed">Anland consumer app is not installed</string>
     <string name="auto_boot_priority">Auto Boot Priority</string>
     <string name="auto_boot_priority_description">Order in which run-at-boot containers start</string>
     <string name="auto_boot_priority_hint">Drag to reorder. Containers start top to bottom - put a gateway (e.g. OpenWRT) first so it boots before the containers that route through it.</string>

--- a/Android/app/src/main/res/values/strings.xml
+++ b/Android/app/src/main/res/values/strings.xml
@@ -207,7 +207,7 @@
     <string name="run_at_boot_description">Start container on boot</string>
     <string name="enable_anland">Anland Display</string>
     <string name="enable_anland_description">Run the anland display daemon so you can open a desktop window</string>
-    <string name="launch_anland_window">启动 Anland 窗口</string>
+    <string name="launch_anland_window">Launch Anland</string>
     <string name="anland_not_installed">Anland consumer app is not installed</string>
     <string name="auto_boot_priority">Auto Boot Priority</string>
     <string name="auto_boot_priority_description">Order in which run-at-boot containers start</string>

--- a/Makefile
+++ b/Makefile
@@ -60,6 +60,9 @@ SRCS = $(SRC_DIR)/main.c \
        $(SRC_DIR)/android/x11.c \
        $(SRC_DIR)/android/virgl.c \
        $(SRC_DIR)/android/pulseaudio.c \
+       $(SRC_DIR)/anland/anland.c \
+       $(SRC_DIR)/anland/display_daemon.c \
+       $(SRC_DIR)/anland/socket_utils.c \
        $(SRC_DIR)/virtualize.c
 
 # Compiler flags - hardened warning set, all warnings are errors
@@ -141,6 +144,16 @@ $(OBJ_DIR)/%.o: $(SRC_DIR)/%.c | $(OBJ_DIR)
 	$(msg_cc)
 	$(Q)mkdir -p $(dir $@)
 	$(Q)$(CC) $(CFLAGS) -c $< -o $@
+
+# The anland module vendors the upstream display daemon (written to C11 with
+# unnamed unions / const-casts) plus our integration glue. Relax the pedantic
+# and a few hardened warnings that only apply to first-party code; keep -Werror
+# and the rest. More-specific stem, so this wins over the generic rule above.
+ANLAND_CFLAGS = $(filter-out -Wpedantic -Wcast-qual -Wnull-dereference,$(CFLAGS)) -Wno-format-truncation
+$(OBJ_DIR)/anland/%.o: $(SRC_DIR)/anland/%.c | $(OBJ_DIR)
+	$(msg_cc)
+	$(Q)mkdir -p $(dir $@)
+	$(Q)$(CC) $(ANLAND_CFLAGS) -c $< -o $@
 
 # Link step
 $(BINARY_NAME): $(OBJS) | $(OUT_DIR)

--- a/src/anland/anland.c
+++ b/src/anland/anland.c
@@ -1,0 +1,211 @@
+/*
+ * Droidspaces - anland display daemon integration
+ *
+ * Embeds the anland broker daemon (libdisplay_daemon, vendored alongside this
+ * file) into the container lifecycle. For a container with anland enabled we:
+ *   - generate a per-container host socket path under <workspace>/anland,
+ *   - fork a persistent process that runs the daemon's epoll loop on it,
+ *   - record the pid and the socket path in the Pids dir so the app can find
+ *     and stop it, and
+ *   - bind-mount the socket onto the container's /run/display.sock (post-pivot).
+ *
+ * The Android consumer app connects to the same socket (via its root fd-helper)
+ * and a patched KWin ("producer") inside the container connects to
+ * /run/display.sock; the daemon just brokers their handshake.
+ *
+ * Modeled on src/android/x11.c. Unlike X11 (a single global server) each
+ * container gets its own daemon, so the pid / socket-path files are keyed by
+ * container name.
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+#define _GNU_SOURCE
+#include "droidspace.h"
+
+#include <fcntl.h>
+#include <signal.h>
+#include <stdio.h>
+#include <string.h>
+#include <unistd.h>
+
+#include "display_daemon.h"
+
+/* Per-container Pids-dir filenames (keyed by container name). */
+static void anland_pid_file(const struct ds_config *cfg, char *buf, size_t n) {
+  snprintf(buf, n, "%s.anland.pid", cfg->container_name);
+}
+static void anland_sock_file(const struct ds_config *cfg, char *buf, size_t n) {
+  snprintf(buf, n, "%s.anland", cfg->container_name);
+}
+
+/* anland is per-container, so a daemon is never shared between containers:
+ * ds_global_daemon_stop's "keep alive for others" check is always false. */
+static int anland_never_needed(void) { return 0; }
+
+/* ---- daemon child ----------------------------------------------------- */
+
+/*
+ * The forked daemon process. Runs the vendored libdisplay_daemon epoll loop
+ * in-process (the library is linked into this binary, so no execv is needed).
+ * Never returns: always _exit()s.
+ */
+static void anland_daemon_child(int out_fd, const char *sock_path) {
+  /* Detach from the launcher's session and make the daemon robust/persistent
+   * (SIGTERM is left default so ds_global_daemon_stop can kill it). */
+  setsid();
+  signal(SIGHUP, SIG_IGN);
+  signal(SIGINT, SIG_IGN);
+  signal(SIGQUIT, SIG_IGN);
+  signal(SIGPIPE, SIG_IGN);
+  ds_oom_protect();
+
+  /* stdout/stderr -> log pipe, stdin -> /dev/null */
+  int devnull = open("/dev/null", O_RDONLY);
+  if (devnull >= 0) {
+    dup2(devnull, STDIN_FILENO);
+    close(devnull);
+  }
+  dup2(out_fd, STDOUT_FILENO);
+  dup2(out_fd, STDERR_FILENO);
+  close(out_fd);
+
+  daemon_ctx *ctx = NULL;
+  if (daemon_create(&ctx, sock_path) < 0) {
+    fprintf(stderr, "failed to bind %s\n", sock_path);
+    _exit(1);
+  }
+  daemon_run(ctx);      /* blocks until SIGTERM-triggered exit via the loop flag */
+  daemon_destroy(ctx);  /* closes clients, unlinks the socket */
+  _exit(0);
+}
+
+/* Fork the daemon child and a log-relay grandchild (Logs/anland.log).
+ * Returns the daemon PID, or -1 on error. */
+static pid_t spawn_anland_daemon(const char *sock_path) {
+  int pipefd[2];
+  if (pipe(pipefd) < 0) {
+    ds_warn("[anland] pipe: %s", strerror(errno));
+    return -1;
+  }
+
+  pid_t child = fork();
+  if (child < 0) {
+    ds_warn("[anland] fork: %s", strerror(errno));
+    close(pipefd[0]);
+    close(pipefd[1]);
+    return -1;
+  }
+  if (child == 0) {
+    close(pipefd[0]);
+    anland_daemon_child(pipefd[1], sock_path); /* never returns */
+    _exit(1);
+  }
+
+  /* Parent: hand the read end to a log relay; the daemon child holds the only
+   * write end, so the relay sees EOF when the daemon exits. */
+  close(pipefd[1]);
+  ds_spawn_log_relay(pipefd[0], "anland.log", "anland");
+  return child;
+}
+
+/* ---- public API ------------------------------------------------------- */
+
+int ds_anland_daemon_start(struct ds_config *cfg) {
+  if (!cfg || !cfg->anland || !is_android())
+    return -1;
+  if (getuid() != 0) {
+    ds_error("[anland] not running as root");
+    return -1;
+  }
+
+  char pidfile[NAME_MAX + 16], sockfile[NAME_MAX + 16];
+  anland_pid_file(cfg, pidfile, sizeof(pidfile));
+  anland_sock_file(cfg, sockfile, sizeof(sockfile));
+
+  /* Reuse an existing live daemon (ds_daemon_read_pid verifies liveness). */
+  pid_t existing = ds_daemon_read_pid(pidfile);
+  if (existing > 0) {
+    cfg->anland_pid = existing;
+    char rec[PATH_MAX];
+    snprintf(rec, sizeof(rec), "%s/%s", get_pids_dir(), sockfile);
+    int fd = open(rec, O_RDONLY | O_CLOEXEC);
+    if (fd >= 0) {
+      ssize_t r = read(fd, cfg->anland_sock, sizeof(cfg->anland_sock) - 1);
+      close(fd);
+      if (r > 0) {
+        cfg->anland_sock[r] = '\0';
+        cfg->anland_sock[strcspn(cfg->anland_sock, "\r\n")] = '\0';
+      }
+    }
+    ds_log("[anland] daemon already running (PID %d)", (int)existing);
+    return 1;
+  }
+
+  /* Socket dir + generated per-container socket path. */
+  char dir[PATH_MAX];
+  snprintf(dir, sizeof(dir), "%s/anland", get_workspace_dir());
+  mkdir_p(dir, 0771);
+
+  char uuid[DS_UUID_LEN + 1];
+  if (generate_uuid(uuid, sizeof(uuid)) < 0) {
+    ds_error("[anland] failed to generate socket name");
+    return -1;
+  }
+  snprintf(cfg->anland_sock, sizeof(cfg->anland_sock), "%s/%s.sock", dir, uuid);
+
+  ds_log("[anland] launching display daemon on %s", cfg->anland_sock);
+  pid_t child = spawn_anland_daemon(cfg->anland_sock);
+  if (child <= 0)
+    return -1;
+
+  cfg->anland_pid = child;
+  ds_daemon_write_pid(pidfile, child);
+
+  /* Record the socket path so the app (and a later restart) can find it. */
+  char rec[PATH_MAX];
+  snprintf(rec, sizeof(rec), "%s/%s", get_pids_dir(), sockfile);
+  write_file_atomic(rec, cfg->anland_sock);
+
+  /* Give the daemon a moment to bind before we bind-mount the socket. */
+  wait_for_socket_or_death(child, cfg->anland_sock, 2000, 20000);
+  return 0;
+}
+
+void ds_anland_daemon_stop(struct ds_config *cfg) {
+  if (!cfg)
+    return;
+  char pidfile[NAME_MAX + 16], sockfile[NAME_MAX + 16];
+  anland_pid_file(cfg, pidfile, sizeof(pidfile));
+  anland_sock_file(cfg, sockfile, sizeof(sockfile));
+
+  ds_global_daemon_stop(anland_never_needed, cfg->anland_pid, &cfg->anland_pid,
+                        pidfile, cfg->anland_sock, "[anland]");
+  ds_daemon_remove_pid(sockfile);
+}
+
+/* ---- socket bridge ---------------------------------------------------- */
+
+int ds_setup_anland_socket(struct ds_config *cfg) {
+  if (!cfg || !cfg->anland || !is_android())
+    return 0;
+  if (cfg->anland_sock[0] == '\0') {
+    ds_warn("[anland] no daemon socket recorded - skipping bind mount");
+    return 0;
+  }
+
+  /* Post-pivot: the host socket is reachable under /.old_root. */
+  char src[PATH_MAX];
+  snprintf(src, sizeof(src), "/.old_root%s", cfg->anland_sock);
+  if (access(src, F_OK) != 0) {
+    ds_warn("[anland] host socket not found at %s - skipping bind mount", src);
+    return 0;
+  }
+
+  mkdir_p("/run", 0755);
+  if (ds_bind_mount_socket(src, "/run/display.sock", 0, "anland") < 0)
+    return 0;
+
+  ds_log("[anland] display socket bind-mounted to /run/display.sock");
+  return 0;
+}

--- a/src/anland/anland.c
+++ b/src/anland/anland.c
@@ -33,11 +33,12 @@
 
 #include <sys/stat.h>
 
-/* Host directory for the per-container display sockets. Deliberately under
- * /data/local/tmp (world-traversable, same tree the consumer app already uses
- * for its default socket) so the consumer can reach the socket without hitting
- * the permission problems of a workspace-private path. */
-#define ANLAND_SOCK_DIR "/data/local/tmp/anland"
+/* Host directory for the per-container display sockets: /data/local/tmp, which
+ * always exists and is the same directory the consumer app already uses for its
+ * default socket, so the consumer can reach it without the permission problems
+ * of a workspace-private path. The socket files are named anland-<uuid>.sock
+ * directly in this dir (no subdirectory to create). */
+#define ANLAND_SOCK_DIR "/data/local/tmp"
 
 /* Per-container Pids-dir filenames (keyed by container name). */
 static void anland_pid_file(const struct ds_config *cfg, char *buf, size_t n) {
@@ -150,18 +151,14 @@ int ds_anland_daemon_start(struct ds_config *cfg) {
     return 1;
   }
 
-  /* Socket dir + generated per-container socket path. World-traversable dir so
-   * the consumer app can reach the socket. */
-  mkdir_p(ANLAND_SOCK_DIR, 0777);
-  chmod(ANLAND_SOCK_DIR, 0777);
-
+  /* Generated per-container socket path, directly in /data/local/tmp. */
   char uuid[DS_UUID_LEN + 1];
   if (generate_uuid(uuid, sizeof(uuid)) < 0) {
     ds_error("[anland] failed to generate socket name");
     return -1;
   }
   snprintf(cfg->anland_sock, sizeof(cfg->anland_sock),
-           ANLAND_SOCK_DIR "/%s.sock", uuid);
+           ANLAND_SOCK_DIR "/anland-%s.sock", uuid);
 
   ds_log("[anland] launching display daemon on %s", cfg->anland_sock);
   pid_t child = spawn_anland_daemon(cfg->anland_sock);

--- a/src/anland/anland.c
+++ b/src/anland/anland.c
@@ -118,6 +118,25 @@ static pid_t spawn_anland_daemon(const char *sock_path) {
   return child;
 }
 
+/* Load the recorded per-container socket path (Pids/<name>.anland) into
+ * cfg->anland_sock. No-op when the file is missing/empty. Needed because the
+ * socket path is runtime-only (not persisted to container.config), so a cfg
+ * loaded from disk at stop time has an empty anland_sock. */
+static void anland_load_sock(struct ds_config *cfg) {
+  char sockfile[NAME_MAX + 16], rec[PATH_MAX];
+  anland_sock_file(cfg, sockfile, sizeof(sockfile));
+  snprintf(rec, sizeof(rec), "%s/%s", get_pids_dir(), sockfile);
+  int fd = open(rec, O_RDONLY | O_CLOEXEC);
+  if (fd < 0)
+    return;
+  ssize_t r = read(fd, cfg->anland_sock, sizeof(cfg->anland_sock) - 1);
+  close(fd);
+  if (r > 0) {
+    cfg->anland_sock[r] = '\0';
+    cfg->anland_sock[strcspn(cfg->anland_sock, "\r\n")] = '\0';
+  }
+}
+
 /* ---- public API ------------------------------------------------------- */
 
 int ds_anland_daemon_start(struct ds_config *cfg) {
@@ -136,17 +155,7 @@ int ds_anland_daemon_start(struct ds_config *cfg) {
   pid_t existing = ds_daemon_read_pid(pidfile);
   if (existing > 0) {
     cfg->anland_pid = existing;
-    char rec[PATH_MAX];
-    snprintf(rec, sizeof(rec), "%s/%s", get_pids_dir(), sockfile);
-    int fd = open(rec, O_RDONLY | O_CLOEXEC);
-    if (fd >= 0) {
-      ssize_t r = read(fd, cfg->anland_sock, sizeof(cfg->anland_sock) - 1);
-      close(fd);
-      if (r > 0) {
-        cfg->anland_sock[r] = '\0';
-        cfg->anland_sock[strcspn(cfg->anland_sock, "\r\n")] = '\0';
-      }
-    }
+    anland_load_sock(cfg);
     ds_log("[anland] daemon already running (PID %d)", (int)existing);
     return 1;
   }
@@ -187,8 +196,14 @@ void ds_anland_daemon_stop(struct ds_config *cfg) {
   anland_pid_file(cfg, pidfile, sizeof(pidfile));
   anland_sock_file(cfg, sockfile, sizeof(sockfile));
 
+  /* Recover the socket path from the Pids file if this cfg was loaded from disk
+   * (anland_sock is runtime-only), so ds_global_daemon_stop can unlink it. */
+  if (cfg->anland_sock[0] == '\0')
+    anland_load_sock(cfg);
+
   ds_global_daemon_stop(anland_never_needed, cfg->anland_pid, &cfg->anland_pid,
-                        pidfile, cfg->anland_sock, "[anland]");
+                        pidfile, cfg->anland_sock[0] ? cfg->anland_sock : NULL,
+                        "[anland]");
   ds_daemon_remove_pid(sockfile);
 }
 

--- a/src/anland/anland.c
+++ b/src/anland/anland.c
@@ -31,6 +31,14 @@
 
 #include "display_daemon.h"
 
+#include <sys/stat.h>
+
+/* Host directory for the per-container display sockets. Deliberately under
+ * /data/local/tmp (world-traversable, same tree the consumer app already uses
+ * for its default socket) so the consumer can reach the socket without hitting
+ * the permission problems of a workspace-private path. */
+#define ANLAND_SOCK_DIR "/data/local/tmp/anland"
+
 /* Per-container Pids-dir filenames (keyed by container name). */
 static void anland_pid_file(const struct ds_config *cfg, char *buf, size_t n) {
   snprintf(buf, n, "%s.anland.pid", cfg->container_name);
@@ -142,17 +150,18 @@ int ds_anland_daemon_start(struct ds_config *cfg) {
     return 1;
   }
 
-  /* Socket dir + generated per-container socket path. */
-  char dir[PATH_MAX];
-  snprintf(dir, sizeof(dir), "%s/anland", get_workspace_dir());
-  mkdir_p(dir, 0771);
+  /* Socket dir + generated per-container socket path. World-traversable dir so
+   * the consumer app can reach the socket. */
+  mkdir_p(ANLAND_SOCK_DIR, 0777);
+  chmod(ANLAND_SOCK_DIR, 0777);
 
   char uuid[DS_UUID_LEN + 1];
   if (generate_uuid(uuid, sizeof(uuid)) < 0) {
     ds_error("[anland] failed to generate socket name");
     return -1;
   }
-  snprintf(cfg->anland_sock, sizeof(cfg->anland_sock), "%s/%s.sock", dir, uuid);
+  snprintf(cfg->anland_sock, sizeof(cfg->anland_sock),
+           ANLAND_SOCK_DIR "/%s.sock", uuid);
 
   ds_log("[anland] launching display daemon on %s", cfg->anland_sock);
   pid_t child = spawn_anland_daemon(cfg->anland_sock);
@@ -167,8 +176,10 @@ int ds_anland_daemon_start(struct ds_config *cfg) {
   snprintf(rec, sizeof(rec), "%s/%s", get_pids_dir(), sockfile);
   write_file_atomic(rec, cfg->anland_sock);
 
-  /* Give the daemon a moment to bind before we bind-mount the socket. */
+  /* Give the daemon a moment to bind, then loosen the socket perms so the
+   * consumer app can connect to it. */
   wait_for_socket_or_death(child, cfg->anland_sock, 2000, 20000);
+  chmod(cfg->anland_sock, 0666);
   return 0;
 }
 

--- a/src/anland/display_daemon.c
+++ b/src/anland/display_daemon.c
@@ -1,0 +1,351 @@
+#include <errno.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/epoll.h>
+#include <sys/socket.h>
+#include <sys/un.h>
+#include <unistd.h>
+
+#include "display_daemon.h"
+#include "protocol.h"
+#include "socket_utils.h"
+
+#define MAX_EVENTS 16
+/* Hello fd set: { buf_ready, fence, data, shm, audio }. The daemon only relays
+ * the fds; it never interprets the slots. */
+#define MAX_FDS    5
+
+struct client {
+    int  ctrl_fd;
+    bool is_consumer;
+};
+
+struct daemon_ctx {
+    struct client *consumer;
+    struct client *producer;
+    int epoll_fd;
+    int listen_fd;
+    volatile bool running;
+
+    struct screen_info stored_screen;
+    bool has_screen_info;
+
+    int deposited_fds[MAX_FDS];
+    int deposited_fd_count;
+
+    bool producer_waiting_screen;
+    bool producer_waiting_fds;
+
+    char sock_path[sizeof(((struct sockaddr_un *)0)->sun_path)];
+};
+
+static void client_free(daemon_ctx *ctx, struct client *c)
+{
+    if (!c) return;
+    if (c->ctrl_fd >= 0) {
+        epoll_ctl(ctx->epoll_fd, EPOLL_CTL_DEL, c->ctrl_fd, NULL);
+        close(c->ctrl_fd);
+    }
+    free(c);
+}
+
+static void clear_deposited_fds(daemon_ctx *ctx)
+{
+    for (int i = 0; i < ctx->deposited_fd_count; i++)
+        close(ctx->deposited_fds[i]);
+    ctx->deposited_fd_count = 0;
+}
+
+static int send_ctrl(int fd, uint32_t type)
+{
+    struct ctrl_msg msg = { .type = type, .size = 0 };
+    return send_all(fd, &msg, sizeof(msg));
+}
+
+static int send_screen_info_msg(daemon_ctx *ctx, int fd)
+{
+    struct ctrl_msg hdr = { .type = CTRL_MSG_SCREEN_INFO, .size = sizeof(struct screen_info) };
+    uint8_t buf[sizeof(struct ctrl_msg) + sizeof(struct screen_info)];
+    memcpy(buf, &hdr, sizeof(hdr));
+    memcpy(buf + sizeof(hdr), &ctx->stored_screen, sizeof(ctx->stored_screen));
+    return send_all(fd, buf, sizeof(buf));
+}
+
+static void try_deliver_fds(daemon_ctx *ctx)
+{
+    if (!ctx->producer || ctx->deposited_fd_count < MAX_FDS) {
+        ctx->producer_waiting_fds = true;
+        return;
+    }
+
+    struct ctrl_msg msg = { .type = CTRL_MSG_FDS_READY, .size = 0 };
+    if (send_fds(ctx->producer->ctrl_fd, &msg, sizeof(msg),
+                 ctx->deposited_fds, ctx->deposited_fd_count) < 0) {
+        fprintf(stderr, "daemon: failed to send fds to producer\n");
+        ctx->producer_waiting_fds = true;
+        return;
+    }
+
+    if (ctx->consumer)
+        send_ctrl(ctx->consumer->ctrl_fd, CTRL_MSG_FDS_READY);
+
+    for (int i = 0; i < ctx->deposited_fd_count; i++)
+        close(ctx->deposited_fds[i]);
+    ctx->deposited_fd_count = 0;
+    ctx->producer_waiting_fds = false;
+
+    fprintf(stderr, "daemon: fds delivered to producer\n");
+}
+
+/*
+ * Tear down whichever role this client holds, reset the associated state, then free
+ * it. Used both for real disconnects (EPOLLHUP / recv error) and to evict a stale
+ * client when a new one takes over the same role -- whether the old client is still
+ * alive or already a ghost, finding one is reason enough to drop it.
+ *
+ * The role pointer is cleared BEFORE client_free() so that any event still queued for
+ * this client in the current epoll batch fails the "is it a current role?" guard in
+ * the main loop and is skipped instead of dereferencing freed memory.
+ */
+static void drop_client(daemon_ctx *ctx, struct client *c)
+{
+    if (!c)
+        return;
+    if (c == ctx->consumer) {
+        fprintf(stderr, "daemon: consumer disconnected\n");
+        ctx->consumer = NULL;
+        /* The deposited fds belong to the consumer that just left; a future producer
+         * must never be handed this stale set. Drop them together with the consumer. */
+        clear_deposited_fds(ctx);
+    } else if (c == ctx->producer) {
+        fprintf(stderr, "daemon: producer disconnected\n");
+        ctx->producer = NULL;
+        ctx->producer_waiting_screen = false;
+        ctx->producer_waiting_fds = false;
+    }
+    client_free(ctx, c);
+}
+
+static void handle_client_data(daemon_ctx *ctx, struct client *c)
+{
+    struct ctrl_msg hdr;
+    int fds[MAX_FDS];
+    int fd_count = 0;
+
+    int n = recv_fds(c->ctrl_fd, &hdr, sizeof(hdr), fds, MAX_FDS, &fd_count);
+    if (n <= 0) {
+        drop_client(ctx, c);
+        return;
+    }
+
+    uint8_t payload[sizeof(struct screen_info)];
+    if (hdr.size > 0) {
+        if (hdr.size > sizeof(payload) || recv_all(c->ctrl_fd, payload, hdr.size) < 0) {
+            drop_client(ctx, c);
+            return;
+        }
+    }
+
+    switch (hdr.type) {
+    case CTRL_MSG_CONSUMER_HELLO:
+        if (c == ctx->consumer && fd_count >= MAX_FDS - 1) {
+            clear_deposited_fds(ctx);
+            memcpy(ctx->deposited_fds, fds, sizeof(int) * fd_count);
+            ctx->deposited_fd_count = fd_count;
+            fprintf(stderr, "daemon: consumer re-deposited %d fds\n", fd_count);
+            if (ctx->producer_waiting_fds)
+                try_deliver_fds(ctx);
+        }
+        break;
+
+    case CTRL_MSG_SCREEN_INFO:
+        if (c == ctx->consumer && hdr.size == sizeof(struct screen_info)) {
+            struct screen_info si;
+            memcpy(&si, payload, sizeof(si));
+            /* Always accept the consumer's screen info, even if it differs from a
+             * previous connection — the Android display may have rotated or switched
+             * resolution. Overwrite and forward to any waiting producer. */
+            ctx->stored_screen = si;
+            ctx->has_screen_info = true;
+            fprintf(stderr, "daemon: screen info %ux%u fmt=%u\n",
+                    si.width, si.height, si.format);
+            if (ctx->producer_waiting_screen && ctx->producer) {
+                send_screen_info_msg(ctx, ctx->producer->ctrl_fd);
+                ctx->producer_waiting_screen = false;
+            }
+        }
+        break;
+
+    case CTRL_MSG_PICKUP_FDS:
+        if (c == ctx->producer)
+            try_deliver_fds(ctx);
+        break;
+
+    default:
+        break;
+    }
+}
+
+static void handle_new_connection(daemon_ctx *ctx, int listen_fd)
+{
+    int client_fd = accept(listen_fd, NULL, NULL);
+    if (client_fd < 0)
+        return;
+
+    struct ctrl_msg hdr;
+    int fds[MAX_FDS];
+    int fd_count = 0;
+
+    int n = recv_fds(client_fd, &hdr, sizeof(hdr), fds, MAX_FDS, &fd_count);
+    if (n < (int)sizeof(struct ctrl_msg)) {
+        close(client_fd);
+        return;
+    }
+
+    struct client *c = calloc(1, sizeof(*c));
+    if (!c) {
+        close(client_fd);
+        return;
+    }
+    c->ctrl_fd = client_fd;
+
+    if (hdr.type == CTRL_MSG_CONSUMER_HELLO) {
+        /* Evict any prior consumer (alive or ghost) and its stale deposit before this
+         * one takes over the role. */
+        if (ctx->consumer)
+            drop_client(ctx, ctx->consumer);
+        c->is_consumer = true;
+        ctx->consumer = c;
+
+        clear_deposited_fds(ctx);
+        memcpy(ctx->deposited_fds, fds, sizeof(int) * fd_count);
+        ctx->deposited_fd_count = fd_count;
+        fprintf(stderr, "daemon: consumer connected, %d fds\n", fd_count);
+
+        if (ctx->producer_waiting_fds)
+            try_deliver_fds(ctx);
+
+    } else if (hdr.type == CTRL_MSG_PRODUCER_HELLO) {
+        /* Evict any prior producer (alive or ghost) before this one takes over. */
+        if (ctx->producer)
+            drop_client(ctx, ctx->producer);
+        c->is_consumer = false;
+        ctx->producer = c;
+        ctx->producer_waiting_screen = false;
+        ctx->producer_waiting_fds = false;
+        fprintf(stderr, "daemon: producer connected\n");
+
+        if (ctx->has_screen_info)
+            send_screen_info_msg(ctx, client_fd);
+        else
+            ctx->producer_waiting_screen = true;
+
+    } else {
+        close(client_fd);
+        free(c);
+        return;
+    }
+
+    struct epoll_event ev = { .events = EPOLLIN | EPOLLHUP | EPOLLERR, .data.ptr = c };
+    epoll_ctl(ctx->epoll_fd, EPOLL_CTL_ADD, client_fd, &ev);
+}
+
+int daemon_create(daemon_ctx **out, const char *sock_path)
+{
+    daemon_ctx *ctx = calloc(1, sizeof(*ctx));
+    if (!ctx)
+        return -1;
+    ctx->epoll_fd = -1;
+    ctx->listen_fd = -1;
+    ctx->running = true;
+    strncpy(ctx->sock_path, sock_path, sizeof(ctx->sock_path) - 1);
+
+    unlink(sock_path);
+    ctx->listen_fd = socket(AF_UNIX, SOCK_STREAM, 0);
+    if (ctx->listen_fd < 0) {
+        perror("socket");
+        daemon_destroy(ctx);
+        return -1;
+    }
+
+    struct sockaddr_un addr;
+    memset(&addr, 0, sizeof(addr));
+    addr.sun_family = AF_UNIX;
+    strncpy(addr.sun_path, sock_path, sizeof(addr.sun_path) - 1);
+
+    if (bind(ctx->listen_fd, (struct sockaddr *)&addr, sizeof(addr)) < 0) {
+        perror("bind");
+        daemon_destroy(ctx);
+        return -1;
+    }
+    if (listen(ctx->listen_fd, 4) < 0) {
+        perror("listen");
+        daemon_destroy(ctx);
+        return -1;
+    }
+
+    ctx->epoll_fd = epoll_create1(0);
+    if (ctx->epoll_fd < 0) {
+        perror("epoll_create1");
+        daemon_destroy(ctx);
+        return -1;
+    }
+    struct epoll_event ev = { .events = EPOLLIN, .data.ptr = NULL };
+    epoll_ctl(ctx->epoll_fd, EPOLL_CTL_ADD, ctx->listen_fd, &ev);
+
+    fprintf(stderr, "daemon: listening on %s\n", sock_path);
+
+    *out = ctx;
+    return 0;
+}
+
+void daemon_run(daemon_ctx *ctx)
+{
+    struct epoll_event events[MAX_EVENTS];
+    while (ctx->running) {
+        int nfds = epoll_wait(ctx->epoll_fd, events, MAX_EVENTS, 1000);
+        for (int i = 0; i < nfds; i++) {
+            if (events[i].data.ptr == NULL) {
+                handle_new_connection(ctx, ctx->listen_fd);
+            } else {
+                struct client *c = events[i].data.ptr;
+                /* A client freed earlier in this same batch -- a real disconnect, or
+                 * one evicted by a new connection taking over its role -- leaves a
+                 * stale event behind. Skip anything that is no longer a current role
+                 * so we never touch freed memory. */
+                if (c != ctx->consumer && c != ctx->producer)
+                    continue;
+                if (events[i].events & (EPOLLHUP | EPOLLERR))
+                    drop_client(ctx, c);
+                else
+                    handle_client_data(ctx, c);
+            }
+        }
+    }
+}
+
+void daemon_stop(daemon_ctx *ctx)
+{
+    if (ctx)
+        ctx->running = false;
+}
+
+void daemon_destroy(daemon_ctx *ctx)
+{
+    if (!ctx)
+        return;
+
+    clear_deposited_fds(ctx);
+    client_free(ctx, ctx->consumer);
+    client_free(ctx, ctx->producer);
+    if (ctx->listen_fd >= 0)
+        close(ctx->listen_fd);
+    if (ctx->epoll_fd >= 0)
+        close(ctx->epoll_fd);
+    if (ctx->sock_path[0])
+        unlink(ctx->sock_path);
+    fprintf(stderr, "daemon: shutdown\n");
+    free(ctx);
+}

--- a/src/anland/display_daemon.h
+++ b/src/anland/display_daemon.h
@@ -1,0 +1,29 @@
+#ifndef DISPLAY_DAEMON_H
+#define DISPLAY_DAEMON_H
+
+/*
+ * Relay daemon that brokers the consumer/producer handshake: it stashes the
+ * consumer's screen info and deposited fds, then hands them to the producer.
+ *
+ * All runtime state lives in an opaque daemon_ctx, so multiple independent
+ * instances can coexist in one process. The library installs no signal handlers
+ * and touches no process-global state; the hosting program owns that (see
+ * daemon/daemon.c for the standalone ELF).
+ */
+typedef struct daemon_ctx daemon_ctx;
+
+/* Create an instance listening on sock_path (internally unlink+bind+listen and
+ * sets up epoll). Returns 0 on success, -1 on failure. */
+int  daemon_create(daemon_ctx **out, const char *sock_path);
+
+/* Run the epoll loop until daemon_stop() is called. Blocking. */
+void daemon_run(daemon_ctx *ctx);
+
+/* Request the run loop to exit. Only sets a volatile flag, so it is safe to call
+ * from a signal handler or another thread. */
+void daemon_stop(daemon_ctx *ctx);
+
+/* Close all clients and sockets, unlink the socket path, and free ctx. */
+void daemon_destroy(daemon_ctx *ctx);
+
+#endif

--- a/src/anland/protocol.h
+++ b/src/anland/protocol.h
@@ -1,0 +1,193 @@
+#ifndef DISPLAY_PROTOCOL_H
+#define DISPLAY_PROTOCOL_H
+
+#include <stdint.h>
+
+#define CTRL_MSG_CONSUMER_HELLO  1
+#define CTRL_MSG_PRODUCER_HELLO  2
+#define CTRL_MSG_SCREEN_INFO     7
+#define CTRL_MSG_REJECT          8
+#define CTRL_MSG_PICKUP_FDS      9
+#define CTRL_MSG_FDS_READY      10
+
+#define DATA_MSG_BUF_READY       100
+#define DATA_MSG_REFRESH_DONE    101
+#define DATA_MSG_INPUT_EVENT     102
+#define DATA_MSG_OUTPUT_EVENT    103
+#define DATA_MSG_INPUT_EXTEND_FDS  104
+#define DATA_MSG_BUFS_READY      200
+
+#define MAX_BUFS 8
+
+struct ctrl_msg {
+    uint32_t type;
+    uint32_t size;
+    uint8_t  payload[];
+} __attribute__((packed));
+
+struct data_msg {
+    uint32_t type;
+    uint32_t size;
+    uint8_t  payload[];
+} __attribute__((packed));
+
+struct screen_info {
+    uint32_t width;
+    uint32_t height;
+    uint32_t format;
+    uint32_t refresh;
+} __attribute__((packed));
+
+struct buf_info {
+    uint32_t stride;
+    uint32_t width;      /* buffer logical width  (consumer-side native resolution) */
+    uint32_t height;     /* buffer logical height (consumer-side native resolution) */
+    uint32_t format;
+    uint64_t modifier;
+    uint32_t offset;
+} __attribute__((packed));
+
+#define INPUT_TYPE_TOUCH          1
+#define INPUT_TYPE_KEY            2
+#define INPUT_TYPE_POINTER_MOTION 3
+#define INPUT_TYPE_POINTER_BUTTON 4
+#define INPUT_TYPE_POINTER_AXIS   5
+#define INPUT_TYPE_TOUCH_FRAME    6
+/* Not really input: the consumer reports its current display refresh rate over
+ * the same data channel so the producer can repace its RenderLoop at runtime.
+ * Deliberately reuses the InputEvent framing (DATA_MSG_INPUT_EVENT) so the
+ * producer's poll_input_event() drains it like any other event instead of
+ * stalling the stream on an unknown DATA_MSG_* header. */
+#define INPUT_TYPE_DISPLAY_REFRESH 7
+#define INPUT_TYPE_CLIPBOARD      8
+#define INPUT_TYPE_TEXT_INPUT      9
+#define INPUT_TYPE_ACTION 10
+#define INPUT_TYPE_RESOURCE 11
+#define INPUT_TYPE_RESOURCE_INVALID 12
+
+#define SERVICE_TYPE_CAMERA 1
+
+#define INPUT_ACTION_DOWN    0
+
+#define INPUT_ACTION_DOWN    0
+#define INPUT_ACTION_UP      1
+#define INPUT_ACTION_MOVE    2
+
+#define OUTPUT_TYPE_CLIPBOARD 1
+#define OUTPUT_TYPE_RESOURCES_REQUEST 2
+
+
+
+struct InputEvent {
+    uint32_t type;
+    union {
+        struct {
+            int32_t  action;
+            float    x;
+            float    y;
+            int32_t  pointer_id;
+        } touch;
+        struct {
+            int32_t  action;
+            int32_t  keycode;
+        } key;
+        struct {
+            float    x;
+            float    y;
+            float    dx;
+            float    dy;
+        } pointer_motion;
+        struct {
+            uint32_t button;
+            int32_t  pressed;
+        } pointer_button;
+        struct {
+            uint32_t axis;
+            float    value;
+            int32_t  discrete;
+        } pointer_axis;
+        struct {
+            uint32_t refresh_mhz; // current display refresh rate, milli-Hz
+        } display;
+        struct {
+            uint32_t size; //这个packet只是通知包 作为header真正数据会集中发送,这里通知随后数据的大小
+        } clipboard;
+        struct {
+            uint32_t size; //这个packet只是通知包 作为header真正数据会集中发送,这里通知随后数据的大小
+        } text_input;
+        struct {
+            uint32_t action;
+            int32_t value;
+        } input_action;
+        struct {
+            uint32_t type;
+            uint32_t fdnum;//fdnum是fd的数量,后续会有fdnum个fd跟随在这个结构体后面
+        } resource;
+        struct {
+            uint32_t padding[4];
+        };
+    };
+} __attribute__((packed));
+
+struct OutputEvent{
+    uint32_t type;
+    union {
+        struct {
+            uint32_t size; //这个packet只是通知包 作为header真正数据会集中发送,这里通知随后数据的大小
+        } clipboard;
+        struct {
+            uint32_t type;
+            uint32_t args[3]; //support 3 args
+        } resources_request;
+        struct
+        {
+            uint32_t padding[4];
+        };
+
+    };
+} __attribute__((packed));
+
+/*
+ * Audio runs on its own dedicated bidirectional socketpair (hello fd slot 4),
+ * deliberately kept off the data channel so a burst of PCM never head-of-line
+ * blocks input/clipboard. The socket is full duplex: the producer writes desktop
+ * playback PCM that the consumer reads, and the consumer writes microphone PCM
+ * that the producer reads -- each side only ever reads what the other wrote.
+ * Every direction sends one AUDIO_MSG_FORMAT, then a stream of AUDIO_MSG_PCM.
+ *
+ * PCM is interleaved per frame. For stereo (channels == 2) the sample order
+ * within each frame is LEFT then RIGHT, i.e. channel positions FL, FR -- the
+ * producer's SPA channel map and the consumer's AAudio stereo layout must both
+ * honour this order so the left/right channels are never swapped.
+ *
+ * Audio quality is negotiated, not pinned: the consumer owns the real hardware,
+ * so on connect it opens its AAudio streams, reads back the rate/channels the
+ * device actually chose, and sends one AUDIO_MSG_FORMAT per direction (tagged with
+ * role) to the producer. The producer builds its PipeWire sink/source to match,
+ * so neither side resamples blindly and the PCM byte math lines up on both ends.
+ */
+#define AUDIO_MSG_FORMAT 1
+#define AUDIO_MSG_PCM    2
+
+/* PCM sample format codes for struct audio_format.format. */
+#define AUDIO_FORMAT_S16LE 0
+
+/* Which direction a struct audio_format describes. */
+#define AUDIO_ROLE_PLAYBACK 0   /* producer -> consumer (desktop sound -> speaker) */
+#define AUDIO_ROLE_CAPTURE  1   /* consumer -> producer (mic -> virtual source)    */
+
+struct audio_format {
+    uint32_t rate;       /* frames per second the device chose, e.g. 48000 / 44100 */
+    uint32_t channels;   /* interleaved; stereo is L,R (FL,FR) */
+    uint32_t format;     /* AUDIO_FORMAT_* */
+    uint32_t role;       /* AUDIO_ROLE_* -- which direction this describes */
+    uint32_t quantum;    /* requested buffer in frames (latency preset); 0 = engine default */
+} __attribute__((packed));
+
+struct audio_msg {
+    uint32_t type;       /* AUDIO_MSG_FORMAT | AUDIO_MSG_PCM */
+    uint32_t size;       /* payload bytes that follow this header */
+} __attribute__((packed));
+
+
+#endif

--- a/src/anland/socket_utils.c
+++ b/src/anland/socket_utils.c
@@ -1,0 +1,121 @@
+#include "socket_utils.h"
+
+#include <errno.h>
+#include <stdint.h>
+#include <string.h>
+#include <sys/socket.h>
+#include <sys/un.h>
+#include <unistd.h>
+
+int send_fds(int sock, const void *data, size_t data_len,
+             const int *fds, int fd_count)
+{
+    struct iovec iov = {
+        .iov_base = (void *)data,
+        .iov_len  = data_len,
+    };
+
+    char cmsg_buf[CMSG_SPACE(sizeof(int) * fd_count)];
+    memset(cmsg_buf, 0, sizeof(cmsg_buf));
+
+    struct msghdr msg = {
+        .msg_iov        = &iov,
+        .msg_iovlen     = 1,
+        .msg_control    = cmsg_buf,
+        .msg_controllen = sizeof(cmsg_buf),
+    };
+
+    struct cmsghdr *cmsg = CMSG_FIRSTHDR(&msg);
+    cmsg->cmsg_level = SOL_SOCKET;
+    cmsg->cmsg_type  = SCM_RIGHTS;
+    cmsg->cmsg_len   = CMSG_LEN(sizeof(int) * fd_count);
+    memcpy(CMSG_DATA(cmsg), fds, sizeof(int) * fd_count);
+
+    ssize_t n = sendmsg(sock, &msg, MSG_NOSIGNAL);
+    return (n == (ssize_t)data_len) ? 0 : -1;
+}
+
+int recv_fds(int sock, void *data, size_t data_len,
+             int *fds, int fd_count, int *fds_received)
+{
+    struct iovec iov = {
+        .iov_base = data,
+        .iov_len  = data_len,
+    };
+
+    char cmsg_buf[CMSG_SPACE(sizeof(int) * fd_count)];
+    memset(cmsg_buf, 0, sizeof(cmsg_buf));
+
+    struct msghdr msg = {
+        .msg_iov        = &iov,
+        .msg_iovlen     = 1,
+        .msg_control    = cmsg_buf,
+        .msg_controllen = sizeof(cmsg_buf),
+    };
+
+    ssize_t n = recvmsg(sock, &msg, 0);
+    if (n <= 0)
+        return -1;
+
+    *fds_received = 0;
+    struct cmsghdr *cmsg = CMSG_FIRSTHDR(&msg);
+    if (cmsg && cmsg->cmsg_level == SOL_SOCKET && cmsg->cmsg_type == SCM_RIGHTS) {
+        int count = (cmsg->cmsg_len - CMSG_LEN(0)) / sizeof(int);
+        if (count > fd_count)
+            count = fd_count;
+        memcpy(fds, CMSG_DATA(cmsg), sizeof(int) * count);
+        *fds_received = count;
+    }
+
+    return (int)n;
+}
+
+int connect_unix(const char *path)
+{
+    int fd = socket(AF_UNIX, SOCK_STREAM, 0);
+    if (fd < 0)
+        return -1;
+
+    struct sockaddr_un addr;
+    memset(&addr, 0, sizeof(addr));
+    addr.sun_family = AF_UNIX;
+    strncpy(addr.sun_path, path, sizeof(addr.sun_path) - 1);
+
+    if (connect(fd, (struct sockaddr *)&addr, sizeof(addr)) < 0) {
+        close(fd);
+        return -1;
+    }
+    return fd;
+}
+
+int send_all(int fd, const void *buf, size_t len)
+{
+    const uint8_t *p = buf;
+    size_t sent = 0;
+    while (sent < len) {
+        ssize_t n = send(fd, p + sent, len - sent, MSG_NOSIGNAL);
+        if (n <= 0) {
+            if (n < 0 && errno == EINTR)
+                continue;
+            return -1;
+        }
+        sent += n;
+    }
+    return 0;
+}
+
+int recv_all(int fd, void *buf, size_t len)
+{
+    uint8_t *p = buf;
+    size_t got = 0;
+    while (got < len) {
+        ssize_t n = recv(fd, p + got, len - got, 0);
+        if (n <= 0) {
+            if (n < 0 && errno == EINTR)
+                continue;
+            return -1;
+        }
+        got += n;
+    }
+    return 0;
+}

--- a/src/anland/socket_utils.h
+++ b/src/anland/socket_utils.h
@@ -1,0 +1,18 @@
+#ifndef DISPLAY_SOCKET_UTILS_H
+#define DISPLAY_SOCKET_UTILS_H
+
+#include <stddef.h>
+
+int send_fds(int sock, const void *data, size_t data_len,
+             const int *fds, int fd_count);
+
+int recv_fds(int sock, void *data, size_t data_len,
+             int *fds, int fd_count, int *fds_received);
+
+int connect_unix(const char *path);
+
+int send_all(int fd, const void *buf, size_t len);
+
+int recv_all(int fd, void *buf, size_t len);
+
+#endif

--- a/src/config.c
+++ b/src/config.c
@@ -291,6 +291,8 @@ int ds_config_load(const char *config_path, struct ds_config *cfg) {
       cfg->virgl_extra_flags = val[0] ? strdup(val) : NULL;
     } else if (strcmp(key, "enable_pulseaudio") == 0) {
       cfg->pulseaudio = parse_bool(val);
+    } else if (strcmp(key, "enable_anland") == 0) {
+      cfg->anland = parse_bool(val);
     } else if (strcmp(key, "selinux_permissive") == 0) {
       cfg->selinux_permissive = parse_bool(val);
     } else if (strcmp(key, "volatile_mode") == 0) {
@@ -637,6 +639,7 @@ static void ds_config_serialize_known(FILE *f, struct ds_config *cfg) {
     if (cfg->virgl_extra_flags)
       fprintf(f, "virgl_extra_flags=%s\n", cfg->virgl_extra_flags);
     fprintf(f, "enable_pulseaudio=%d\n", cfg->pulseaudio);
+    fprintf(f, "enable_anland=%d\n", cfg->anland);
   }
   fprintf(f, "enable_hw_access=%d\n", cfg->hw_access);
   fprintf(f, "enable_gpu_mode=%d\n", cfg->gpu_mode);

--- a/src/container.c
+++ b/src/container.c
@@ -184,6 +184,7 @@ void cleanup_container_resources(struct ds_config *cfg, pid_t pid,
     ds_x11_daemon_stop(cfg);
     ds_virgl_daemon_stop(cfg);
     ds_pulse_daemon_stop(cfg);
+    ds_anland_daemon_stop(cfg);
     if (count_running_containers(NULL, 0) == 0) {
       android_optimizations(0);
     }
@@ -499,6 +500,14 @@ int start_rootfs(struct ds_config *cfg) {
 
   if (is_android() && cfg->pulseaudio) {
     ds_pulse_daemon_start(cfg);
+  }
+
+  /* anland display daemon: generate the per-container host socket and start the
+   * broker before fork so the socket exists when bind-mounted post-pivot. The
+   * generated cfg->anland_sock is recorded in the Pids dir (not container.config)
+   * by ds_anland_daemon_start. */
+  if (is_android() && cfg->anland) {
+    ds_anland_daemon_start(cfg);
   }
 
   /* 3. Early pre-flight for volatile mode (before any host changes) */

--- a/src/hardware.c
+++ b/src/hardware.c
@@ -806,5 +806,8 @@ int setup_hardware_access(struct ds_config *cfg) {
   /* 4. Setup PulseAudio socket (Android only) */
   ds_setup_pulse_socket(cfg);
 
+  /* 5. Setup anland display socket -> /run/display.sock (Android only) */
+  ds_setup_anland_socket(cfg);
+
   return 0;
 }

--- a/src/include/droidspace.h
+++ b/src/include/droidspace.h
@@ -365,6 +365,7 @@ struct ds_config {
   int virgl;              /* --virgl (Android only) */
   char *virgl_extra_flags; /* --virgl-flags "..." (heap, NULL if unset) */
   int pulseaudio;          /* --pulse-audio (Android only) */
+  int anland;              /* --anland: embed anland display daemon (Android) */
   int volatile_mode;       /* --volatile */
   int disable_ipv6;        /* --disable-ipv6 */
   int android_storage;     /* --enable-android-storage */
@@ -385,6 +386,8 @@ struct ds_config {
   pid_t x11_pid;                  /* PID of the Termux-X11 server process */
   pid_t virgl_pid;                /* PID of the VirGL server process */
   pid_t pulse_pid;                /* PID of the PulseAudio daemon process */
+  pid_t anland_pid;               /* PID of the anland display daemon process */
+  char anland_sock[PATH_MAX];     /* generated host socket for the anland daemon */
   int is_img_mount;               /* 1 if rootfs was loop-mounted from .img */
   char img_mount_point[PATH_MAX]; /* where the .img was mounted */
   ds_init_type_t init_type;       /* detected container PID 1 init family */
@@ -652,6 +655,14 @@ int setup_hardware_access(struct ds_config *cfg);
 int ds_x11_daemon_start(struct ds_config *cfg);
 void ds_x11_daemon_stop(struct ds_config *cfg);
 int ds_setup_x11_socket(struct ds_config *cfg);
+
+/* ---------------------------------------------------------------------------
+ * anland/anland.c
+ * ---------------------------------------------------------------------------*/
+
+int ds_anland_daemon_start(struct ds_config *cfg);
+void ds_anland_daemon_stop(struct ds_config *cfg);
+int ds_setup_anland_socket(struct ds_config *cfg);
 
 /* ---------------------------------------------------------------------------
  * virgl-android.c

--- a/src/main.c
+++ b/src/main.c
@@ -90,7 +90,9 @@ void print_usage(void) {
       "      --virgl-flags=\"FLAGS\"   Extra flags passed to "
       "virgl_test_server_android\n"
       "      --pulse-audio         Configure PulseAudio sound server "
-      "support\n\n");
+      "support\n"
+      "      --anland              Embed the anland display daemon "
+      "(Android)\n\n");
 
   printf(
       C_BOLD
@@ -413,6 +415,7 @@ int main(int argc, char **argv) {
       {"virgl", no_argument, 0, 270},
       {"virgl-flags", required_argument, 0, 272},
       {"pulse-audio", no_argument, 0, 273},
+      {"anland", no_argument, 0, 278},
       {"gateway", required_argument, 0, 274},
       {"gateway-container", required_argument, 0, 274},
       {"gateway-net", required_argument, 0, 275},
@@ -676,6 +679,9 @@ int main(int argc, char **argv) {
       break;
     case 273:
       cfg.pulseaudio = 1;
+      break;
+    case 278:
+      cfg.anland = 1;
       break;
     case 274:
       safe_strncpy(cfg.gateway_container, optarg,


### PR DESCRIPTION
## Integrated Anland Wayland display bridge

### Summary

Adds an **embedded per-container Anland display daemon** that lets a graphical
(KWin/Wayland) session inside a container be surfaced as a native, resizable
Android window through the [Anland](https://github.com/superturtlee/anland)
consumer app. Each container runs its own daemon, so containers stay fully
isolated and multiple desktops can be opened side-by-side (multi-window /
split-screen).

Requires the Anland **5.14** consumer build (adds external-argument launch +
multi-window support).

### Core runtime (`src/anland/`)

- **New `--anland` flag** and `enable_anland` config key (`main.c`, `config.c`,
  `droidspace.h`), persisted/serialized like the existing `--pulse-audio` option.
- **`anland.c`** — daemon per container* :
  - On `start_rootfs`, before fork, generates a unique host socket
    `/data/local/tmp/anland-<uuid>.sock`, forks a persistent broker process
    running the vendored `libdisplay_daemon` epoll loop in-process (no `execv`),
    and relays its output to `Logs/anland.log`.
  - Records the PID and socket path under the new `Pids/` dir
    (`<name>.anland.pid`, `<name>.anland`) so the app and later restarts can find
    or reuse a live daemon; the socket path is runtime-only and not written to
    `container.config`.
  - `ds_setup_anland_socket` bind-mounts the host socket onto the container's
    `/run/display.sock`.
  - Clean teardown wired into `cleanup_container_resources`.
- **`display_daemon.c/.h`, `protocol.h`, `socket_utils.c/.h`** — vendored
  upstream that hands off screen info and fds between the in-container
  producer (patched KWin) and the Android consumer. .
- **Makefile** — adds the three `src/anland/*.c` units with a relaxed warning
  profile (drops `-Wpedantic`/`-Wcast-qual`/`-Wnull-dereference` for the vendored
  C11 code, keeps `-Werror`).

### Android app

- **`ContainerInfo.enableAnland`** field, serialized as `enable_anland` and
  parsed back (`ContainerManager.kt`); `ContainerManager.getAnlandSocket()` reads
  `Pids/<name>.anland` — a non-empty path means the window can be launched.
- **`AnlandUtils.launchWindow()`** — launches
  `com.anland.consumer/.SecondaryActivity` with the socket path and container
  name, dedup-by-socket for focus; toasts if the consumer isn't installed.
- **Edit container**: new "Anland Display" `ToggleCard`.
- **Container details**: `TerminalCard` gains a full-width **Launch Anland**
  button, shown only when Anland is enabled *and* a live socket exists.
- **Control panel**: `RunningContainerCard` gains a small **anland** pill next to
  the Terminal button, gated the same way.
- **Manifest**: `<queries>` entry for `com.anland.consumer` (Android 11+ package
  visibility). **sepolicy.rule**: rules allowing the daemon/consumer fd +
  unix-socket exchange and graphics-buffer sharing. New/updated strings.

### Compatibility

- **Qualcomm (all)** — fully supported via Turnip / Freedreno Mesa drivers.
- **MediaTek and other SoCs** — no Mesa driver, so only software rendering is
  available; not practically usable.
- **Anland 5.14+** — this version adds launching with sockpath parms and multi windows
