### PR TITLE
Add allow userns option to solve Anland Compositor running slow

### DIFF
--- a/Android/app/src/main/AndroidManifest.xml
+++ b/Android/app/src/main/AndroidManifest.xml
@@ -13,6 +13,12 @@
     <uses-permission android:name="android.permission.WAKE_LOCK" />
     <uses-permission android:name="android.permission.REQUEST_IGNORE_BATTERY_OPTIMIZATIONS" />
 
+    <!-- Package visibility (Android 11+): allow launching the anland consumer
+         app for the "Launch Anland Window" action. -->
+    <queries>
+        <package android:name="com.anland.consumer" />
+    </queries>
+
     <application
         android:name=".DroidspacesApplication"
         android:allowBackup="true"

--- a/Android/app/src/main/assets/boot-module/sepolicy.rule
+++ b/Android/app/src/main/assets/boot-module/sepolicy.rule
@@ -74,3 +74,15 @@ allow mediaserver droidspacesd fd use
 
 # fix permission denied when read/write mounted storage (#213)
 allow mediaprovider_app droidspacesd fd use
+
+# for anland
+allow untrusted_app droidspacesd fd use
+allow droidspacesd untrusted_app fd use
+allow droidspacesd untrusted_app unix_stream_socket { read write }
+allow droidspacesd device chr_file { open read write ioctl map }
+allow droidspacesd droidspacesd unix_stream_socket { create connect listen accept bind getattr getopt setopt shutdown read write }
+allow droidspacesd hal_graphics_allocator_default fd use
+allow surfaceflinger droidspacesd fd use
+allow hal_graphics_composer_default droidspacesd fd use
+allow untrusted_app su unix_stream_socket { read write }
+

--- a/Android/app/src/main/java/com/droidspaces/app/ui/component/ContainerCard.kt
+++ b/Android/app/src/main/java/com/droidspaces/app/ui/component/ContainerCard.kt
@@ -179,6 +179,7 @@ fun ContainerCard(
             if (container.enableHwAccess) options.add(context.getString(R.string.hw_option))
             if (container.enableGpuMode || container.enableHwAccess) options.add(context.getString(R.string.gpu_option))
             if (container.enableTermuxX11) options.add(context.getString(R.string.x11_option))
+            if (container.enableAnland) options.add(context.getString(R.string.anland_option))
             if (container.enableVirgl) options.add(context.getString(R.string.virgl_option))
             if (container.enablePulseaudio) options.add(context.getString(R.string.pulseaudio_option))
             if (container.selinuxPermissive) options.add(context.getString(R.string.selinux_permissive_option))

--- a/Android/app/src/main/java/com/droidspaces/app/ui/component/ContainerCard.kt
+++ b/Android/app/src/main/java/com/droidspaces/app/ui/component/ContainerCard.kt
@@ -183,6 +183,7 @@ fun ContainerCard(
             if (container.enableVirgl) options.add(context.getString(R.string.virgl_option))
             if (container.enablePulseaudio) options.add(context.getString(R.string.pulseaudio_option))
             if (container.selinuxPermissive) options.add(context.getString(R.string.selinux_permissive_option))
+            if (container.allowUserns) options.add(context.getString(R.string.userns_option))
             if (container.volatileMode) options.add(context.getString(R.string.volatile_option))
             if (container.forceCgroupv1) options.add(context.getString(R.string.cgroup_v1_option))
             if (container.blockNestedNs) options.add(context.getString(R.string.deadlock_shield_option))

--- a/Android/app/src/main/java/com/droidspaces/app/ui/component/RunningContainerCard.kt
+++ b/Android/app/src/main/java/com/droidspaces/app/ui/component/RunningContainerCard.kt
@@ -32,6 +32,8 @@ fun RunningContainerCard(
     container: ContainerInfo,
     onEnter: () -> Unit = {},
     onTerminalClick: () -> Unit = {},
+    anlandEnabled: Boolean = false,
+    onLaunchAnland: () -> Unit = {},
     osInfo: ContainerOSInfoManager.OSInfo? = null,
     modifier: Modifier = Modifier
 ) {
@@ -184,6 +186,37 @@ fun RunningContainerCard(
                                 )
                             }
                         }
+                    }
+                }
+            }
+
+            // Launch the anland desktop window, shown only when this container has
+            // the anland display daemon enabled and a live socket recorded.
+            if (anlandEnabled) {
+                Surface(
+                    onClick = onLaunchAnland,
+                    modifier = Modifier.fillMaxWidth().height(44.dp),
+                    shape = RoundedCornerShape(12.dp),
+                    color = MaterialTheme.colorScheme.secondaryContainer,
+                    contentColor = MaterialTheme.colorScheme.onSecondaryContainer,
+                    tonalElevation = 0.dp
+                ) {
+                    Row(
+                        modifier = Modifier.fillMaxSize(),
+                        verticalAlignment = Alignment.CenterVertically,
+                        horizontalArrangement = Arrangement.Center
+                    ) {
+                        Icon(
+                            imageVector = Icons.Default.OpenInNew,
+                            contentDescription = null,
+                            modifier = Modifier.size(18.dp)
+                        )
+                        Spacer(Modifier.width(8.dp))
+                        Text(
+                            text = context.getString(R.string.launch_anland_window),
+                            style = MaterialTheme.typography.labelLarge,
+                            fontWeight = FontWeight.Bold
+                        )
                     }
                 }
             }

--- a/Android/app/src/main/java/com/droidspaces/app/ui/component/RunningContainerCard.kt
+++ b/Android/app/src/main/java/com/droidspaces/app/ui/component/RunningContainerCard.kt
@@ -75,6 +75,39 @@ fun RunningContainerCard(
                     modifier = Modifier.weight(1f)
                 )
 
+                // Small "anland" pill next to the terminal button, shown only when
+                // this container has the anland display daemon enabled and a live
+                // socket recorded.
+                if (anlandEnabled) {
+                    Surface(
+                        onClick = onLaunchAnland,
+                        shape = RoundedCornerShape(12.dp),
+                        color = MaterialTheme.colorScheme.secondaryContainer,
+                        contentColor = MaterialTheme.colorScheme.onSecondaryContainer,
+                        modifier = Modifier.height(30.dp).clip(RoundedCornerShape(12.dp)),
+                        tonalElevation = 0.dp
+                    ) {
+                        Row(
+                            modifier = Modifier.padding(horizontal = 10.dp),
+                            verticalAlignment = Alignment.CenterVertically,
+                            horizontalArrangement = Arrangement.Center
+                        ) {
+                            Icon(
+                                imageVector = Icons.Default.DesktopWindows,
+                                contentDescription = null,
+                                modifier = Modifier.size(14.dp)
+                            )
+                            Spacer(Modifier.width(6.dp))
+                            Text(
+                                text = "anland",
+                                style = MaterialTheme.typography.labelMedium,
+                                fontWeight = FontWeight.Bold
+                            )
+                        }
+                    }
+                    Spacer(Modifier.width(8.dp))
+                }
+
                 val sessionCount by remember {
                     derivedStateOf {
                         TerminalSessionService.globalSessionList.values.count {
@@ -186,37 +219,6 @@ fun RunningContainerCard(
                                 )
                             }
                         }
-                    }
-                }
-            }
-
-            // Launch the anland desktop window, shown only when this container has
-            // the anland display daemon enabled and a live socket recorded.
-            if (anlandEnabled) {
-                Surface(
-                    onClick = onLaunchAnland,
-                    modifier = Modifier.fillMaxWidth().height(44.dp),
-                    shape = RoundedCornerShape(12.dp),
-                    color = MaterialTheme.colorScheme.secondaryContainer,
-                    contentColor = MaterialTheme.colorScheme.onSecondaryContainer,
-                    tonalElevation = 0.dp
-                ) {
-                    Row(
-                        modifier = Modifier.fillMaxSize(),
-                        verticalAlignment = Alignment.CenterVertically,
-                        horizontalArrangement = Arrangement.Center
-                    ) {
-                        Icon(
-                            imageVector = Icons.Default.OpenInNew,
-                            contentDescription = null,
-                            modifier = Modifier.size(18.dp)
-                        )
-                        Spacer(Modifier.width(8.dp))
-                        Text(
-                            text = context.getString(R.string.launch_anland_window),
-                            style = MaterialTheme.typography.labelLarge,
-                            fontWeight = FontWeight.Bold
-                        )
                     }
                 }
             }

--- a/Android/app/src/main/java/com/droidspaces/app/ui/screen/ContainerDetailsScreen.kt
+++ b/Android/app/src/main/java/com/droidspaces/app/ui/screen/ContainerDetailsScreen.kt
@@ -28,6 +28,7 @@ import com.droidspaces.app.util.ContainerProcdManager
 import com.droidspaces.app.util.ContainerOpenRCManager
 import com.droidspaces.app.util.ContainerDiskUsageManager
 import com.droidspaces.app.util.ContainerManager
+import com.droidspaces.app.util.AnlandUtils
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import kotlinx.coroutines.delay
@@ -72,6 +73,14 @@ fun ContainerDetailsScreen(
     // Uses persistent cache that survives app restarts
     var osInfo by remember {
         mutableStateOf(ContainerOSInfoManager.getCachedOSInfo(container.name, context))
+    }
+
+    // anland display socket (recorded by the native runtime in Pids/<name>.anland);
+    // presence gates the "Launch Anland Window" action in the terminal card.
+    var anlandSocket by remember { mutableStateOf<String?>(null) }
+    LaunchedEffect(container.name, container.enableAnland, refreshTrigger) {
+        anlandSocket = if (container.enableAnland)
+            ContainerManager.getAnlandSocket(container.name) else null
     }
 
     // Init system state - detect systemd first, then OpenWrt/procd, then OpenRC
@@ -255,7 +264,11 @@ fun ContainerDetailsScreen(
             item(key = "terminal_${container.name}") {
                 TerminalCard(
                     containerName = container.name,
-                    onOpenTerminal = onNavigateToTerminal
+                    onOpenTerminal = onNavigateToTerminal,
+                    anlandEnabled = container.enableAnland && anlandSocket != null,
+                    onLaunchAnland = {
+                        anlandSocket?.let { AnlandUtils.launchWindow(context, container.name, it) }
+                    }
                 )
             }
 
@@ -373,6 +386,8 @@ private fun IdentityToken(
 private fun TerminalCard(
     containerName: String,
     onOpenTerminal: () -> Unit,
+    anlandEnabled: Boolean = false,
+    onLaunchAnland: () -> Unit = {},
     modifier: Modifier = Modifier,
 ) {
     val context = LocalContext.current
@@ -402,10 +417,12 @@ private fun TerminalCard(
         color = MaterialTheme.colorScheme.surfaceContainerHigh,
         border = androidx.compose.foundation.BorderStroke(1.dp, MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.5f))
     ) {
+      Column(
+          modifier = Modifier.fillMaxWidth().padding(20.dp),
+          verticalArrangement = Arrangement.spacedBy(14.dp)
+      ) {
         Row(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(20.dp),
+            modifier = Modifier.fillMaxWidth(),
             horizontalArrangement = Arrangement.SpaceBetween,
             verticalAlignment = Alignment.CenterVertically
         ) {
@@ -461,6 +478,31 @@ private fun TerminalCard(
                 )
             }
         }
+
+        // Launch the anland desktop window, shown only when this container has
+        // the anland display daemon enabled and a live socket recorded.
+        if (anlandEnabled) {
+            Button(
+                onClick = onLaunchAnland,
+                modifier = Modifier.fillMaxWidth(),
+                colors = ButtonDefaults.buttonColors(
+                    containerColor = MaterialTheme.colorScheme.secondaryContainer,
+                    contentColor = MaterialTheme.colorScheme.onSecondaryContainer
+                )
+            ) {
+                Icon(
+                    Icons.Default.DesktopWindows,
+                    contentDescription = null,
+                    modifier = Modifier.size(16.dp)
+                )
+                Spacer(Modifier.width(6.dp))
+                Text(
+                    context.getString(R.string.launch_anland_window),
+                    fontWeight = FontWeight.SemiBold
+                )
+            }
+        }
+      }
     }
 }
 

--- a/Android/app/src/main/java/com/droidspaces/app/ui/screen/ControlPanelScreen.kt
+++ b/Android/app/src/main/java/com/droidspaces/app/ui/screen/ControlPanelScreen.kt
@@ -23,6 +23,12 @@ import com.droidspaces.app.ui.component.PullToRefreshWrapper
 import com.droidspaces.app.ui.component.RunningContainerCard
 import com.droidspaces.app.ui.viewmodel.ContainerViewModel
 import com.droidspaces.app.ui.viewmodel.SystemStatsViewModel
+import com.droidspaces.app.util.ContainerManager
+import android.content.ActivityNotFoundException
+import android.content.ComponentName
+import android.content.Context
+import android.content.Intent
+import android.widget.Toast
 import androidx.compose.ui.platform.LocalContext
 import com.droidspaces.app.R
 
@@ -64,6 +70,17 @@ fun ControlPanelScreen(
 
     val containerUsageMap = systemStatsViewModel.containerUsageMap
 
+    // Per-container anland display socket (recorded by the native runtime in
+    // Pids/<name>.anland). Refreshed whenever the running-container set changes;
+    // presence gates the "Launch Anland Window" button.
+    val anlandSockets = remember { mutableStateMapOf<String, String>() }
+    LaunchedEffect(runningContainers) {
+        anlandSockets.clear()
+        runningContainers.filter { it.enableAnland }.forEach { c ->
+            ContainerManager.getAnlandSocket(c.name)?.let { anlandSockets[c.name] = it }
+        }
+    }
+
     Box(modifier = Modifier.fillMaxSize()) {
         // Show content based on root and backend availability
         // Using when instead of early return to prevent UI glitches during recomposition
@@ -94,6 +111,7 @@ fun ControlPanelScreen(
                         verticalArrangement = Arrangement.spacedBy(16.dp)
                     ) {
                         runningContainers.forEach { container ->
+                            val anlandSock = anlandSockets[container.name]
                             RunningContainerCard(
                                 container = container,
                                 onEnter = {
@@ -101,6 +119,10 @@ fun ControlPanelScreen(
                                 },
                                 onTerminalClick = {
                                     onNavigateToTerminal(container.name)
+                                },
+                                anlandEnabled = container.enableAnland && anlandSock != null,
+                                onLaunchAnland = {
+                                    anlandSock?.let { launchAnland(context, container.name, it) }
                                 },
                                 osInfo = containerUsageMap[container.name],
                             )
@@ -115,6 +137,33 @@ fun ControlPanelScreen(
             hostState = snackbarHostState,
             modifier = Modifier.align(Alignment.BottomCenter)
         )
+    }
+}
+
+/**
+ * Launch the anland consumer app's multi-window activity, pointed at this
+ * container's display socket and titled with the container name. Uses
+ * SecondaryActivity (the consumer's parametrized entry, which dedups by socket
+ * path). No-op with a toast if the consumer app isn't installed.
+ */
+private fun launchAnland(context: Context, containerName: String, socketPath: String) {
+    val intent = Intent(Intent.ACTION_MAIN).apply {
+        component = ComponentName(
+            "com.anland.consumer",
+            "com.anland.consumer.SecondaryActivity"
+        )
+        putExtra("socket_path", socketPath)
+        putExtra("window_name", containerName)
+        addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_MULTIPLE_TASK)
+    }
+    try {
+        context.startActivity(intent)
+    } catch (e: ActivityNotFoundException) {
+        Toast.makeText(
+            context,
+            context.getString(R.string.anland_not_installed),
+            Toast.LENGTH_SHORT
+        ).show()
     }
 }
 

--- a/Android/app/src/main/java/com/droidspaces/app/ui/screen/ControlPanelScreen.kt
+++ b/Android/app/src/main/java/com/droidspaces/app/ui/screen/ControlPanelScreen.kt
@@ -23,12 +23,8 @@ import com.droidspaces.app.ui.component.PullToRefreshWrapper
 import com.droidspaces.app.ui.component.RunningContainerCard
 import com.droidspaces.app.ui.viewmodel.ContainerViewModel
 import com.droidspaces.app.ui.viewmodel.SystemStatsViewModel
+import com.droidspaces.app.util.AnlandUtils
 import com.droidspaces.app.util.ContainerManager
-import android.content.ActivityNotFoundException
-import android.content.ComponentName
-import android.content.Context
-import android.content.Intent
-import android.widget.Toast
 import androidx.compose.ui.platform.LocalContext
 import com.droidspaces.app.R
 
@@ -122,7 +118,7 @@ fun ControlPanelScreen(
                                 },
                                 anlandEnabled = container.enableAnland && anlandSock != null,
                                 onLaunchAnland = {
-                                    anlandSock?.let { launchAnland(context, container.name, it) }
+                                    anlandSock?.let { AnlandUtils.launchWindow(context, container.name, it) }
                                 },
                                 osInfo = containerUsageMap[container.name],
                             )
@@ -137,33 +133,6 @@ fun ControlPanelScreen(
             hostState = snackbarHostState,
             modifier = Modifier.align(Alignment.BottomCenter)
         )
-    }
-}
-
-/**
- * Launch the anland consumer app's multi-window activity, pointed at this
- * container's display socket and titled with the container name. Uses
- * SecondaryActivity (the consumer's parametrized entry, which dedups by socket
- * path). No-op with a toast if the consumer app isn't installed.
- */
-private fun launchAnland(context: Context, containerName: String, socketPath: String) {
-    val intent = Intent(Intent.ACTION_MAIN).apply {
-        component = ComponentName(
-            "com.anland.consumer",
-            "com.anland.consumer.SecondaryActivity"
-        )
-        putExtra("socket_path", socketPath)
-        putExtra("window_name", containerName)
-        addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_MULTIPLE_TASK)
-    }
-    try {
-        context.startActivity(intent)
-    } catch (e: ActivityNotFoundException) {
-        Toast.makeText(
-            context,
-            context.getString(R.string.anland_not_installed),
-            Toast.LENGTH_SHORT
-        ).show()
     }
 }
 

--- a/Android/app/src/main/java/com/droidspaces/app/ui/screen/EditContainerScreen.kt
+++ b/Android/app/src/main/java/com/droidspaces/app/ui/screen/EditContainerScreen.kt
@@ -102,6 +102,7 @@ fun EditContainerScreen(
     var virglExtraFlags by remember { mutableStateOf(container.virglExtraFlags) }
     var enablePulseaudio by remember { mutableStateOf(container.enablePulseaudio) }
     var selinuxPermissive by remember { mutableStateOf(container.selinuxPermissive) }
+    var allowUserns by remember { mutableStateOf(container.allowUserns) }
     var volatileMode by remember { mutableStateOf(container.volatileMode) }
     var bindMounts by remember { mutableStateOf(container.bindMounts) }
     var dnsServers by remember { mutableStateOf(container.dnsServers) }
@@ -143,6 +144,7 @@ fun EditContainerScreen(
     var savedVirglExtraFlags by remember { mutableStateOf(container.virglExtraFlags) }
     var savedEnablePulseaudio by remember { mutableStateOf(container.enablePulseaudio) }
     var savedSelinuxPermissive by remember { mutableStateOf(container.selinuxPermissive) }
+    var savedAllowUserns by remember { mutableStateOf(container.allowUserns) }
     var savedVolatileMode by remember { mutableStateOf(container.volatileMode) }
     var savedBindMounts by remember { mutableStateOf(container.bindMounts) }
     var savedDnsServers by remember { mutableStateOf(container.dnsServers) }
@@ -186,6 +188,7 @@ fun EditContainerScreen(
             virglExtraFlags != savedVirglExtraFlags ||
             enablePulseaudio != savedEnablePulseaudio ||
             selinuxPermissive != savedSelinuxPermissive ||
+            allowUserns != savedAllowUserns ||
             volatileMode != savedVolatileMode ||
             bindMounts != savedBindMounts ||
             dnsServers != savedDnsServers ||
@@ -235,6 +238,7 @@ fun EditContainerScreen(
                     virglExtraFlags = virglExtraFlags,
                     enablePulseaudio = enablePulseaudio,
                     selinuxPermissive = selinuxPermissive,
+                    allowUserns = allowUserns,
                     volatileMode = volatileMode,
                     bindMounts = bindMounts,
                     dnsServers = dnsServers,
@@ -275,6 +279,7 @@ fun EditContainerScreen(
                         savedVirglExtraFlags = virglExtraFlags
                         savedEnablePulseaudio = enablePulseaudio
                         savedSelinuxPermissive = selinuxPermissive
+                        savedAllowUserns = allowUserns
                         savedVolatileMode = volatileMode
                         savedBindMounts = bindMounts
                         savedDnsServers = dnsServers
@@ -976,6 +981,17 @@ fun EditContainerScreen(
                 onCheckedChange = {
                     clearFocus()
                     selinuxPermissive = it
+                }
+            )
+
+            ToggleCard(
+                icon = Icons.Default.Security,
+                title = context.getString(R.string.allow_userns),
+                description = context.getString(R.string.allow_userns_description),
+                checked = allowUserns,
+                onCheckedChange = {
+                    clearFocus()
+                    allowUserns = it
                 }
             )
 

--- a/Android/app/src/main/java/com/droidspaces/app/ui/screen/EditContainerScreen.kt
+++ b/Android/app/src/main/java/com/droidspaces/app/ui/screen/EditContainerScreen.kt
@@ -106,6 +106,7 @@ fun EditContainerScreen(
     var bindMounts by remember { mutableStateOf(container.bindMounts) }
     var dnsServers by remember { mutableStateOf(container.dnsServers) }
     var runAtBoot by remember { mutableStateOf(container.runAtBoot) }
+    var enableAnland by remember { mutableStateOf(container.enableAnland) }
     var envFileContent by remember { mutableStateOf(container.envFileContent ?: "") }
     var upstreamInterfaces by remember { mutableStateOf(container.upstreamInterfaces) }
     var portForwards by remember { mutableStateOf(container.portForwards) }
@@ -146,6 +147,7 @@ fun EditContainerScreen(
     var savedBindMounts by remember { mutableStateOf(container.bindMounts) }
     var savedDnsServers by remember { mutableStateOf(container.dnsServers) }
     var savedRunAtBoot by remember { mutableStateOf(container.runAtBoot) }
+    var savedEnableAnland by remember { mutableStateOf(container.enableAnland) }
     var savedEnvFileContent by remember { mutableStateOf(container.envFileContent ?: "") }
     var savedUpstreamInterfaces by remember { mutableStateOf(container.upstreamInterfaces) }
     var savedPortForwards by remember { mutableStateOf(container.portForwards) }
@@ -188,6 +190,7 @@ fun EditContainerScreen(
             bindMounts != savedBindMounts ||
             dnsServers != savedDnsServers ||
             runAtBoot != savedRunAtBoot ||
+            enableAnland != savedEnableAnland ||
             envFileContent != savedEnvFileContent ||
             upstreamInterfaces != savedUpstreamInterfaces ||
             portForwards != savedPortForwards ||
@@ -236,6 +239,7 @@ fun EditContainerScreen(
                     bindMounts = bindMounts,
                     dnsServers = dnsServers,
                     runAtBoot = runAtBoot,
+                    enableAnland = enableAnland,
                     envFileContent = if (envFileContent.isBlank()) null else envFileContent,
                     upstreamInterfaces = upstreamInterfaces,
                     portForwards = portForwards,
@@ -275,6 +279,7 @@ fun EditContainerScreen(
                         savedBindMounts = bindMounts
                         savedDnsServers = dnsServers
                         savedRunAtBoot = runAtBoot
+                        savedEnableAnland = enableAnland
                         savedEnvFileContent = envFileContent
                         savedUpstreamInterfaces = upstreamInterfaces
                         savedPortForwards = portForwards
@@ -1020,6 +1025,17 @@ fun EditContainerScreen(
                 onCheckedChange = {
                     clearFocus()
                     runAtBoot = it
+                }
+            )
+
+            ToggleCard(
+                icon = Icons.Default.DesktopWindows,
+                title = context.getString(R.string.enable_anland),
+                description = context.getString(R.string.enable_anland_description),
+                checked = enableAnland,
+                onCheckedChange = {
+                    clearFocus()
+                    enableAnland = it
                 }
             )
 

--- a/Android/app/src/main/java/com/droidspaces/app/ui/screen/EditContainerScreen.kt
+++ b/Android/app/src/main/java/com/droidspaces/app/ui/screen/EditContainerScreen.kt
@@ -984,15 +984,30 @@ fun EditContainerScreen(
                 }
             )
 
+            val isSeccompDisabled = privileged.contains("noseccomp") || privileged.contains("full")
+
+            //use /proc/self/setgroups to detect userns (only exists when CONFIG_USER_NS is enabled)
+            val usernsSupported = remember { java.io.File("/proc/self/setgroups").exists() }
+
+            LaunchedEffect(isSeccompDisabled, usernsSupported) {
+                if (isSeccompDisabled) blockNestedNs = false
+                if (isSeccompDisabled && usernsSupported) allowUserns = true
+                if (!usernsSupported) allowUserns = false
+            }
+
             ToggleCard(
                 icon = Icons.Default.Security,
                 title = context.getString(R.string.allow_userns),
-                description = context.getString(R.string.allow_userns_description),
+                description = if (usernsSupported)
+                    context.getString(R.string.allow_userns_description)
+                else
+                    context.getString(R.string.allow_userns_description_not_supported),
                 checked = allowUserns,
                 onCheckedChange = {
                     clearFocus()
                     allowUserns = it
-                }
+                },
+                enabled = !isSeccompDisabled && usernsSupported
             )
 
             ToggleCard(
@@ -1016,11 +1031,6 @@ fun EditContainerScreen(
                     forceCgroupv1 = it
                 }
             )
-
-            val isSeccompDisabled = privileged.contains("noseccomp") || privileged.contains("full")
-            LaunchedEffect(isSeccompDisabled) {
-                if (isSeccompDisabled) blockNestedNs = false
-            }
 
             ToggleCard(
                 icon = Icons.Default.GppBad,

--- a/Android/app/src/main/java/com/droidspaces/app/ui/screen/EditContainerScreen.kt
+++ b/Android/app/src/main/java/com/droidspaces/app/ui/screen/EditContainerScreen.kt
@@ -996,7 +996,7 @@ fun EditContainerScreen(
             }
 
             ToggleCard(
-                icon = Icons.Default.Security,
+                icon = Icons.Default.Groups,
                 title = context.getString(R.string.allow_userns),
                 description = if (usernsSupported)
                     context.getString(R.string.allow_userns_description)

--- a/Android/app/src/main/java/com/droidspaces/app/ui/screen/EditContainerScreen.kt
+++ b/Android/app/src/main/java/com/droidspaces/app/ui/screen/EditContainerScreen.kt
@@ -926,6 +926,18 @@ fun EditContainerScreen(
             )
 
             ToggleCard(
+                icon = Icons.Default.DesktopWindows,
+                title = context.getString(R.string.enable_anland),
+                description = context.getString(R.string.enable_anland_description),
+                checked = enableAnland,
+                onCheckedChange = {
+                    clearFocus()
+                    enableAnland = it
+                },
+                enabled = true
+            )
+
+            ToggleCard(
                 icon = Icons.Default.Layers,
                 title = context.getString(R.string.enable_virgl),
                 description = context.getString(R.string.enable_virgl_description),
@@ -1025,17 +1037,6 @@ fun EditContainerScreen(
                 onCheckedChange = {
                     clearFocus()
                     runAtBoot = it
-                }
-            )
-
-            ToggleCard(
-                icon = Icons.Default.DesktopWindows,
-                title = context.getString(R.string.enable_anland),
-                description = context.getString(R.string.enable_anland_description),
-                checked = enableAnland,
-                onCheckedChange = {
-                    clearFocus()
-                    enableAnland = it
                 }
             )
 

--- a/Android/app/src/main/java/com/droidspaces/app/util/AnlandUtils.kt
+++ b/Android/app/src/main/java/com/droidspaces/app/util/AnlandUtils.kt
@@ -1,0 +1,44 @@
+package com.droidspaces.app.util
+
+import android.content.ActivityNotFoundException
+import android.content.ComponentName
+import android.content.Context
+import android.content.Intent
+import android.widget.Toast
+import com.droidspaces.app.R
+
+/**
+ * Helpers for the anland display integration on the app side.
+ */
+object AnlandUtils {
+
+    private const val CONSUMER_PACKAGE = "com.anland.consumer"
+    private const val CONSUMER_ACTIVITY = "com.anland.consumer.SecondaryActivity"
+    // Matches MainActivity.EXTRA_SOCKET_PATH / EXTRA_WINDOW_NAME in the consumer app.
+    private const val EXTRA_SOCKET_PATH = "socket_path"
+    private const val EXTRA_WINDOW_NAME = "window_name"
+
+    /**
+     * Launch the anland consumer app's multi-window activity, pointed at this
+     * container's display socket and titled with the container name. The consumer
+     * dedups by socket path, so re-launching focuses the existing window. Shows a
+     * toast and does nothing if the consumer app isn't installed.
+     */
+    fun launchWindow(context: Context, containerName: String, socketPath: String) {
+        val intent = Intent(Intent.ACTION_MAIN).apply {
+            component = ComponentName(CONSUMER_PACKAGE, CONSUMER_ACTIVITY)
+            putExtra(EXTRA_SOCKET_PATH, socketPath)
+            putExtra(EXTRA_WINDOW_NAME, containerName)
+            addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_MULTIPLE_TASK)
+        }
+        try {
+            context.startActivity(intent)
+        } catch (e: ActivityNotFoundException) {
+            Toast.makeText(
+                context,
+                context.getString(R.string.anland_not_installed),
+                Toast.LENGTH_SHORT
+            ).show()
+        }
+    }
+}

--- a/Android/app/src/main/java/com/droidspaces/app/util/Constants.kt
+++ b/Android/app/src/main/java/com/droidspaces/app/util/Constants.kt
@@ -15,6 +15,7 @@ object Constants {
 
     // Container paths
     const val CONTAINERS_BASE_PATH = "/data/local/Droidspaces/Containers"
+    const val PIDS_BASE_PATH = "/data/local/Droidspaces/Pids"
     const val MODULE_SYSTEM_BIN_PATH = "$MAGISK_MODULE_PATH/system/bin"
     const val SYSTEM_BIN_SYMLINK_PATH = "$MODULE_SYSTEM_BIN_PATH/$DROIDSPACES_BINARY_NAME"
     const val KEY_SYMLINK_ENABLED = "symlink_enabled"

--- a/Android/app/src/main/java/com/droidspaces/app/util/ContainerManager.kt
+++ b/Android/app/src/main/java/com/droidspaces/app/util/ContainerManager.kt
@@ -40,6 +40,7 @@ data class ContainerInfo(
     val virglExtraFlags: String = "",
     val enablePulseaudio: Boolean = false,
     val selinuxPermissive: Boolean = false,
+    val allowUserns: Boolean = false,
     val volatileMode: Boolean = false,
     val bindMounts: List<BindMount> = emptyList(),
     val dnsServers: String = "",
@@ -85,6 +86,7 @@ data class ContainerInfo(
         if (virglExtraFlags.isNotBlank()) appendLine("virgl_extra_flags=$virglExtraFlags")
         appendLine("enable_pulseaudio=${if (enablePulseaudio) "1" else "0"}")
         appendLine("selinux_permissive=${if (selinuxPermissive) "1" else "0"}")
+        appendLine("allow_userns=${if (allowUserns) "1" else "0"}")
         appendLine("volatile_mode=${if (volatileMode) "1" else "0"}")
         if (bindMounts.isNotEmpty()) {
             appendLine("bind_mounts=${bindMounts.joinToString(",") { "${it.src}:${it.dest}${if (it.ro) ":ro" else ""}" }}")
@@ -323,6 +325,7 @@ object ContainerManager {
                 virglExtraFlags = configMap["virgl_extra_flags"] ?: "",
                 enablePulseaudio = configMap["enable_pulseaudio"] == "1",
                 selinuxPermissive = configMap["selinux_permissive"] == "1",
+                allowUserns = configMap["allow_userns"] == "1",
                 volatileMode = configMap["volatile_mode"] == "1",
                 bindMounts = bindMounts,
                 dnsServers = configMap["dns_servers"] ?: "",

--- a/Android/app/src/main/java/com/droidspaces/app/util/ContainerManager.kt
+++ b/Android/app/src/main/java/com/droidspaces/app/util/ContainerManager.kt
@@ -45,6 +45,7 @@ data class ContainerInfo(
     val dnsServers: String = "",
     val runAtBoot: Boolean = false,
     val runAtBootPriority: Int = 0,
+    val enableAnland: Boolean = false,
     val status: ContainerStatus = ContainerStatus.STOPPED,
     val pid: Int? = null,
     val useSparseImage: Boolean = false,
@@ -104,6 +105,7 @@ data class ContainerInfo(
         if (runAtBoot && runAtBootPriority > 0) {
             appendLine("run_at_boot_priority=$runAtBootPriority")
         }
+        appendLine("enable_anland=${if (enableAnland) "1" else "0"}")
         appendLine("force_cgroupv1=${if (forceCgroupv1) "1" else "0"}")
         appendLine("block_nested_ns=${if (blockNestedNs) "1" else "0"}")
         if (netMode == "nat" && staticNatIp.isNotEmpty()) {
@@ -326,6 +328,7 @@ object ContainerManager {
                 dnsServers = configMap["dns_servers"] ?: "",
                 runAtBoot = configMap["run_at_boot"] == "1",
                 runAtBootPriority = configMap["run_at_boot_priority"]?.toIntOrNull() ?: 0,
+                enableAnland = configMap["enable_anland"] == "1",
                 status = ContainerStatus.STOPPED,
                 useSparseImage = useSparseImage,
                 sparseImageSizeGB = sparseImageSizeGB,
@@ -391,6 +394,24 @@ object ContainerManager {
         }
 
         Pair(false, null)
+    }
+
+    /**
+     * Return the anland display-daemon socket path for a running container, or
+     * null if it isn't running / anland isn't active. The native runtime records
+     * the generated per-container socket path in Pids/<name>.anland at start and
+     * removes it on stop, so the presence of a non-empty path also signals that
+     * the anland window can be launched.
+     */
+    suspend fun getAnlandSocket(containerName: String): String? = withContext(Dispatchers.IO) {
+        try {
+            val path = "${Constants.PIDS_BASE_PATH}/$containerName.anland"
+            val result = Shell.cmd("cat \"$path\" 2>/dev/null").exec()
+            val sock = result.out.firstOrNull()?.trim()
+            if (result.isSuccess && !sock.isNullOrEmpty()) sock else null
+        } catch (e: Exception) {
+            null
+        }
     }
 
     /**

--- a/Android/app/src/main/res/values/strings.xml
+++ b/Android/app/src/main/res/values/strings.xml
@@ -205,6 +205,10 @@
     <string name="selinux_permissive_description">Set SELinux permissive</string>
     <string name="run_at_boot">Run at Boot</string>
     <string name="run_at_boot_description">Start container on boot</string>
+    <string name="enable_anland">Anland Display</string>
+    <string name="enable_anland_description">Run the anland display daemon so you can open a desktop window</string>
+    <string name="launch_anland_window">启动 Anland 窗口</string>
+    <string name="anland_not_installed">Anland consumer app is not installed</string>
     <string name="auto_boot_priority">Auto Boot Priority</string>
     <string name="auto_boot_priority_description">Order in which run-at-boot containers start</string>
     <string name="auto_boot_priority_hint">Drag to reorder. Containers start top to bottom - put a gateway (e.g. OpenWRT) first so it boots before the containers that route through it.</string>

--- a/Android/app/src/main/res/values/strings.xml
+++ b/Android/app/src/main/res/values/strings.xml
@@ -151,6 +151,7 @@
     <string name="deadlock_shield_option">Deadlock Shield</string>
     <string name="privileged_option">Privileged</string>
     <string name="anland_option">Anland</string>
+    <string name="userns_option">User Namespaces</string>
     <string name="installation_setup_summary">Installation Summary</string>
     <string name="review_configuration">Review Configuration</string>
     <string name="tarball_label">Tarball</string>
@@ -204,6 +205,8 @@
     <string name="virgl_extra_flags_placeholder">e.g. --multi-clients --angle-vulkan</string>
     <string name="selinux_permissive">SELinux Permissive</string>
     <string name="selinux_permissive_description">Set SELinux permissive</string>
+    <string name="allow_userns">Allow User Namespaces</string>
+    <string name="allow_userns_description">Allow unprivileged user namespaces, which flatpak requires. It may also solve some anland producers running slow. However you may be vulnerable to certain exploits like Fragnesia without a patched kernel.</string>
     <string name="run_at_boot">Run at Boot</string>
     <string name="run_at_boot_description">Start container on boot</string>
     <string name="enable_anland">Anland Display</string>

--- a/Android/app/src/main/res/values/strings.xml
+++ b/Android/app/src/main/res/values/strings.xml
@@ -207,6 +207,7 @@
     <string name="selinux_permissive_description">Set SELinux permissive</string>
     <string name="allow_userns">Allow User Namespaces</string>
     <string name="allow_userns_description">Allow unprivileged user namespaces, which flatpak requires. It may also solve some anland producers running slow. However you may be vulnerable to certain exploits like Fragnesia without a patched kernel.</string>
+    <string name="allow_userns_description_not_supported">Not supported. CONFIG_USER_NS not enabled in kernel.</string>
     <string name="run_at_boot">Run at Boot</string>
     <string name="run_at_boot_description">Start container on boot</string>
     <string name="enable_anland">Anland Display</string>

--- a/Android/app/src/main/res/values/strings.xml
+++ b/Android/app/src/main/res/values/strings.xml
@@ -150,6 +150,7 @@
     <string name="cgroup_v1_option">Cgroup V1</string>
     <string name="deadlock_shield_option">Deadlock Shield</string>
     <string name="privileged_option">Privileged</string>
+    <string name="anland_option">Anland</string>
     <string name="installation_setup_summary">Installation Summary</string>
     <string name="review_configuration">Review Configuration</string>
     <string name="tarball_label">Tarball</string>

--- a/Android/app/src/main/res/values/strings.xml
+++ b/Android/app/src/main/res/values/strings.xml
@@ -207,7 +207,7 @@
     <string name="run_at_boot_description">Start container on boot</string>
     <string name="enable_anland">Anland Display</string>
     <string name="enable_anland_description">Run the anland display daemon so you can open a desktop window</string>
-    <string name="launch_anland_window">启动 Anland 窗口</string>
+    <string name="launch_anland_window">Launch Anland</string>
     <string name="anland_not_installed">Anland consumer app is not installed</string>
     <string name="auto_boot_priority">Auto Boot Priority</string>
     <string name="auto_boot_priority_description">Order in which run-at-boot containers start</string>

--- a/Documentation/resources/kernel-patches/GKI/kernel-6.12/Security/README.md
+++ b/Documentation/resources/kernel-patches/GKI/kernel-6.12/Security/README.md
@@ -31,7 +31,9 @@ The patches in this directory fix security vulnerabilities in specific kernel su
     slab_cross_cache_confusion.patch
     act_pedit.patch
     ssh_keysign_pwn.patch
+    dirty_clone.patch
     (For most kernel build scripts, other patchs are not needed)
 2. not using userns
     bad_epoll.patch (Essential)
     ssh_keysign_pwn.patch
+    dirty_clone.patch

--- a/Documentation/resources/kernel-patches/GKI/kernel-6.12/Security/README.md
+++ b/Documentation/resources/kernel-patches/GKI/kernel-6.12/Security/README.md
@@ -1,0 +1,37 @@
+# Security Patches and Kernel Configuration Mapping (GKI kernel-6.12)
+
+The patches in this directory fix security vulnerabilities in specific kernel subsystems. **A patch is only needed when its corresponding kernel configuration option (CONFIG) is enabled**, because only then is the affected code compiled into the kernel. If a CONFIG is disabled, the matching patch can be skipped.
+
+## Mapping Table
+
+| Patch | Affected files | Required CONFIG | Description |
+| --- | --- | --- | --- |
+| `act_pedit.patch` | `net/sched/act_pedit.c`, `include/net/tc_act/tc_pedit.h` | `CONFIG_NET_ACT_PEDIT` (depends on `CONFIG_NET_SCHED`, `CONFIG_NET_CLS_ACT`) | Out-of-bounds read/write fix in the tc `pedit` traffic-control action |
+| `bad_epoll.patch` | `fs/eventpoll.c` | `CONFIG_EPOLL` | Use-after-free fix for `struct file` / `eventpoll` in epoll |
+| `cifswitch.patch` | `fs/smb/client/cifs_spnego.c` | `CONFIG_CIFS` + `CONFIG_CIFS_UPCALL` | CIFS SPNEGO upcall key description validation |
+| `copy_fail.patch` | `crypto/af_alg.c` | `CONFIG_CRYPTO_USER_API` (and sub-options such as `CONFIG_CRYPTO_USER_API_SKCIPHER` / `AEAD`) | SGL count/offset fix in the AF_ALG userspace crypto interface. No need for Droidspaces as it has secomp blocking AF_ALG |
+| `dirty_frag_esp.patch` | `net/ipv4/esp4.c`, `net/ipv6/esp6.c`, `net/ipv4/ip_output.c`, `net/ipv6/ip6_output.c` | `CONFIG_INET_ESP` and/or `CONFIG_INET6_ESP` (IPsec ESP) | Shared-fragment handling fix in the ESP input path |
+| `dirty_frag_rxrpc.patch` | Same ESP files + `net/rxrpc/*` | `CONFIG_AF_RXRPC` (also includes the ESP changes above, i.e. `CONFIG_INET_ESP` / `CONFIG_INET6_ESP`) | Shared-fragment vulnerability fix triggered via RxRPC |
+| `fragnesia.patch` | `net/core/skbuff.c` | `CONFIG_NET` (core networking, effectively always enabled) | `SKBFL_SHARED_FRAG` flag propagation fix in `skb_try_coalesce` |
+| `pintheft.patch` | `net/rds/message.c` | `CONFIG_RDS` | Pinned-page leak fix on the RDS zerocopy failure path |
+| `slab_cross_cache_confusion.patch` | `net/core/skbuff.c` | `CONFIG_NET` (core networking, effectively always enabled) | Cross-cache confusion fix for the skb small head cache |
+| `ssh_keysign_pwn.patch` | `kernel/ptrace.c`, `kernel/exit.c`, `include/linux/sched.h` | None (ptrace is a core feature, always compiled) | Preserve `dumpable` state after process exit; fixes a ptrace access-check bypass |
+
+## Usage Notes
+
+1. Before applying a patch, check whether the corresponding CONFIG is enabled (`=y` or `=m`) in the target kernel's `.config` (or `defconfig`).
+2. If a CONFIG is disabled (`# CONFIG_XXX is not set`), the vulnerable code is not compiled and the matching patch can be skipped.
+3. Patches marked "core networking / core feature, effectively always enabled" (`fragnesia`, `slab_cross_cache_confusion`, `ssh_keysign_pwn`) should be applied under nearly all configurations.
+
+## Droidspaces
+1. For normal users using userns:
+    copy_fail.patch (No need but for hardening, Optional)
+    bad_epoll.patch (Essential)
+    dirty_frag_esp.patch
+    slab_cross_cache_confusion.patch
+    act_pedit.patch
+    ssh_keysign_pwn.patch
+    (For most kernel build scripts, other patchs are not needed)
+2. not using userns
+    bad_epoll.patch (Essential)
+    ssh_keysign_pwn.patch

--- a/Documentation/resources/kernel-patches/GKI/kernel-6.12/Security/act_pedit.patch
+++ b/Documentation/resources/kernel-patches/GKI/kernel-6.12/Security/act_pedit.patch
@@ -1,0 +1,191 @@
+diff --git a/include/net/tc_act/tc_pedit.h b/include/net/tc_act/tc_pedit.h
+index 83fe39931..a26d4cd3b 100644
+--- a/include/net/tc_act/tc_pedit.h
++++ b/include/net/tc_act/tc_pedit.h
+@@ -14,7 +14,6 @@ struct tcf_pedit_key_ex {
+ struct tcf_pedit_parms {
+ 	struct tc_pedit_key	*tcfp_keys;
+ 	struct tcf_pedit_key_ex	*tcfp_keys_ex;
+-	u32 tcfp_off_max_hint;
+ 	unsigned char tcfp_nkeys;
+ 	unsigned char tcfp_flags;
+ 	struct rcu_head rcu;
+diff --git a/net/sched/act_pedit.c b/net/sched/act_pedit.c
+index fc0a35a7b..71d400bef 100644
+--- a/net/sched/act_pedit.c
++++ b/net/sched/act_pedit.c
+@@ -16,6 +16,9 @@
+ #include <linux/ip.h>
+ #include <linux/ipv6.h>
+ #include <linux/slab.h>
++#include <linux/overflow.h>
++#include <linux/unaligned.h>
++#include <net/ip.h>
+ #include <net/ipv6.h>
+ #include <net/netlink.h>
+ #include <net/pkt_sched.h>
+@@ -242,7 +245,6 @@ static int tcf_pedit_init(struct net *net, struct nlattr *nla,
+ 		goto out_free_ex;
+ 	}
+ 
+-	nparms->tcfp_off_max_hint = 0;
+ 	nparms->tcfp_flags = parm->flags;
+ 	nparms->tcfp_nkeys = parm->nkeys;
+ 
+@@ -267,15 +269,6 @@ static int tcf_pedit_init(struct net *net, struct nlattr *nla,
+ 		nparms->tcfp_keys[i].shift = min_t(size_t,
+ 						   BITS_PER_TYPE(int) - 1,
+ 						   nparms->tcfp_keys[i].shift);
+-
+-		/* The AT option can read a single byte, we can bound the actual
+-		 * value with uchar max.
+-		 */
+-		cur += (0xff & offmask) >> nparms->tcfp_keys[i].shift;
+-
+-		/* Each key touches 4 bytes starting from the computed offset */
+-		nparms->tcfp_off_max_hint =
+-			max(nparms->tcfp_off_max_hint, cur + 4);
+ 	}
+ 
+ 	p = to_pedit(*a);
+@@ -318,15 +311,12 @@ static void tcf_pedit_cleanup(struct tc_action *a)
+ 		call_rcu(&parms->rcu, tcf_pedit_cleanup_rcu);
+ }
+ 
+-static bool offset_valid(struct sk_buff *skb, int offset)
++static bool offset_valid(struct sk_buff *skb, int offset, int len)
+ {
+-	if (offset > 0 && offset > skb->len)
+-		return false;
+-
+-	if  (offset < 0 && -offset > skb_headroom(skb))
++	if (offset < -(int)skb_headroom(skb))
+ 		return false;
+ 
+-	return true;
++	return offset <= (int)skb->len - len;
+ }
+ 
+ static int pedit_l4_skb_offset(struct sk_buff *skb, int *hoffset, const int header_type)
+@@ -341,6 +331,9 @@ static int pedit_l4_skb_offset(struct sk_buff *skb, int *hoffset, const int head
+ 
+ 		if (!iph)
+ 			goto out;
++		if (iph->ihl < 5 || iph->protocol != header_type ||
++		    (iph->frag_off & htons(IP_OFFSET)))
++			goto out;
+ 		*hoffset = noff + iph->ihl * 4;
+ 		ret = 0;
+ 		break;
+@@ -393,18 +386,10 @@ TC_INDIRECT_SCOPE int tcf_pedit_act(struct sk_buff *skb,
+ 	struct tcf_pedit_key_ex *tkey_ex;
+ 	struct tcf_pedit_parms *parms;
+ 	struct tc_pedit_key *tkey;
+-	u32 max_offset;
+ 	int i;
+ 
+ 	parms = rcu_dereference_bh(p->parms);
+ 
+-	max_offset = (skb_transport_header_was_set(skb) ?
+-		      skb_transport_offset(skb) :
+-		      skb_network_offset(skb)) +
+-		     parms->tcfp_off_max_hint;
+-	if (skb_ensure_writable(skb, min(skb->len, max_offset)))
+-		goto done;
+-
+ 	tcf_lastuse_update(&p->tcf_tm);
+ 	tcf_action_update_bstats(&p->common, skb);
+ 
+@@ -412,10 +397,11 @@ TC_INDIRECT_SCOPE int tcf_pedit_act(struct sk_buff *skb,
+ 	tkey_ex = parms->tcfp_keys_ex;
+ 
+ 	for (i = parms->tcfp_nkeys; i > 0; i--, tkey++) {
++		int write_offset, write_len;
+ 		int offset = tkey->off;
+ 		int hoffset = 0;
+-		u32 *ptr, hdata;
+-		u32 val;
++		u32 cur_val, val;
++		u32 *ptr;
+ 		int rc;
+ 
+ 		if (tkey_ex) {
+@@ -433,13 +419,15 @@ TC_INDIRECT_SCOPE int tcf_pedit_act(struct sk_buff *skb,
+ 
+ 		if (tkey->offmask) {
+ 			u8 *d, _d;
++			int at_offset;
+ 
+-			if (!offset_valid(skb, hoffset + tkey->at)) {
++			if (check_add_overflow(hoffset, (int)tkey->at, &at_offset) ||
++			    !offset_valid(skb, at_offset, sizeof(_d))) {
+ 				pr_info_ratelimited("tc action pedit 'at' offset %d out of bounds\n",
+ 						    hoffset + tkey->at);
+ 				goto bad;
+ 			}
+-			d = skb_header_pointer(skb, hoffset + tkey->at,
++			d = skb_header_pointer(skb, at_offset,
+ 					       sizeof(_d), &_d);
+ 			if (!d)
+ 				goto bad;
+@@ -451,31 +439,51 @@ TC_INDIRECT_SCOPE int tcf_pedit_act(struct sk_buff *skb,
+ 			}
+ 		}
+ 
+-		if (!offset_valid(skb, hoffset + offset)) {
+-			pr_info_ratelimited("tc action pedit offset %d out of bounds\n", hoffset + offset);
++		if (check_add_overflow(hoffset, offset, &write_offset)) {
++			pr_info_ratelimited("tc action pedit offset overflow\n");
+ 			goto bad;
+ 		}
+ 
+-		ptr = skb_header_pointer(skb, hoffset + offset,
+-					 sizeof(hdata), &hdata);
+-		if (!ptr)
++		if (!offset_valid(skb, write_offset, sizeof(*ptr))) {
++			pr_info_ratelimited("tc action pedit offset %d out of bounds\n",
++					    write_offset);
+ 			goto bad;
++		}
++
++		if (write_offset < 0) {
++			if (skb_cow(skb, -write_offset))
++				goto bad;
++			if (write_offset + (int)sizeof(*ptr) > 0) {
++				if (skb_ensure_writable(skb,
++							min_t(int, skb->len,
++							      write_offset + (int)sizeof(*ptr))))
++					goto bad;
++			}
++		} else {
++			if (check_add_overflow(write_offset, (int)sizeof(*ptr),
++					       &write_len))
++				goto bad;
++			if (skb_ensure_writable(skb, min_t(int, skb->len,
++							   write_len)))
++				goto bad;
++		}
++
++		ptr = (u32 *)(skb->data + write_offset);
++		cur_val = get_unaligned(ptr);
+ 		/* just do it, baby */
+ 		switch (cmd) {
+ 		case TCA_PEDIT_KEY_EX_CMD_SET:
+ 			val = tkey->val;
+ 			break;
+ 		case TCA_PEDIT_KEY_EX_CMD_ADD:
+-			val = (*ptr + tkey->val) & ~tkey->mask;
++			val = (cur_val + tkey->val) & ~tkey->mask;
+ 			break;
+ 		default:
+ 			pr_info_ratelimited("tc action pedit bad command (%d)\n", cmd);
+ 			goto bad;
+ 		}
+ 
+-		*ptr = ((*ptr & tkey->mask) ^ val);
+-		if (ptr == &hdata)
+-			skb_store_bits(skb, hoffset + offset, ptr, 4);
++		put_unaligned((cur_val & tkey->mask) ^ val, ptr);
+ 	}
+ 
+ 	goto done;

--- a/Documentation/resources/kernel-patches/GKI/kernel-6.12/Security/bad_epoll.patch
+++ b/Documentation/resources/kernel-patches/GKI/kernel-6.12/Security/bad_epoll.patch
@@ -1,0 +1,95 @@
+commit 2a29f4ed50f38379b4a94cef434175eb003c14f3
+Author: Yibo Wang <2024312277@stu.hit.edu.cn>
+Date:   Mon Jul 6 21:17:41 2026 +0800
+
+    fixe bad epoll
+
+diff --git a/fs/eventpoll.c b/fs/eventpoll.c
+index a605368d7..dbcae9e79 100644
+--- a/fs/eventpoll.c
++++ b/fs/eventpoll.c
+@@ -799,6 +799,8 @@ static void ep_free(struct eventpoll *ep)
+ 	kfree_rcu(ep, rcu);
+ }
+ 
++static struct file *epi_fget(const struct epitem *epi);
++
+ /*
+  * Removes a "struct epitem" from the eventpoll RB tree and deallocates
+  * all the associated resources. Must be called with "mtx" held.
+@@ -820,13 +822,34 @@ static bool __ep_remove(struct eventpoll *ep, struct epitem *epi, bool force)
+ 	 */
+ 	ep_unregister_pollwait(ep, epi);
+ 
+-	/* Remove the current item from the list of epoll hooks */
+-	spin_lock(&file->f_lock);
+-	if (epi->dying && !force) {
+-		spin_unlock(&file->f_lock);
+-		return false;
++	if (!force) {
++		/* cheap sync with eventpoll_release_file() */
++		if (unlikely(READ_ONCE(epi->dying)))
++			return false;
++
++		/*
++		 * If we manage to grab a reference it means we're not in
++		 * eventpoll_release_file() and aren't going to be. Pinning
++		 * @file keeps it from reaching refcount zero and starting
++		 * __fput() while we clear and dereference file->f_ep and use
++		 * @file inside the f_lock critical section below, closing the
++		 * struct file / watched struct eventpoll UAF. A successful pin
++		 * also proves we are not racing eventpoll_release_file() on
++		 * this epi, so the redundant re-check of epi->dying under
++		 * f_lock is dropped.
++		 *
++		 * If the pin fails @file has already reached refcount zero and
++		 * its __fput() is in flight; because we bail before clearing
++		 * f_ep that path takes the eventpoll_release() slow path into
++		 * eventpoll_release_file(), which removes the epi under ep->mtx.
++		 */
++		file = epi_fget(epi);
++		if (!file)
++			return false;
+ 	}
+ 
++	/* Remove the current item from the list of epoll hooks */
++	spin_lock(&file->f_lock);
+ 	to_free = NULL;
+ 	head = file->f_ep;
+ 	if (head->first == &epi->fllink && !epi->fllink.next) {
+@@ -861,6 +884,11 @@ static bool __ep_remove(struct eventpoll *ep, struct epitem *epi, bool force)
+ 	kfree_rcu(epi, rcu);
+ 
+ 	percpu_counter_dec(&ep->user->epoll_watches);
++
++	/* Drop the reference pinned above; not taken on the force path. */
++	if (!force)
++		fput(file);
++
+ 	return true;
+ }
+ 
+diff --git a/fs/eventpoll.c b/fs/eventpoll.c
+index 5714e900567c4..4b43bf41296d4 100644
+--- a/fs/eventpoll.c
++++ b/fs/eventpoll.c
+@@ -226,6 +226,9 @@ struct eventpoll {
+ 	 */
+ 	refcount_t refcount;
+ 
++	/* used to defer freeing past ep_get_upwards_depth_proc() RCU walk */
++	struct rcu_head rcu;
++
+ #ifdef CONFIG_NET_RX_BUSY_POLL
+ 	/* used to track busy poll napi_id */
+ 	unsigned int napi_id;
+@@ -819,7 +822,8 @@ static void ep_free(struct eventpoll *ep)
+ 	mutex_destroy(&ep->mtx);
+ 	free_uid(ep->user);
+ 	wakeup_source_unregister(ep->ws);
+-	kfree(ep);
++	/* ep_get_upwards_depth_proc() may still hold epi->ep under RCU */
++	kfree_rcu(ep, rcu);
+ }
+ 
+ /*

--- a/Documentation/resources/kernel-patches/GKI/kernel-6.12/Security/cifswitch.patch
+++ b/Documentation/resources/kernel-patches/GKI/kernel-6.12/Security/cifswitch.patch
@@ -1,0 +1,40 @@
+diff --git a/fs/smb/client/cifs_spnego.c b/fs/smb/client/cifs_spnego.c
+index bc1c1e9b2..507985939 100644
+--- a/fs/smb/client/cifs_spnego.c
++++ b/fs/smb/client/cifs_spnego.c
+@@ -8,6 +8,7 @@
+  */
+ 
+ #include <linux/list.h>
++#include <linux/cred.h>
+ #include <linux/slab.h>
+ #include <linux/string.h>
+ #include <keys/user-type.h>
+@@ -46,12 +47,27 @@ cifs_spnego_key_destroy(struct key *key)
+ 	kfree(key->payload.data[0]);
+ }
+ 
++static int
++cifs_spnego_key_vet_description(const char *description)
++{
++	/*
++	 * cifs.spnego descriptions are authority-bearing inputs to cifs.upcall.
++	 * They are only valid when produced by CIFS while using the private
++	 * spnego_cred installed below.  Do not let userspace create this type
++	 * of key through request_key(2)/add_key(2), since the helper treats
++	 * pid/uid/creduid/upcall_target as kernel-originating fields.
++	 */
++	if (current_cred() != spnego_cred)
++		return -EPERM;
++	return 0;
++}
+ 
+ /*
+  * keytype for CIFS spnego keys
+  */
+ struct key_type cifs_spnego_key_type = {
+ 	.name		= "cifs.spnego",
++	.vet_description = cifs_spnego_key_vet_description,
+ 	.instantiate	= cifs_spnego_key_instantiate,
+ 	.destroy	= cifs_spnego_key_destroy,
+ 	.describe	= user_describe,

--- a/Documentation/resources/kernel-patches/GKI/kernel-6.12/Security/copy_fail.patch
+++ b/Documentation/resources/kernel-patches/GKI/kernel-6.12/Security/copy_fail.patch
@@ -1,0 +1,303 @@
+diff --git a/crypto/af_alg.c b/crypto/af_alg.c
+index ca6fdcc6c..4ff3b3064 100644
+--- a/crypto/af_alg.c
++++ b/crypto/af_alg.c
+@@ -635,15 +635,13 @@ static int af_alg_alloc_tsgl(struct sock *sk)
+ /**
+  * af_alg_count_tsgl - Count number of TX SG entries
+  *
+- * The counting starts from the beginning of the SGL to @bytes. If
+- * an @offset is provided, the counting of the SG entries starts at the @offset.
++ * The counting starts from the beginning of the SGL to @bytes.
+  *
+  * @sk: socket of connection to user space
+  * @bytes: Count the number of SG entries holding given number of bytes.
+- * @offset: Start the counting of SG entries from the given offset.
+  * Return: Number of TX SG entries found given the constraints
+  */
+-unsigned int af_alg_count_tsgl(struct sock *sk, size_t bytes, size_t offset)
++unsigned int af_alg_count_tsgl(struct sock *sk, size_t bytes)
+ {
+ 	const struct alg_sock *ask = alg_sk(sk);
+ 	const struct af_alg_ctx *ctx = ask->private;
+@@ -658,25 +656,11 @@ unsigned int af_alg_count_tsgl(struct sock *sk, size_t bytes, size_t offset)
+ 		const struct scatterlist *sg = sgl->sg;
+ 
+ 		for (i = 0; i < sgl->cur; i++) {
+-			size_t bytes_count;
+-
+-			/* Skip offset */
+-			if (offset >= sg[i].length) {
+-				offset -= sg[i].length;
+-				bytes -= sg[i].length;
+-				continue;
+-			}
+-
+-			bytes_count = sg[i].length - offset;
+-
+-			offset = 0;
+ 			sgl_count++;
+-
+-			/* If we have seen requested number of bytes, stop */
+-			if (bytes_count >= bytes)
++			if (sg[i].length >= bytes)
+ 				return sgl_count;
+ 
+-			bytes -= bytes_count;
++			bytes -= sg[i].length;
+ 		}
+ 	}
+ 
+@@ -688,19 +672,14 @@ EXPORT_SYMBOL_GPL(af_alg_count_tsgl);
+  * af_alg_pull_tsgl - Release the specified buffers from TX SGL
+  *
+  * If @dst is non-null, reassign the pages to @dst. The caller must release
+- * the pages. If @dst_offset is given only reassign the pages to @dst starting
+- * at the @dst_offset (byte). The caller must ensure that @dst is large
+- * enough (e.g. by using af_alg_count_tsgl with the same offset).
++ * the pages.
+  *
+  * @sk: socket of connection to user space
+  * @used: Number of bytes to pull from TX SGL
+  * @dst: If non-NULL, buffer is reassigned to dst SGL instead of releasing. The
+  *	 caller must release the buffers in dst.
+- * @dst_offset: Reassign the TX SGL from given offset. All buffers before
+- *	        reaching the offset is released.
+  */
+-void af_alg_pull_tsgl(struct sock *sk, size_t used, struct scatterlist *dst,
+-		      size_t dst_offset)
++void af_alg_pull_tsgl(struct sock *sk, size_t used, struct scatterlist *dst)
+ {
+ 	struct alg_sock *ask = alg_sk(sk);
+ 	struct af_alg_ctx *ctx = ask->private;
+@@ -725,18 +704,10 @@ void af_alg_pull_tsgl(struct sock *sk, size_t used, struct scatterlist *dst,
+ 			 * SG entries in dst.
+ 			 */
+ 			if (dst) {
+-				if (dst_offset >= plen) {
+-					/* discard page before offset */
+-					dst_offset -= plen;
+-				} else {
+-					/* reassign page to dst after offset */
+-					get_page(page);
+-					sg_set_page(dst + j, page,
+-						    plen - dst_offset,
+-						    sg[i].offset + dst_offset);
+-					dst_offset = 0;
+-					j++;
+-				}
++				/* reassign page to dst after offset */
++				get_page(page);
++				sg_set_page(dst + j, page, plen, sg[i].offset);
++				j++;
+ 			}
+ 
+ 			sg[i].length -= plen;
+diff --git a/crypto/algif_aead.c b/crypto/algif_aead.c
+index 7d58cbbce..25bce8cd9 100644
+--- a/crypto/algif_aead.c
++++ b/crypto/algif_aead.c
+@@ -26,7 +26,6 @@
+ #include <crypto/internal/aead.h>
+ #include <crypto/scatterwalk.h>
+ #include <crypto/if_alg.h>
+-#include <crypto/skcipher.h>
+ #include <crypto/null.h>
+ #include <linux/init.h>
+ #include <linux/list.h>
+@@ -96,9 +95,8 @@ static int _aead_recvmsg(struct socket *sock, struct msghdr *msg,
+ 	struct aead_tfm *aeadc = pask->private;
+ 	struct crypto_aead *tfm = aeadc->aead;
+ 	struct crypto_sync_skcipher *null_tfm = aeadc->null_tfm;
+-	unsigned int i, as = crypto_aead_authsize(tfm);
++	unsigned int as = crypto_aead_authsize(tfm);
+ 	struct af_alg_async_req *areq;
+-	struct af_alg_tsgl *tsgl, *tmp;
+ 	struct scatterlist *rsgl_src, *tsgl_src = NULL;
+ 	int err = 0;
+ 	size_t used = 0;		/* [in]  TX bufs to be en/decrypted */
+@@ -178,23 +176,24 @@ static int _aead_recvmsg(struct socket *sock, struct msghdr *msg,
+ 		outlen -= less;
+ 	}
+ 
++	/*
++	 * Create a per request TX SGL for this request which tracks the
++	 * SG entries from the global TX SGL.
++	 */
+ 	processed = used + ctx->aead_assoclen;
+-	list_for_each_entry_safe(tsgl, tmp, &ctx->tsgl_list, list) {
+-		for (i = 0; i < tsgl->cur; i++) {
+-			struct scatterlist *process_sg = tsgl->sg + i;
+-
+-			if (!(process_sg->length) || !sg_page(process_sg))
+-				continue;
+-			tsgl_src = process_sg;
+-			break;
+-		}
+-		if (tsgl_src)
+-			break;
+-	}
+-	if (processed && !tsgl_src) {
+-		err = -EFAULT;
++	areq->tsgl_entries = af_alg_count_tsgl(sk, processed);
++	if (!areq->tsgl_entries)
++		areq->tsgl_entries = 1;
++	areq->tsgl = sock_kmalloc(sk, array_size(sizeof(*areq->tsgl),
++					         areq->tsgl_entries),
++				  GFP_KERNEL);
++	if (!areq->tsgl) {
++		err = -ENOMEM;
+ 		goto free;
+ 	}
++	sg_init_table(areq->tsgl, areq->tsgl_entries);
++	af_alg_pull_tsgl(sk, processed, areq->tsgl);
++	tsgl_src = areq->tsgl;
+ 
+ 	/*
+ 	 * Copy of AAD from source to destination
+@@ -203,83 +202,18 @@ static int _aead_recvmsg(struct socket *sock, struct msghdr *msg,
+ 	 * when user space uses an in-place cipher operation, the kernel
+ 	 * will copy the data as it does not see whether such in-place operation
+ 	 * is initiated.
+-	 *
+-	 * To ensure efficiency, the following implementation ensure that the
+-	 * ciphers are invoked to perform a crypto operation in-place. This
+-	 * is achieved by memory management specified as follows.
+ 	 */
+ 
+ 	/* Use the RX SGL as source (and destination) for crypto op. */
+ 	rsgl_src = areq->first_rsgl.sgl.sgt.sgl;
+-
+-	if (ctx->enc) {
+-		/*
+-		 * Encryption operation - The in-place cipher operation is
+-		 * achieved by the following operation:
+-		 *
+-		 * TX SGL: AAD || PT
+-		 *	    |	   |
+-		 *	    | copy |
+-		 *	    v	   v
+-		 * RX SGL: AAD || PT || Tag
+-		 */
+-		err = crypto_aead_copy_sgl(null_tfm, tsgl_src,
+-					   areq->first_rsgl.sgl.sgt.sgl,
+-					   processed);
+-		if (err)
+-			goto free;
+-		af_alg_pull_tsgl(sk, processed, NULL, 0);
+-	} else {
+-		/*
+-		 * Decryption operation - To achieve an in-place cipher
+-		 * operation, the following  SGL structure is used:
+-		 *
+-		 * TX SGL: AAD || CT || Tag
+-		 *	    |	   |	 ^
+-		 *	    | copy |	 | Create SGL link.
+-		 *	    v	   v	 |
+-		 * RX SGL: AAD || CT ----+
+-		 */
+-
+-		 /* Copy AAD || CT to RX SGL buffer for in-place operation. */
+-		err = crypto_aead_copy_sgl(null_tfm, tsgl_src,
+-					   areq->first_rsgl.sgl.sgt.sgl,
+-					   outlen);
+-		if (err)
+-			goto free;
+-
+-		/* Create TX SGL for tag and chain it to RX SGL. */
+-		areq->tsgl_entries = af_alg_count_tsgl(sk, processed,
+-						       processed - as);
+-		if (!areq->tsgl_entries)
+-			areq->tsgl_entries = 1;
+-		areq->tsgl = sock_kmalloc(sk, array_size(sizeof(*areq->tsgl),
+-							 areq->tsgl_entries),
+-					  GFP_KERNEL);
+-		if (!areq->tsgl) {
+-			err = -ENOMEM;
+-			goto free;
+-		}
+-		sg_init_table(areq->tsgl, areq->tsgl_entries);
+-
+-		/* Release TX SGL, except for tag data and reassign tag data. */
+-		af_alg_pull_tsgl(sk, processed, areq->tsgl, processed - as);
+-
+-		/* chain the areq TX SGL holding the tag with RX SGL */
+-		if (usedpages) {
+-			/* RX SGL present */
+-			struct af_alg_sgl *sgl_prev = &areq->last_rsgl->sgl;
+-			struct scatterlist *sg = sgl_prev->sgt.sgl;
+-
+-			sg_unmark_end(sg + sgl_prev->sgt.nents - 1);
+-			sg_chain(sg, sgl_prev->sgt.nents + 1, areq->tsgl);
+-		} else
+-			/* no RX SGL present (e.g. authentication only) */
+-			rsgl_src = areq->tsgl;
+-	}
++	err = crypto_aead_copy_sgl(null_tfm, tsgl_src,
++					rsgl_src,
++					ctx->aead_assoclen);
++	if (err)
++		goto free;
+ 
+ 	/* Initialize the crypto operation */
+-	aead_request_set_crypt(&areq->cra_u.aead_req, rsgl_src,
++	aead_request_set_crypt(&areq->cra_u.aead_req, tsgl_src,
+ 			       areq->first_rsgl.sgl.sgt.sgl, used, ctx->iv);
+ 	aead_request_set_ad(&areq->cra_u.aead_req, ctx->aead_assoclen);
+ 	aead_request_set_tfm(&areq->cra_u.aead_req, tfm);
+@@ -514,7 +448,7 @@ static void aead_sock_destruct(struct sock *sk)
+ 	struct crypto_aead *tfm = aeadc->aead;
+ 	unsigned int ivlen = crypto_aead_ivsize(tfm);
+ 
+-	af_alg_pull_tsgl(sk, ctx->used, NULL, 0);
++	af_alg_pull_tsgl(sk, ctx->used, NULL);
+ 	sock_kzfree_s(sk, ctx->iv, ivlen);
+ 	sock_kfree_s(sk, ctx, ctx->len);
+ 	af_alg_release_parent(sk);
+diff --git a/crypto/algif_skcipher.c b/crypto/algif_skcipher.c
+index 125d395c5..82735e51b 100644
+--- a/crypto/algif_skcipher.c
++++ b/crypto/algif_skcipher.c
+@@ -138,7 +138,7 @@ static int _skcipher_recvmsg(struct socket *sock, struct msghdr *msg,
+ 	 * Create a per request TX SGL for this request which tracks the
+ 	 * SG entries from the global TX SGL.
+ 	 */
+-	areq->tsgl_entries = af_alg_count_tsgl(sk, len, 0);
++	areq->tsgl_entries = af_alg_count_tsgl(sk, len);
+ 	if (!areq->tsgl_entries)
+ 		areq->tsgl_entries = 1;
+ 	areq->tsgl = sock_kmalloc(sk, array_size(sizeof(*areq->tsgl),
+@@ -149,7 +149,7 @@ static int _skcipher_recvmsg(struct socket *sock, struct msghdr *msg,
+ 		goto free;
+ 	}
+ 	sg_init_table(areq->tsgl, areq->tsgl_entries);
+-	af_alg_pull_tsgl(sk, len, areq->tsgl, 0);
++	af_alg_pull_tsgl(sk, len, areq->tsgl);
+ 
+ 	/* Initialize the crypto operation */
+ 	skcipher_request_set_tfm(&areq->cra_u.skcipher_req, tfm);
+@@ -363,7 +363,7 @@ static void skcipher_sock_destruct(struct sock *sk)
+ 	struct alg_sock *pask = alg_sk(psk);
+ 	struct crypto_skcipher *tfm = pask->private;
+ 
+-	af_alg_pull_tsgl(sk, ctx->used, NULL, 0);
++	af_alg_pull_tsgl(sk, ctx->used, NULL);
+ 	sock_kzfree_s(sk, ctx->iv, crypto_skcipher_ivsize(tfm));
+ 	if (ctx->state)
+ 		sock_kzfree_s(sk, ctx->state, crypto_skcipher_statesize(tfm));
+diff --git a/include/crypto/if_alg.h b/include/crypto/if_alg.h
+index 107b797c3..0cc8fa749 100644
+--- a/include/crypto/if_alg.h
++++ b/include/crypto/if_alg.h
+@@ -230,9 +230,8 @@ static inline bool af_alg_readable(struct sock *sk)
+ 	return PAGE_SIZE <= af_alg_rcvbuf(sk);
+ }
+ 
+-unsigned int af_alg_count_tsgl(struct sock *sk, size_t bytes, size_t offset);
+-void af_alg_pull_tsgl(struct sock *sk, size_t used, struct scatterlist *dst,
+-		      size_t dst_offset);
++unsigned int af_alg_count_tsgl(struct sock *sk, size_t bytes);
++void af_alg_pull_tsgl(struct sock *sk, size_t used, struct scatterlist *dst);
+ void af_alg_wmem_wakeup(struct sock *sk);
+ int af_alg_wait_for_data(struct sock *sk, unsigned flags, unsigned min);
+ int af_alg_sendmsg(struct socket *sock, struct msghdr *msg, size_t size,

--- a/Documentation/resources/kernel-patches/GKI/kernel-6.12/Security/dirty_frag_esp.patch
+++ b/Documentation/resources/kernel-patches/GKI/kernel-6.12/Security/dirty_frag_esp.patch
@@ -1,0 +1,55 @@
+diff --git a/net/ipv4/esp4.c b/net/ipv4/esp4.c
+index cbe4c6fc8..c0df2a6d6 100644
+--- a/net/ipv4/esp4.c
++++ b/net/ipv4/esp4.c
+@@ -869,7 +869,8 @@ static int esp_input(struct xfrm_state *x, struct sk_buff *skb)
+ 			nfrags = 1;
+ 
+ 			goto skip_cow;
+-		} else if (!skb_has_frag_list(skb)) {
++		} else if (!skb_has_frag_list(skb) &&
++			   !skb_has_shared_frag(skb)) {
+ 			nfrags = skb_shinfo(skb)->nr_frags;
+ 			nfrags++;
+ 
+diff --git a/net/ipv4/ip_output.c b/net/ipv4/ip_output.c
+index 0bda561aa..ba51fc425 100644
+--- a/net/ipv4/ip_output.c
++++ b/net/ipv4/ip_output.c
+@@ -1231,6 +1231,8 @@ static int __ip_append_data(struct sock *sk,
+ 			if (err < 0)
+ 				goto error;
+ 			copy = err;
++			if (!(flags & MSG_NO_SHARED_FRAGS))
++				skb_shinfo(skb)->flags |= SKBFL_SHARED_FRAG;
+ 			wmem_alloc_delta += copy;
+ 		} else if (!zc) {
+ 			int i = skb_shinfo(skb)->nr_frags;
+diff --git a/net/ipv6/esp6.c b/net/ipv6/esp6.c
+index 62d17d7f6..6b747c3eb 100644
+--- a/net/ipv6/esp6.c
++++ b/net/ipv6/esp6.c
+@@ -911,7 +911,8 @@ static int esp6_input(struct xfrm_state *x, struct sk_buff *skb)
+ 			nfrags = 1;
+ 
+ 			goto skip_cow;
+-		} else if (!skb_has_frag_list(skb)) {
++		} else if (!skb_has_frag_list(skb) &&
++			   !skb_has_shared_frag(skb)) {
+ 			nfrags = skb_shinfo(skb)->nr_frags;
+ 			nfrags++;
+ 
+diff --git a/net/ipv6/ip6_output.c b/net/ipv6/ip6_output.c
+index f0e5431c2..74224a3d0 100644
+--- a/net/ipv6/ip6_output.c
++++ b/net/ipv6/ip6_output.c
+@@ -1753,6 +1753,8 @@ static int __ip6_append_data(struct sock *sk,
+ 			if (err < 0)
+ 				goto error;
+ 			copy = err;
++			if (!(flags & MSG_NO_SHARED_FRAGS))
++				skb_shinfo(skb)->flags |= SKBFL_SHARED_FRAG;
+ 			wmem_alloc_delta += copy;
+ 		} else if (!zc) {
+ 			int i = skb_shinfo(skb)->nr_frags;
+

--- a/Documentation/resources/kernel-patches/GKI/kernel-6.12/Security/dirty_frag_rxrpc.patch
+++ b/Documentation/resources/kernel-patches/GKI/kernel-6.12/Security/dirty_frag_rxrpc.patch
@@ -1,0 +1,484 @@
+diff --git a/net/rxrpc/ar-internal.h b/net/rxrpc/ar-internal.h
+index 6b036c056..f5965c541 100644
+--- a/net/rxrpc/ar-internal.h
++++ b/net/rxrpc/ar-internal.h
+@@ -1253,7 +1253,6 @@ int rxrpc_server_keyring(struct rxrpc_sock *, sockptr_t, int);
+ void rxrpc_kernel_data_consumed(struct rxrpc_call *, struct sk_buff *);
+ void rxrpc_new_skb(struct sk_buff *, enum rxrpc_skb_trace);
+ void rxrpc_see_skb(struct sk_buff *, enum rxrpc_skb_trace);
+-void rxrpc_eaten_skb(struct sk_buff *, enum rxrpc_skb_trace);
+ void rxrpc_get_skb(struct sk_buff *, enum rxrpc_skb_trace);
+ void rxrpc_free_skb(struct sk_buff *, enum rxrpc_skb_trace);
+ void rxrpc_purge_queue(struct sk_buff_head *);
+diff --git a/net/rxrpc/call_event.c b/net/rxrpc/call_event.c
+index 7bbb68504..46a502ffd 100644
+--- a/net/rxrpc/call_event.c
++++ b/net/rxrpc/call_event.c
+@@ -342,8 +342,26 @@ bool rxrpc_input_call_event(struct rxrpc_call *call, struct sk_buff *skb)
+ 	if (skb && skb->mark == RXRPC_SKB_MARK_ERROR)
+ 		goto out;
+ 
+-	if (skb)
+-		rxrpc_input_call_packet(call, skb);
++	if (skb) {
++		struct rxrpc_skb_priv *sp = rxrpc_skb(skb);
++
++		if (sp->hdr.type == RXRPC_PACKET_TYPE_DATA &&
++		    sp->hdr.securityIndex != 0 &&
++		    (skb_cloned(skb) ||
++		     skb_has_frag_list(skb) ||
++	     skb_has_shared_frag(skb))) {
++			struct sk_buff *nskb = skb_copy(skb, GFP_ATOMIC);
++			if (nskb) {
++				rxrpc_new_skb(nskb, rxrpc_skb_new_unshared);
++				rxrpc_input_call_packet(call, nskb);
++				rxrpc_free_skb(nskb, rxrpc_skb_put_call_rx);
++			} else {
++				rxrpc_see_skb(skb, rxrpc_skb_see_unshare_nomem);
++			}
++		} else {
++			rxrpc_input_call_packet(call, skb);
++		}
++	}
+ 
+ 	/* If we see our async-event poke, check for timeout trippage. */
+ 	now = ktime_get_real();
+diff --git a/net/rxrpc/conn_event.c b/net/rxrpc/conn_event.c
+index c4eb7986e..70e27aa46 100644
+--- a/net/rxrpc/conn_event.c
++++ b/net/rxrpc/conn_event.c
+@@ -226,6 +226,34 @@ static void rxrpc_call_is_secure(struct rxrpc_call *call)
+ 		rxrpc_notify_socket(call);
+ }
+ 
++static int rxrpc_verify_response(struct rxrpc_connection *conn,
++				 struct sk_buff *skb)
++{
++	int ret;
++
++	if (skb_cloned(skb) || skb_has_frag_list(skb) ||
++	    skb_has_shared_frag(skb)) {
++		/* Copy the packet if shared so that we can do in-place
++		 * decryption.
++		 */
++		struct sk_buff *nskb = skb_copy(skb, GFP_NOFS);
++
++		if (nskb) {
++			rxrpc_new_skb(nskb, rxrpc_skb_new_unshared);
++			ret = conn->security->verify_response(conn, nskb);
++			rxrpc_free_skb(nskb, rxrpc_skb_put_response_copy);
++		} else {
++			/* OOM - Drop the packet. */
++			rxrpc_see_skb(skb, rxrpc_skb_see_unshare_nomem);
++			ret = -ENOMEM;
++		}
++	} else {
++		ret = conn->security->verify_response(conn, skb);
++	}
++
++	return ret;
++}
++
+ /*
+  * connection-level Rx packet processor
+  */
+@@ -245,7 +273,7 @@ static int rxrpc_process_event(struct rxrpc_connection *conn,
+ 		return conn->security->respond_to_challenge(conn, skb);
+ 
+ 	case RXRPC_PACKET_TYPE_RESPONSE:
+-		ret = conn->security->verify_response(conn, skb);
++		ret = rxrpc_verify_response(conn, skb);
+ 		if (ret < 0)
+ 			return ret;
+ 
+@@ -334,7 +362,6 @@ void rxrpc_process_delayed_final_acks(struct rxrpc_connection *conn, bool force)
+ static void rxrpc_do_process_connection(struct rxrpc_connection *conn)
+ {
+ 	struct sk_buff *skb;
+-	int ret;
+ 
+ 	if (test_and_clear_bit(RXRPC_CONN_EV_CHALLENGE, &conn->events))
+ 		rxrpc_secure_connection(conn);
+@@ -343,17 +370,8 @@ static void rxrpc_do_process_connection(struct rxrpc_connection *conn)
+ 	 * connection that each one has when we've finished with it */
+ 	while ((skb = skb_dequeue(&conn->rx_queue))) {
+ 		rxrpc_see_skb(skb, rxrpc_skb_see_conn_work);
+-		ret = rxrpc_process_event(conn, skb);
+-		switch (ret) {
+-		case -ENOMEM:
+-		case -EAGAIN:
+-			skb_queue_head(&conn->rx_queue, skb);
+-			rxrpc_queue_conn(conn, rxrpc_conn_queue_retry_work);
+-			break;
+-		default:
+-			rxrpc_free_skb(skb, rxrpc_skb_put_conn_work);
+-			break;
+-		}
++		rxrpc_process_event(conn, skb);
++		rxrpc_free_skb(skb, rxrpc_skb_put_conn_work);
+ 	}
+ }
+ 
+diff --git a/net/rxrpc/io_thread.c b/net/rxrpc/io_thread.c
+index 07c74c77d..275caa737 100644
+--- a/net/rxrpc/io_thread.c
++++ b/net/rxrpc/io_thread.c
+@@ -178,13 +178,12 @@ static bool rxrpc_extract_abort(struct sk_buff *skb)
+ /*
+  * Process packets received on the local endpoint
+  */
+-static bool rxrpc_input_packet(struct rxrpc_local *local, struct sk_buff **_skb)
++static bool rxrpc_input_packet(struct rxrpc_local *local, struct sk_buff *skb)
+ {
+ 	struct rxrpc_connection *conn;
+ 	struct sockaddr_rxrpc peer_srx;
+ 	struct rxrpc_skb_priv *sp;
+ 	struct rxrpc_peer *peer = NULL;
+-	struct sk_buff *skb = *_skb;
+ 	bool ret = false;
+ 
+ 	skb_pull(skb, sizeof(struct udphdr));
+@@ -230,25 +229,6 @@ static bool rxrpc_input_packet(struct rxrpc_local *local, struct sk_buff **_skb)
+ 			return rxrpc_bad_message(skb, rxrpc_badmsg_zero_call);
+ 		if (sp->hdr.seq == 0)
+ 			return rxrpc_bad_message(skb, rxrpc_badmsg_zero_seq);
+-
+-		/* Unshare the packet so that it can be modified for in-place
+-		 * decryption.
+-		 */
+-		if (sp->hdr.securityIndex != 0) {
+-			skb = skb_unshare(skb, GFP_ATOMIC);
+-			if (!skb) {
+-				rxrpc_eaten_skb(*_skb, rxrpc_skb_eaten_by_unshare_nomem);
+-				*_skb = NULL;
+-				return just_discard;
+-			}
+-
+-			if (skb != *_skb) {
+-				rxrpc_eaten_skb(*_skb, rxrpc_skb_eaten_by_unshare);
+-				*_skb = skb;
+-				rxrpc_new_skb(skb, rxrpc_skb_new_unshared);
+-				sp = rxrpc_skb(skb);
+-			}
+-		}
+ 		break;
+ 
+ 	case RXRPC_PACKET_TYPE_CHALLENGE:
+@@ -489,7 +469,7 @@ int rxrpc_io_thread(void *data)
+ 			switch (skb->mark) {
+ 			case RXRPC_SKB_MARK_PACKET:
+ 				skb->priority = 0;
+-				if (!rxrpc_input_packet(local, &skb))
++				if (!rxrpc_input_packet(local, skb))
+ 					rxrpc_reject_packet(local, skb);
+ 				trace_rxrpc_rx_done(skb->mark, skb->priority);
+ 				rxrpc_free_skb(skb, rxrpc_skb_put_input);
+diff --git a/net/rxrpc/key.c b/net/rxrpc/key.c
+index 33e8302a7..5d6d20598 100644
+--- a/net/rxrpc/key.c
++++ b/net/rxrpc/key.c
+@@ -339,6 +339,10 @@ static int rxrpc_preparse(struct key_preparsed_payload *prep)
+ 	if (v1->security_index != RXRPC_SECURITY_RXKAD)
+ 		goto error;
+ 
++	ret = -EKEYREJECTED;
++	if (v1->ticket_length > AFSTOKEN_RK_TIX_MAX)
++		goto error;
++
+ 	plen = sizeof(*token->kad) + v1->ticket_length;
+ 	prep->quotalen = plen + sizeof(*token);
+ 
+diff --git a/net/rxrpc/rxkad.c b/net/rxrpc/rxkad.c
+index 48a1475e6..b6075ffeb 100644
+--- a/net/rxrpc/rxkad.c
++++ b/net/rxrpc/rxkad.c
+@@ -487,6 +487,9 @@ static int rxkad_verify_packet_2(struct rxrpc_call *call, struct sk_buff *skb,
+ 		return rxrpc_abort_eproto(call, skb, RXKADSEALEDINCON,
+ 					  rxkad_abort_2_short_header);
+ 
++	/* Don't let the crypto algo see a misaligned length. */
++	sp->len = round_down(sp->len, 8);
++
+ 	/* Decrypt the skbuff in-place.  TODO: We really want to decrypt
+ 	 * directly into the target buffer.
+ 	 */
+@@ -520,6 +523,13 @@ static int rxkad_verify_packet_2(struct rxrpc_call *call, struct sk_buff *skb,
+ 	if (sg != _sg)
+ 		kfree(sg);
+ 
++	if (ret < 0) {
++		if (ret == -ENOMEM)
++			return ret;
++		return rxrpc_abort_eproto(call, skb, RXKADSEALEDINCON,
++					  rxkad_abort_2_crypto_unaligned);
++	}
++
+ 	/* Extract the decrypted packet length */
+ 	if (skb_copy_bits(skb, sp->offset, &sechdr, sizeof(sechdr)) < 0)
+ 		return rxrpc_abort_eproto(call, skb, RXKADDATALEN,
+@@ -1027,7 +1037,7 @@ static int rxkad_verify_response(struct rxrpc_connection *conn,
+ 	struct rxrpc_crypt session_key;
+ 	struct key *server_key;
+ 	time64_t expiry;
+-	void *ticket;
++	void *ticket = NULL;
+ 	u32 version, kvno, ticket_len, level;
+ 	__be32 csum;
+ 	int ret, i;
+@@ -1053,13 +1063,13 @@ static int rxkad_verify_response(struct rxrpc_connection *conn,
+ 	ret = -ENOMEM;
+ 	response = kzalloc(sizeof(struct rxkad_response), GFP_NOFS);
+ 	if (!response)
+-		goto temporary_error;
++		goto error;
+ 
+ 	if (skb_copy_bits(skb, sizeof(struct rxrpc_wire_header),
+ 			  response, sizeof(*response)) < 0) {
+-		rxrpc_abort_conn(conn, skb, RXKADPACKETSHORT, -EPROTO,
+-				 rxkad_abort_resp_short);
+-		goto protocol_error;
++		ret = rxrpc_abort_conn(conn, skb, RXKADPACKETSHORT, -EPROTO,
++				       rxkad_abort_resp_short);
++		goto error;
+ 	}
+ 
+ 	version = ntohl(response->version);
+@@ -1069,40 +1079,40 @@ static int rxkad_verify_response(struct rxrpc_connection *conn,
+ 	trace_rxrpc_rx_response(conn, sp->hdr.serial, version, kvno, ticket_len);
+ 
+ 	if (version != RXKAD_VERSION) {
+-		rxrpc_abort_conn(conn, skb, RXKADINCONSISTENCY, -EPROTO,
+-				 rxkad_abort_resp_version);
+-		goto protocol_error;
++		ret = rxrpc_abort_conn(conn, skb, RXKADINCONSISTENCY, -EPROTO,
++				       rxkad_abort_resp_version);
++		goto error;
+ 	}
+ 
+ 	if (ticket_len < 4 || ticket_len > MAXKRB5TICKETLEN) {
+-		rxrpc_abort_conn(conn, skb, RXKADTICKETLEN, -EPROTO,
+-				 rxkad_abort_resp_tkt_len);
+-		goto protocol_error;
++		ret = rxrpc_abort_conn(conn, skb, RXKADTICKETLEN, -EPROTO,
++				       rxkad_abort_resp_tkt_len);
++		goto error;
+ 	}
+ 
+ 	if (kvno >= RXKAD_TKT_TYPE_KERBEROS_V5) {
+-		rxrpc_abort_conn(conn, skb, RXKADUNKNOWNKEY, -EPROTO,
+-				 rxkad_abort_resp_unknown_tkt);
+-		goto protocol_error;
++		ret = rxrpc_abort_conn(conn, skb, RXKADUNKNOWNKEY, -EPROTO,
++				       rxkad_abort_resp_unknown_tkt);
++		goto error;
+ 	}
+ 
+ 	/* extract the kerberos ticket and decrypt and decode it */
+ 	ret = -ENOMEM;
+ 	ticket = kmalloc(ticket_len, GFP_NOFS);
+ 	if (!ticket)
+-		goto temporary_error_free_resp;
++		goto error;
+ 
+ 	if (skb_copy_bits(skb, sizeof(struct rxrpc_wire_header) + sizeof(*response),
+ 			  ticket, ticket_len) < 0) {
+-		rxrpc_abort_conn(conn, skb, RXKADPACKETSHORT, -EPROTO,
+-				 rxkad_abort_resp_short_tkt);
+-		goto protocol_error;
++		ret = rxrpc_abort_conn(conn, skb, RXKADPACKETSHORT, -EPROTO,
++				       rxkad_abort_resp_short_tkt);
++		goto error;
+ 	}
+ 
+ 	ret = rxkad_decrypt_ticket(conn, server_key, skb, ticket, ticket_len,
+ 				   &session_key, &expiry);
+ 	if (ret < 0)
+-		goto temporary_error_free_ticket;
++		goto error;
+ 
+ 	/* use the session key from inside the ticket to decrypt the
+ 	 * response */
+@@ -1111,18 +1121,18 @@ static int rxkad_verify_response(struct rxrpc_connection *conn,
+ 	if (ntohl(response->encrypted.epoch) != conn->proto.epoch ||
+ 	    ntohl(response->encrypted.cid) != conn->proto.cid ||
+ 	    ntohl(response->encrypted.securityIndex) != conn->security_ix) {
+-		rxrpc_abort_conn(conn, skb, RXKADSEALEDINCON, -EPROTO,
+-				 rxkad_abort_resp_bad_param);
+-		goto protocol_error_free;
++		ret = rxrpc_abort_conn(conn, skb, RXKADSEALEDINCON, -EPROTO,
++				       rxkad_abort_resp_bad_param);
++		goto error;
+ 	}
+ 
+ 	csum = response->encrypted.checksum;
+ 	response->encrypted.checksum = 0;
+ 	rxkad_calc_response_checksum(response);
+ 	if (response->encrypted.checksum != csum) {
+-		rxrpc_abort_conn(conn, skb, RXKADSEALEDINCON, -EPROTO,
+-				 rxkad_abort_resp_bad_checksum);
+-		goto protocol_error_free;
++		ret = rxrpc_abort_conn(conn, skb, RXKADSEALEDINCON, -EPROTO,
++				       rxkad_abort_resp_bad_checksum);
++		goto error;
+ 	}
+ 
+ 	for (i = 0; i < RXRPC_MAXCALLS; i++) {
+@@ -1130,38 +1140,38 @@ static int rxkad_verify_response(struct rxrpc_connection *conn,
+ 		u32 counter = READ_ONCE(conn->channels[i].call_counter);
+ 
+ 		if (call_id > INT_MAX) {
+-			rxrpc_abort_conn(conn, skb, RXKADSEALEDINCON, -EPROTO,
+-					 rxkad_abort_resp_bad_callid);
+-			goto protocol_error_free;
++			ret = rxrpc_abort_conn(conn, skb, RXKADSEALEDINCON, -EPROTO,
++					       rxkad_abort_resp_bad_callid);
++			goto error;
+ 		}
+ 
+ 		if (call_id < counter) {
+-			rxrpc_abort_conn(conn, skb, RXKADSEALEDINCON, -EPROTO,
+-					 rxkad_abort_resp_call_ctr);
+-			goto protocol_error_free;
++			ret = rxrpc_abort_conn(conn, skb, RXKADSEALEDINCON, -EPROTO,
++					       rxkad_abort_resp_call_ctr);
++			goto error;
+ 		}
+ 
+ 		if (call_id > counter) {
+ 			if (conn->channels[i].call) {
+-				rxrpc_abort_conn(conn, skb, RXKADSEALEDINCON, -EPROTO,
++				ret = rxrpc_abort_conn(conn, skb, RXKADSEALEDINCON, -EPROTO,
+ 						 rxkad_abort_resp_call_state);
+-				goto protocol_error_free;
++				goto error;
+ 			}
+ 			conn->channels[i].call_counter = call_id;
+ 		}
+ 	}
+ 
+ 	if (ntohl(response->encrypted.inc_nonce) != conn->rxkad.nonce + 1) {
+-		rxrpc_abort_conn(conn, skb, RXKADOUTOFSEQUENCE, -EPROTO,
+-				 rxkad_abort_resp_ooseq);
+-		goto protocol_error_free;
++		ret = rxrpc_abort_conn(conn, skb, RXKADOUTOFSEQUENCE, -EPROTO,
++				       rxkad_abort_resp_ooseq);
++		goto error;
+ 	}
+ 
+ 	level = ntohl(response->encrypted.level);
+ 	if (level > RXRPC_SECURITY_ENCRYPT) {
+-		rxrpc_abort_conn(conn, skb, RXKADLEVELFAIL, -EPROTO,
+-				 rxkad_abort_resp_level);
+-		goto protocol_error_free;
++		ret = rxrpc_abort_conn(conn, skb, RXKADLEVELFAIL, -EPROTO,
++				       rxkad_abort_resp_level);
++		goto error;
+ 	}
+ 	conn->security_level = level;
+ 
+@@ -1169,31 +1179,12 @@ static int rxkad_verify_response(struct rxrpc_connection *conn,
+ 	 * this the connection security can be handled in exactly the same way
+ 	 * as for a client connection */
+ 	ret = rxrpc_get_server_data_key(conn, &session_key, expiry, kvno);
+-	if (ret < 0)
+-		goto temporary_error_free_ticket;
+-
+-	kfree(ticket);
+-	kfree(response);
+-	_leave(" = 0");
+-	return 0;
+ 
+-protocol_error_free:
+-	kfree(ticket);
+-protocol_error:
+-	kfree(response);
+-	key_put(server_key);
+-	return -EPROTO;
+-
+-temporary_error_free_ticket:
++error:
+ 	kfree(ticket);
+-temporary_error_free_resp:
+ 	kfree(response);
+-temporary_error:
+-	/* Ignore the response packet if we got a temporary error such as
+-	 * ENOMEM.  We just want to send the challenge again.  Note that we
+-	 * also come out this way if the ticket decryption fails.
+-	 */
+ 	key_put(server_key);
++	_leave(" = %d", ret);
+ 	return ret;
+ }
+ 
+diff --git a/net/rxrpc/skbuff.c b/net/rxrpc/skbuff.c
+index 3bcd6ee80..e2169d1a1 100644
+--- a/net/rxrpc/skbuff.c
++++ b/net/rxrpc/skbuff.c
+@@ -46,15 +46,6 @@ void rxrpc_get_skb(struct sk_buff *skb, enum rxrpc_skb_trace why)
+ 	skb_get(skb);
+ }
+ 
+-/*
+- * Note the dropping of a ref on a socket buffer by the core.
+- */
+-void rxrpc_eaten_skb(struct sk_buff *skb, enum rxrpc_skb_trace why)
+-{
+-	int n = atomic_inc_return(&rxrpc_n_rx_skbs);
+-	trace_rxrpc_skb(skb, 0, n, why);
+-}
+-
+ /*
+  * Note the destruction of a socket buffer.
+  */
+diff --git a/include/trace/events/rxrpc.h b/include/trace/events/rxrpc.h
+index eea376976..5086a399a 100644
+--- a/include/trace/events/rxrpc.h
++++ b/include/trace/events/rxrpc.h
+@@ -36,6 +36,7 @@
+ 	EM(rxkad_abort_1_short_encdata,		"rxkad1-short-encdata")	\
+ 	EM(rxkad_abort_1_short_header,		"rxkad1-short-hdr")	\
+ 	EM(rxkad_abort_2_short_check,		"rxkad2-short-check")	\
++	EM(rxkad_abort_2_crypto_unaligned,	"rxkad2-crypto-unaligned") \
+ 	EM(rxkad_abort_2_short_data,		"rxkad2-short-data")	\
+ 	EM(rxkad_abort_2_short_header,		"rxkad2-short-hdr")	\
+ 	EM(rxkad_abort_2_short_len,		"rxkad2-short-len")	\
+@@ -126,8 +127,6 @@
+ 	E_(rxrpc_call_poke_timer_now,		"Timer-now")
+ 
+ #define rxrpc_skb_traces \
+-	EM(rxrpc_skb_eaten_by_unshare,		"ETN unshare  ") \
+-	EM(rxrpc_skb_eaten_by_unshare_nomem,	"ETN unshar-nm") \
+ 	EM(rxrpc_skb_get_conn_secured,		"GET conn-secd") \
+ 	EM(rxrpc_skb_get_conn_work,		"GET conn-work") \
+ 	EM(rxrpc_skb_get_last_nack,		"GET last-nack") \
+@@ -139,6 +138,7 @@
+ 	EM(rxrpc_skb_new_error_report,		"NEW error-rpt") \
+ 	EM(rxrpc_skb_new_jumbo_subpacket,	"NEW jumbo-sub") \
+ 	EM(rxrpc_skb_new_unshared,		"NEW unshared ") \
++	EM(rxrpc_skb_put_call_rx,		"PUT call-rx  ") \
+ 	EM(rxrpc_skb_put_conn_secured,		"PUT conn-secd") \
+ 	EM(rxrpc_skb_put_conn_work,		"PUT conn-work") \
+ 	EM(rxrpc_skb_put_error_report,		"PUT error-rep") \
+@@ -146,12 +146,14 @@
+ 	EM(rxrpc_skb_put_jumbo_subpacket,	"PUT jumbo-sub") \
+ 	EM(rxrpc_skb_put_last_nack,		"PUT last-nack") \
+ 	EM(rxrpc_skb_put_purge,			"PUT purge    ") \
++	EM(rxrpc_skb_put_response_copy,		"PUT resp-cpy ") \
+ 	EM(rxrpc_skb_put_rotate,		"PUT rotate   ") \
+ 	EM(rxrpc_skb_put_unknown,		"PUT unknown  ") \
+ 	EM(rxrpc_skb_see_conn_work,		"SEE conn-work") \
+ 	EM(rxrpc_skb_see_recvmsg,		"SEE recvmsg  ") \
+ 	EM(rxrpc_skb_see_reject,		"SEE reject   ") \
+ 	EM(rxrpc_skb_see_rotate,		"SEE rotate   ") \
++	EM(rxrpc_skb_see_unshare_nomem,		"SEE unshar-nm") \
+ 	E_(rxrpc_skb_see_version,		"SEE version  ")
+ 
+ #define rxrpc_local_traces \
+@@ -235,7 +237,6 @@
+ 	EM(rxrpc_conn_put_unidle,		"PUT unidle  ") \
+ 	EM(rxrpc_conn_put_work,			"PUT work    ") \
+ 	EM(rxrpc_conn_queue_challenge,		"QUE chall   ") \
+-	EM(rxrpc_conn_queue_retry_work,		"QUE retry-wk") \
+ 	EM(rxrpc_conn_queue_rx_work,		"QUE rx-work ") \
+ 	EM(rxrpc_conn_see_new_service_conn,	"SEE new-svc ") \
+ 	EM(rxrpc_conn_see_reap_service,		"SEE reap-svc") \

--- a/Documentation/resources/kernel-patches/GKI/kernel-6.12/Security/dirtyclone.patch
+++ b/Documentation/resources/kernel-patches/GKI/kernel-6.12/Security/dirtyclone.patch
@@ -1,0 +1,157 @@
+From fc6eb39c55e97df2f94ad974b8a5bbcd019da2c8 Mon Sep 17 00:00:00 2001
+From: Hyunwoo Kim <imv4bel@gmail.com>
+Date: Sat, 16 May 2026 07:28:53 +0900
+Subject: net: skbuff: propagate shared-frag marker through frag-transfer
+ helpers
+
+commit 48f6a5356a33dd78e7144ae1faef95ffc990aae0 upstream.
+
+Two frag-transfer helpers (__pskb_copy_fclone() and skb_shift()) fail
+to propagate the SKBFL_SHARED_FRAG bit in skb_shinfo()->flags when
+moving frags from source to destination.  __pskb_copy_fclone() defers
+the rest of the shinfo metadata to skb_copy_header() after copying
+frag descriptors, but that helper only carries over gso_{size,segs,
+type} and never touches skb_shinfo()->flags; skb_shift() moves frag
+descriptors directly and leaves flags untouched.  As a result, the
+destination skb keeps a reference to the same externally-owned or
+page-cache-backed pages while reporting skb_has_shared_frag() as
+false.
+
+The mismatch is harmful in any in-place writer that uses
+skb_has_shared_frag() to decide whether shared pages must be detoured
+through skb_cow_data().  ESP input is one such writer (esp4.c,
+esp6.c), and a single nft 'dup to <local>' rule -- or any other
+nf_dup_ipv4() / xt_TEE caller -- is enough to land a pskb_copy()'d
+skb in esp_input() with the marker stripped, letting an unprivileged
+user write into the page cache of a root-owned read-only file via
+authencesn-ESN stray writes.
+
+Set SKBFL_SHARED_FRAG on the destination whenever frag descriptors
+were actually moved from the source.  skb_copy() and skb_copy_expand()
+share skb_copy_header() too but linearize all paged data into freshly
+allocated head storage and emerge with nr_frags == 0, so
+skb_has_shared_frag() returns false on its own; they need no change.
+
+The same omission exists in skb_gro_receive() and skb_gro_receive_list().
+The former moves the incoming skb's frag descriptors into the
+accumulator's last sub-skb via two paths (a direct frag-move loop and
+the head_frag + memcpy path); the latter chains the incoming skb whole
+onto p's frag_list.  Downstream skb_segment() reads only
+skb_shinfo(p)->flags, and skb_segment_list() reuses each sub-skb's
+shinfo as the nskb -- both p and lp must carry the marker.
+
+The same omission also exists in tcp_clone_payload(), which builds an
+MTU probe skb by moving frag descriptors from skbs on sk_write_queue
+into a freshly allocated nskb.  The helper falls into the same family
+and warrants the same fix for consistency; no TCP TX-side in-place
+writer is currently known to reach a user page through this gap, but
+a future consumer depending on the marker would regress silently.
+
+The same omission exists in skb_segment(): the per-iteration flag
+merge takes only head_skb's flag, and the inner switch that rebinds
+frag_skb to list_skb on head_skb-frags exhaustion does not fold the
+new frag_skb's flag into nskb.  Fold frag_skb's flag at both sites
+so segments drawing frags from frag_list members carry the marker.
+
+Fixes: cef401de7be8 ("net: fix possible wrong checksum generation")
+Fixes: f4c50a4034e6 ("xfrm: esp: avoid in-place decrypt on shared skb frags")
+Suggested-by: Sabrina Dubroca <sd@queasysnail.net>
+Suggested-by: Sultan Alsawaf <sultan@kerneltoast.com>
+Suggested-by: Ben Hutchings <ben@decadent.org.uk>
+Suggested-by: Lin Ma <malin89@huawei.com>
+Suggested-by: Jingguo Tan <tanjingguo@huawei.com>
+Suggested-by: Aaron Esau <aaron1esau@gmail.com>
+Cc: stable@vger.kernel.org
+Signed-off-by: Hyunwoo Kim <imv4bel@gmail.com>
+Tested-by: Rajat Gupta <rajat.gupta@oss.qualcomm.com>
+Link: https://patch.msgid.link/ageeJfJHwgzmKXbh@v4bel
+Signed-off-by: Paolo Abeni <pabeni@redhat.com>
+Signed-off-by: Greg Kroah-Hartman <gregkh@linuxfoundation.org>
+---
+ net/core/gro.c        | 4 ++++
+ net/core/skbuff.c     | 9 ++++++++-
+ net/ipv4/tcp_output.c | 1 +
+ 3 files changed, 13 insertions(+), 1 deletion(-)
+
+diff --git a/net/core/gro.c b/net/core/gro.c
+index ac498c9f82cf5..f5c80c2f69df7 100644
+--- a/net/core/gro.c
++++ b/net/core/gro.c
+@@ -214,10 +214,12 @@ done:
+ 	p->data_len += len;
+ 	p->truesize += delta_truesize;
+ 	p->len += len;
++	skb_shinfo(p)->flags |= skbinfo->flags & SKBFL_SHARED_FRAG;
+ 	if (lp != p) {
+ 		lp->data_len += len;
+ 		lp->truesize += delta_truesize;
+ 		lp->len += len;
++		skb_shinfo(lp)->flags |= skbinfo->flags & SKBFL_SHARED_FRAG;
+ 	}
+ 	NAPI_GRO_CB(skb)->same_flow = 1;
+ 	return 0;
+@@ -245,6 +247,8 @@ int skb_gro_receive_list(struct sk_buff *p, struct sk_buff *skb)
+ 	p->truesize += skb->truesize;
+ 	p->len += skb->len;
+ 
++	skb_shinfo(p)->flags |= skb_shinfo(skb)->flags & SKBFL_SHARED_FRAG;
++
+ 	NAPI_GRO_CB(skb)->same_flow = 1;
+ 
+ 	return 0;
+diff --git a/net/core/skbuff.c b/net/core/skbuff.c
+index 00d60588fb09e..aa9e914884736 100644
+--- a/net/core/skbuff.c
++++ b/net/core/skbuff.c
+@@ -2214,6 +2214,7 @@ struct sk_buff *__pskb_copy_fclone(struct sk_buff *skb, int headroom,
+ 			skb_frag_ref(skb, i);
+ 		}
+ 		skb_shinfo(n)->nr_frags = i;
++		skb_shinfo(n)->flags |= skb_shinfo(skb)->flags & SKBFL_SHARED_FRAG;
+ 	}
+ 
+ 	if (skb_has_frag_list(skb)) {
+@@ -4289,6 +4290,8 @@ onlymerged:
+ 	tgt->ip_summed = CHECKSUM_PARTIAL;
+ 	skb->ip_summed = CHECKSUM_PARTIAL;
+ 
++	skb_shinfo(tgt)->flags |= skb_shinfo(skb)->flags & SKBFL_SHARED_FRAG;
++
+ 	skb_len_add(skb, -shiftlen);
+ 	skb_len_add(tgt, shiftlen);
+ 
+@@ -4899,7 +4902,8 @@ normal:
+ 		skb_copy_from_linear_data_offset(head_skb, offset,
+ 						 skb_put(nskb, hsize), hsize);
+ 
+-		skb_shinfo(nskb)->flags |= skb_shinfo(head_skb)->flags &
++		skb_shinfo(nskb)->flags |= (skb_shinfo(head_skb)->flags |
++					    skb_shinfo(frag_skb)->flags) &
+ 					   SKBFL_SHARED_FRAG;
+ 
+ 		if (skb_zerocopy_clone(nskb, frag_skb, GFP_ATOMIC))
+@@ -4916,6 +4920,9 @@ normal:
+ 				nfrags = skb_shinfo(list_skb)->nr_frags;
+ 				frag = skb_shinfo(list_skb)->frags;
+ 				frag_skb = list_skb;
++
++				skb_shinfo(nskb)->flags |= skb_shinfo(frag_skb)->flags & SKBFL_SHARED_FRAG;
++
+ 				if (!skb_headlen(list_skb)) {
+ 					BUG_ON(!nfrags);
+ 				} else {
+diff --git a/net/ipv4/tcp_output.c b/net/ipv4/tcp_output.c
+index 33c2fb60d0562..c76672f544be4 100644
+--- a/net/ipv4/tcp_output.c
++++ b/net/ipv4/tcp_output.c
+@@ -2391,6 +2391,7 @@ static int tcp_clone_payload(struct sock *sk, struct sk_buff *to,
+ 			todo = min_t(int, skb_frag_size(fragfrom),
+ 				     probe_size - len);
+ 			len += todo;
++			skb_shinfo(to)->flags |= skb_shinfo(skb)->flags & SKBFL_SHARED_FRAG;
+ 			if (lastfrag &&
+ 			    skb_frag_page(fragfrom) == skb_frag_page(lastfrag) &&
+ 			    skb_frag_off(fragfrom) == skb_frag_off(lastfrag) +
+-- 
+cgit 1.3-korg
+

--- a/Documentation/resources/kernel-patches/GKI/kernel-6.12/Security/fragnesia.patch
+++ b/Documentation/resources/kernel-patches/GKI/kernel-6.12/Security/fragnesia.patch
@@ -1,0 +1,11 @@
+--- a/net/core/skbuff.c
++++ b/net/core/skbuff.c
+@@ -6075,6 +6072,8 @@ bool skb_try_coalesce(struct sk_buff *to, struct sk_buff *from,
+ 	       from_shinfo->frags,
+ 	       from_shinfo->nr_frags * sizeof(skb_frag_t));
+ 	to_shinfo->nr_frags += from_shinfo->nr_frags;
++	if (from_shinfo->nr_frags)
++		to_shinfo->flags |= from_shinfo->flags & SKBFL_SHARED_FRAG;
+ 
+ 	if (!skb_cloned(from))
+ 		from_shinfo->nr_frags = 0;

--- a/Documentation/resources/kernel-patches/GKI/kernel-6.12/Security/pintheft.patch
+++ b/Documentation/resources/kernel-patches/GKI/kernel-6.12/Security/pintheft.patch
@@ -1,0 +1,12 @@
+diff --git a/net/rds/message.c b/net/rds/message.c
+index 7af59d244..85484e913 100644
+--- a/net/rds/message.c
++++ b/net/rds/message.c
+@@ -398,6 +398,7 @@ static int rds_message_zcopy_from_user(struct rds_message *rm, struct iov_iter *
+ 
+ 			for (i = 0; i < rm->data.op_nents; i++)
+ 				put_page(sg_page(&rm->data.op_sg[i]));
++			rm->data.op_nents = 0;
+ 			mmp = &rm->data.op_mmp_znotifier->z_mmp;
+ 			mm_unaccount_pinned_pages(mmp);
+ 			ret = -EFAULT;

--- a/Documentation/resources/kernel-patches/GKI/kernel-6.12/Security/slab_cross_cache_confusion.patch
+++ b/Documentation/resources/kernel-patches/GKI/kernel-6.12/Security/slab_cross_cache_confusion.patch
@@ -1,0 +1,14 @@
+--- a/net/core/skbuff.c
++++ b/net/core/skbuff.c
+@@ -1078,10 +1078,7 @@ static int skb_pp_frag_ref(struct sk_buff *skb)
+ 
+ static void skb_kfree_head(void *head, unsigned int end_offset)
+ {
+-	if (end_offset == SKB_SMALL_HEAD_HEADROOM)
+-		kmem_cache_free(net_hotdata.skb_small_head_cache, head);
+-	else
+-		kfree(head);
++	kfree(head);
+ }
+ 
+ static void skb_free_head(struct sk_buff *skb)

--- a/Documentation/resources/kernel-patches/GKI/kernel-6.12/Security/ssh_keysign_pwn.patch
+++ b/Documentation/resources/kernel-patches/GKI/kernel-6.12/Security/ssh_keysign_pwn.patch
@@ -1,0 +1,69 @@
+diff --git a/include/linux/sched.h b/include/linux/sched.h
+index 0a3e180ee..855ba985d 100644
+--- a/include/linux/sched.h
++++ b/include/linux/sched.h
+@@ -1637,7 +1637,7 @@ struct task_struct {
+ 	ANDROID_KABI_RESERVE(1);
+ 	ANDROID_KABI_RESERVE(2);
+ 	ANDROID_KABI_RESERVE(3);
+-	ANDROID_KABI_RESERVE(4);
++	ANDROID_KABI_USE(4,unsigned			user_dumpable:1);
+ 	ANDROID_KABI_RESERVE(5);
+ 	ANDROID_KABI_RESERVE(6);
+ 	ANDROID_KABI_RESERVE(7);
+    diff --git a/kernel/exit.c b/kernel/exit.c
+index b2af1ebbc..f9fe4fd92 100644
+--- a/kernel/exit.c
++++ b/kernel/exit.c
+@@ -563,6 +563,7 @@ static void exit_mm(void)
+ 	 */
+ 	smp_mb__after_spinlock();
+ 	local_irq_disable();
++	current->user_dumpable = (get_dumpable(mm) == SUID_DUMP_USER);
+ 	current->mm = NULL;
+ 	membarrier_update_current_mm(NULL);
+ 	enter_lazy_tlb(mm, current);
+diff --git a/kernel/ptrace.c b/kernel/ptrace.c
+index d5f89f9ef..75bcc1526 100644
+--- a/kernel/ptrace.c
++++ b/kernel/ptrace.c
+@@ -272,11 +272,24 @@ static bool ptrace_has_cap(struct user_namespace *ns, unsigned int mode)
+ 	return ns_capable(ns, CAP_SYS_PTRACE);
+ }
+ 
++static bool task_still_dumpable(struct task_struct *task, unsigned int mode)
++{
++	struct mm_struct *mm = task->mm;
++	if (mm) {
++		if (get_dumpable(mm) == SUID_DUMP_USER)
++			return true;
++		return ptrace_has_cap(mm->user_ns, mode);
++	}
++
++	if (task->user_dumpable)
++		return true;
++	return ptrace_has_cap(&init_user_ns, mode);
++}
++
+ /* Returns 0 on success, -errno on denial. */
+ static int __ptrace_may_access(struct task_struct *task, unsigned int mode)
+ {
+ 	const struct cred *cred = current_cred(), *tcred;
+-	struct mm_struct *mm;
+ 	kuid_t caller_uid;
+ 	kgid_t caller_gid;
+ 
+@@ -337,11 +350,8 @@ static int __ptrace_may_access(struct task_struct *task, unsigned int mode)
+ 	 * Pairs with a write barrier in commit_creds().
+ 	 */
+ 	smp_rmb();
+-	mm = task->mm;
+-	if (mm &&
+-	    ((get_dumpable(mm) != SUID_DUMP_USER) &&
+-	     !ptrace_has_cap(mm->user_ns, mode)))
+-	    return -EPERM;
++	if (!task_still_dumpable(task, mode))
++		return -EPERM;
+ 
+ 	return security_ptrace_access_check(task, mode);
+ }

--- a/Makefile
+++ b/Makefile
@@ -60,6 +60,9 @@ SRCS = $(SRC_DIR)/main.c \
        $(SRC_DIR)/android/x11.c \
        $(SRC_DIR)/android/virgl.c \
        $(SRC_DIR)/android/pulseaudio.c \
+       $(SRC_DIR)/anland/anland.c \
+       $(SRC_DIR)/anland/display_daemon.c \
+       $(SRC_DIR)/anland/socket_utils.c \
        $(SRC_DIR)/virtualize.c
 
 # Compiler flags - hardened warning set, all warnings are errors
@@ -141,6 +144,16 @@ $(OBJ_DIR)/%.o: $(SRC_DIR)/%.c | $(OBJ_DIR)
 	$(msg_cc)
 	$(Q)mkdir -p $(dir $@)
 	$(Q)$(CC) $(CFLAGS) -c $< -o $@
+
+# The anland module vendors the upstream display daemon (written to C11 with
+# unnamed unions / const-casts) plus our integration glue. Relax the pedantic
+# and a few hardened warnings that only apply to first-party code; keep -Werror
+# and the rest. More-specific stem, so this wins over the generic rule above.
+ANLAND_CFLAGS = $(filter-out -Wpedantic -Wcast-qual -Wnull-dereference,$(CFLAGS)) -Wno-format-truncation
+$(OBJ_DIR)/anland/%.o: $(SRC_DIR)/anland/%.c | $(OBJ_DIR)
+	$(msg_cc)
+	$(Q)mkdir -p $(dir $@)
+	$(Q)$(CC) $(ANLAND_CFLAGS) -c $< -o $@
 
 # Link step
 $(BINARY_NAME): $(OBJS) | $(OUT_DIR)

--- a/src/anland/anland.c
+++ b/src/anland/anland.c
@@ -1,0 +1,211 @@
+/*
+ * Droidspaces - anland display daemon integration
+ *
+ * Embeds the anland broker daemon (libdisplay_daemon, vendored alongside this
+ * file) into the container lifecycle. For a container with anland enabled we:
+ *   - generate a per-container host socket path under <workspace>/anland,
+ *   - fork a persistent process that runs the daemon's epoll loop on it,
+ *   - record the pid and the socket path in the Pids dir so the app can find
+ *     and stop it, and
+ *   - bind-mount the socket onto the container's /run/display.sock (post-pivot).
+ *
+ * The Android consumer app connects to the same socket (via its root fd-helper)
+ * and a patched KWin ("producer") inside the container connects to
+ * /run/display.sock; the daemon just brokers their handshake.
+ *
+ * Modeled on src/android/x11.c. Unlike X11 (a single global server) each
+ * container gets its own daemon, so the pid / socket-path files are keyed by
+ * container name.
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+#define _GNU_SOURCE
+#include "droidspace.h"
+
+#include <fcntl.h>
+#include <signal.h>
+#include <stdio.h>
+#include <string.h>
+#include <unistd.h>
+
+#include "display_daemon.h"
+
+/* Per-container Pids-dir filenames (keyed by container name). */
+static void anland_pid_file(const struct ds_config *cfg, char *buf, size_t n) {
+  snprintf(buf, n, "%s.anland.pid", cfg->container_name);
+}
+static void anland_sock_file(const struct ds_config *cfg, char *buf, size_t n) {
+  snprintf(buf, n, "%s.anland", cfg->container_name);
+}
+
+/* anland is per-container, so a daemon is never shared between containers:
+ * ds_global_daemon_stop's "keep alive for others" check is always false. */
+static int anland_never_needed(void) { return 0; }
+
+/* ---- daemon child ----------------------------------------------------- */
+
+/*
+ * The forked daemon process. Runs the vendored libdisplay_daemon epoll loop
+ * in-process (the library is linked into this binary, so no execv is needed).
+ * Never returns: always _exit()s.
+ */
+static void anland_daemon_child(int out_fd, const char *sock_path) {
+  /* Detach from the launcher's session and make the daemon robust/persistent
+   * (SIGTERM is left default so ds_global_daemon_stop can kill it). */
+  setsid();
+  signal(SIGHUP, SIG_IGN);
+  signal(SIGINT, SIG_IGN);
+  signal(SIGQUIT, SIG_IGN);
+  signal(SIGPIPE, SIG_IGN);
+  ds_oom_protect();
+
+  /* stdout/stderr -> log pipe, stdin -> /dev/null */
+  int devnull = open("/dev/null", O_RDONLY);
+  if (devnull >= 0) {
+    dup2(devnull, STDIN_FILENO);
+    close(devnull);
+  }
+  dup2(out_fd, STDOUT_FILENO);
+  dup2(out_fd, STDERR_FILENO);
+  close(out_fd);
+
+  daemon_ctx *ctx = NULL;
+  if (daemon_create(&ctx, sock_path) < 0) {
+    fprintf(stderr, "failed to bind %s\n", sock_path);
+    _exit(1);
+  }
+  daemon_run(ctx);      /* blocks until SIGTERM-triggered exit via the loop flag */
+  daemon_destroy(ctx);  /* closes clients, unlinks the socket */
+  _exit(0);
+}
+
+/* Fork the daemon child and a log-relay grandchild (Logs/anland.log).
+ * Returns the daemon PID, or -1 on error. */
+static pid_t spawn_anland_daemon(const char *sock_path) {
+  int pipefd[2];
+  if (pipe(pipefd) < 0) {
+    ds_warn("[anland] pipe: %s", strerror(errno));
+    return -1;
+  }
+
+  pid_t child = fork();
+  if (child < 0) {
+    ds_warn("[anland] fork: %s", strerror(errno));
+    close(pipefd[0]);
+    close(pipefd[1]);
+    return -1;
+  }
+  if (child == 0) {
+    close(pipefd[0]);
+    anland_daemon_child(pipefd[1], sock_path); /* never returns */
+    _exit(1);
+  }
+
+  /* Parent: hand the read end to a log relay; the daemon child holds the only
+   * write end, so the relay sees EOF when the daemon exits. */
+  close(pipefd[1]);
+  ds_spawn_log_relay(pipefd[0], "anland.log", "anland");
+  return child;
+}
+
+/* ---- public API ------------------------------------------------------- */
+
+int ds_anland_daemon_start(struct ds_config *cfg) {
+  if (!cfg || !cfg->anland || !is_android())
+    return -1;
+  if (getuid() != 0) {
+    ds_error("[anland] not running as root");
+    return -1;
+  }
+
+  char pidfile[NAME_MAX + 16], sockfile[NAME_MAX + 16];
+  anland_pid_file(cfg, pidfile, sizeof(pidfile));
+  anland_sock_file(cfg, sockfile, sizeof(sockfile));
+
+  /* Reuse an existing live daemon (ds_daemon_read_pid verifies liveness). */
+  pid_t existing = ds_daemon_read_pid(pidfile);
+  if (existing > 0) {
+    cfg->anland_pid = existing;
+    char rec[PATH_MAX];
+    snprintf(rec, sizeof(rec), "%s/%s", get_pids_dir(), sockfile);
+    int fd = open(rec, O_RDONLY | O_CLOEXEC);
+    if (fd >= 0) {
+      ssize_t r = read(fd, cfg->anland_sock, sizeof(cfg->anland_sock) - 1);
+      close(fd);
+      if (r > 0) {
+        cfg->anland_sock[r] = '\0';
+        cfg->anland_sock[strcspn(cfg->anland_sock, "\r\n")] = '\0';
+      }
+    }
+    ds_log("[anland] daemon already running (PID %d)", (int)existing);
+    return 1;
+  }
+
+  /* Socket dir + generated per-container socket path. */
+  char dir[PATH_MAX];
+  snprintf(dir, sizeof(dir), "%s/anland", get_workspace_dir());
+  mkdir_p(dir, 0771);
+
+  char uuid[DS_UUID_LEN + 1];
+  if (generate_uuid(uuid, sizeof(uuid)) < 0) {
+    ds_error("[anland] failed to generate socket name");
+    return -1;
+  }
+  snprintf(cfg->anland_sock, sizeof(cfg->anland_sock), "%s/%s.sock", dir, uuid);
+
+  ds_log("[anland] launching display daemon on %s", cfg->anland_sock);
+  pid_t child = spawn_anland_daemon(cfg->anland_sock);
+  if (child <= 0)
+    return -1;
+
+  cfg->anland_pid = child;
+  ds_daemon_write_pid(pidfile, child);
+
+  /* Record the socket path so the app (and a later restart) can find it. */
+  char rec[PATH_MAX];
+  snprintf(rec, sizeof(rec), "%s/%s", get_pids_dir(), sockfile);
+  write_file_atomic(rec, cfg->anland_sock);
+
+  /* Give the daemon a moment to bind before we bind-mount the socket. */
+  wait_for_socket_or_death(child, cfg->anland_sock, 2000, 20000);
+  return 0;
+}
+
+void ds_anland_daemon_stop(struct ds_config *cfg) {
+  if (!cfg)
+    return;
+  char pidfile[NAME_MAX + 16], sockfile[NAME_MAX + 16];
+  anland_pid_file(cfg, pidfile, sizeof(pidfile));
+  anland_sock_file(cfg, sockfile, sizeof(sockfile));
+
+  ds_global_daemon_stop(anland_never_needed, cfg->anland_pid, &cfg->anland_pid,
+                        pidfile, cfg->anland_sock, "[anland]");
+  ds_daemon_remove_pid(sockfile);
+}
+
+/* ---- socket bridge ---------------------------------------------------- */
+
+int ds_setup_anland_socket(struct ds_config *cfg) {
+  if (!cfg || !cfg->anland || !is_android())
+    return 0;
+  if (cfg->anland_sock[0] == '\0') {
+    ds_warn("[anland] no daemon socket recorded - skipping bind mount");
+    return 0;
+  }
+
+  /* Post-pivot: the host socket is reachable under /.old_root. */
+  char src[PATH_MAX];
+  snprintf(src, sizeof(src), "/.old_root%s", cfg->anland_sock);
+  if (access(src, F_OK) != 0) {
+    ds_warn("[anland] host socket not found at %s - skipping bind mount", src);
+    return 0;
+  }
+
+  mkdir_p("/run", 0755);
+  if (ds_bind_mount_socket(src, "/run/display.sock", 0, "anland") < 0)
+    return 0;
+
+  ds_log("[anland] display socket bind-mounted to /run/display.sock");
+  return 0;
+}

--- a/src/anland/anland.c
+++ b/src/anland/anland.c
@@ -89,9 +89,11 @@ static void anland_daemon_child(int out_fd, const char *sock_path) {
   _exit(0);
 }
 
-/* Fork the daemon child and a log-relay grandchild (Logs/anland.log).
+/* Fork the daemon child and a log-relay grandchild. log_path is resolved by
+ * ds_spawn_log_relay() relative to get_logs_dir(), so it must be relative
+ * (e.g. "<name>/anland") and its parent dir must already exist.
  * Returns the daemon PID, or -1 on error. */
-static pid_t spawn_anland_daemon(const char *sock_path) {
+static pid_t spawn_anland_daemon(const char *sock_path, const char *log_path) {
   int pipefd[2];
   if (pipe(pipefd) < 0) {
     ds_warn("[anland] pipe: %s", strerror(errno));
@@ -114,7 +116,7 @@ static pid_t spawn_anland_daemon(const char *sock_path) {
   /* Parent: hand the read end to a log relay; the daemon child holds the only
    * write end, so the relay sees EOF when the daemon exits. */
   close(pipefd[1]);
-  ds_spawn_log_relay(pipefd[0], "anland.log", "anland");
+  ds_spawn_log_relay(pipefd[0], log_path, "anland");
   return child;
 }
 
@@ -170,7 +172,21 @@ int ds_anland_daemon_start(struct ds_config *cfg) {
            ANLAND_SOCK_DIR "/anland-%s.sock", uuid);
 
   ds_log("[anland] launching display daemon on %s", cfg->anland_sock);
-  pid_t child = spawn_anland_daemon(cfg->anland_sock);
+
+  /* ds_spawn_log_relay() resolves its log-file argument relative to
+   * get_logs_dir() (== <workspace>/Logs) and only O_CREATs the final path
+   * component, so we must (a) pre-create the per-container subdir and (b) pass
+   * a RELATIVE "<name>/anland" - passing an absolute path would double-prefix
+   * to <Logs>/<Logs>/... whose parents don't exist, and the relay would fail
+   * its open() and silently exit without writing anything. */
+  char safe_log_name[256];
+  sanitize_container_name(cfg->container_name, safe_log_name,
+                          sizeof(safe_log_name));
+
+  char log_rel[288];
+  snprintf(log_rel, sizeof(log_rel), "%.256s/anland", safe_log_name);
+
+  pid_t child = spawn_anland_daemon(cfg->anland_sock, log_rel);
   if (child <= 0)
     return -1;
 

--- a/src/anland/anland.c
+++ b/src/anland/anland.c
@@ -33,11 +33,12 @@
 
 #include <sys/stat.h>
 
-/* Host directory for the per-container display sockets. Deliberately under
- * /data/local/tmp (world-traversable, same tree the consumer app already uses
- * for its default socket) so the consumer can reach the socket without hitting
- * the permission problems of a workspace-private path. */
-#define ANLAND_SOCK_DIR "/data/local/tmp/anland"
+/* Host directory for the per-container display sockets: /data/local/tmp, which
+ * always exists and is the same directory the consumer app already uses for its
+ * default socket, so the consumer can reach it without the permission problems
+ * of a workspace-private path. The socket files are named anland-<uuid>.sock
+ * directly in this dir (no subdirectory to create). */
+#define ANLAND_SOCK_DIR "/data/local/tmp"
 
 /* Per-container Pids-dir filenames (keyed by container name). */
 static void anland_pid_file(const struct ds_config *cfg, char *buf, size_t n) {
@@ -150,18 +151,14 @@ int ds_anland_daemon_start(struct ds_config *cfg) {
     return 1;
   }
 
-  /* Socket dir + generated per-container socket path. World-traversable dir so
-   * the consumer app can reach the socket. */
-  mkdir_p(ANLAND_SOCK_DIR, 0777);
-  chmod(ANLAND_SOCK_DIR, 0777);
-
+  /* Generated per-container socket path, directly in /data/local/tmp. */
   char uuid[DS_UUID_LEN + 1];
   if (generate_uuid(uuid, sizeof(uuid)) < 0) {
     ds_error("[anland] failed to generate socket name");
     return -1;
   }
   snprintf(cfg->anland_sock, sizeof(cfg->anland_sock),
-           ANLAND_SOCK_DIR "/%s.sock", uuid);
+           ANLAND_SOCK_DIR "/anland-%s.sock", uuid);
 
   ds_log("[anland] launching display daemon on %s", cfg->anland_sock);
   pid_t child = spawn_anland_daemon(cfg->anland_sock);

--- a/src/anland/anland.c
+++ b/src/anland/anland.c
@@ -118,6 +118,25 @@ static pid_t spawn_anland_daemon(const char *sock_path) {
   return child;
 }
 
+/* Load the recorded per-container socket path (Pids/<name>.anland) into
+ * cfg->anland_sock. No-op when the file is missing/empty. Needed because the
+ * socket path is runtime-only (not persisted to container.config), so a cfg
+ * loaded from disk at stop time has an empty anland_sock. */
+static void anland_load_sock(struct ds_config *cfg) {
+  char sockfile[NAME_MAX + 16], rec[PATH_MAX];
+  anland_sock_file(cfg, sockfile, sizeof(sockfile));
+  snprintf(rec, sizeof(rec), "%s/%s", get_pids_dir(), sockfile);
+  int fd = open(rec, O_RDONLY | O_CLOEXEC);
+  if (fd < 0)
+    return;
+  ssize_t r = read(fd, cfg->anland_sock, sizeof(cfg->anland_sock) - 1);
+  close(fd);
+  if (r > 0) {
+    cfg->anland_sock[r] = '\0';
+    cfg->anland_sock[strcspn(cfg->anland_sock, "\r\n")] = '\0';
+  }
+}
+
 /* ---- public API ------------------------------------------------------- */
 
 int ds_anland_daemon_start(struct ds_config *cfg) {
@@ -136,17 +155,7 @@ int ds_anland_daemon_start(struct ds_config *cfg) {
   pid_t existing = ds_daemon_read_pid(pidfile);
   if (existing > 0) {
     cfg->anland_pid = existing;
-    char rec[PATH_MAX];
-    snprintf(rec, sizeof(rec), "%s/%s", get_pids_dir(), sockfile);
-    int fd = open(rec, O_RDONLY | O_CLOEXEC);
-    if (fd >= 0) {
-      ssize_t r = read(fd, cfg->anland_sock, sizeof(cfg->anland_sock) - 1);
-      close(fd);
-      if (r > 0) {
-        cfg->anland_sock[r] = '\0';
-        cfg->anland_sock[strcspn(cfg->anland_sock, "\r\n")] = '\0';
-      }
-    }
+    anland_load_sock(cfg);
     ds_log("[anland] daemon already running (PID %d)", (int)existing);
     return 1;
   }
@@ -187,8 +196,14 @@ void ds_anland_daemon_stop(struct ds_config *cfg) {
   anland_pid_file(cfg, pidfile, sizeof(pidfile));
   anland_sock_file(cfg, sockfile, sizeof(sockfile));
 
+  /* Recover the socket path from the Pids file if this cfg was loaded from disk
+   * (anland_sock is runtime-only), so ds_global_daemon_stop can unlink it. */
+  if (cfg->anland_sock[0] == '\0')
+    anland_load_sock(cfg);
+
   ds_global_daemon_stop(anland_never_needed, cfg->anland_pid, &cfg->anland_pid,
-                        pidfile, cfg->anland_sock, "[anland]");
+                        pidfile, cfg->anland_sock[0] ? cfg->anland_sock : NULL,
+                        "[anland]");
   ds_daemon_remove_pid(sockfile);
 }
 

--- a/src/anland/anland.c
+++ b/src/anland/anland.c
@@ -31,6 +31,14 @@
 
 #include "display_daemon.h"
 
+#include <sys/stat.h>
+
+/* Host directory for the per-container display sockets. Deliberately under
+ * /data/local/tmp (world-traversable, same tree the consumer app already uses
+ * for its default socket) so the consumer can reach the socket without hitting
+ * the permission problems of a workspace-private path. */
+#define ANLAND_SOCK_DIR "/data/local/tmp/anland"
+
 /* Per-container Pids-dir filenames (keyed by container name). */
 static void anland_pid_file(const struct ds_config *cfg, char *buf, size_t n) {
   snprintf(buf, n, "%s.anland.pid", cfg->container_name);
@@ -142,17 +150,18 @@ int ds_anland_daemon_start(struct ds_config *cfg) {
     return 1;
   }
 
-  /* Socket dir + generated per-container socket path. */
-  char dir[PATH_MAX];
-  snprintf(dir, sizeof(dir), "%s/anland", get_workspace_dir());
-  mkdir_p(dir, 0771);
+  /* Socket dir + generated per-container socket path. World-traversable dir so
+   * the consumer app can reach the socket. */
+  mkdir_p(ANLAND_SOCK_DIR, 0777);
+  chmod(ANLAND_SOCK_DIR, 0777);
 
   char uuid[DS_UUID_LEN + 1];
   if (generate_uuid(uuid, sizeof(uuid)) < 0) {
     ds_error("[anland] failed to generate socket name");
     return -1;
   }
-  snprintf(cfg->anland_sock, sizeof(cfg->anland_sock), "%s/%s.sock", dir, uuid);
+  snprintf(cfg->anland_sock, sizeof(cfg->anland_sock),
+           ANLAND_SOCK_DIR "/%s.sock", uuid);
 
   ds_log("[anland] launching display daemon on %s", cfg->anland_sock);
   pid_t child = spawn_anland_daemon(cfg->anland_sock);
@@ -167,8 +176,10 @@ int ds_anland_daemon_start(struct ds_config *cfg) {
   snprintf(rec, sizeof(rec), "%s/%s", get_pids_dir(), sockfile);
   write_file_atomic(rec, cfg->anland_sock);
 
-  /* Give the daemon a moment to bind before we bind-mount the socket. */
+  /* Give the daemon a moment to bind, then loosen the socket perms so the
+   * consumer app can connect to it. */
   wait_for_socket_or_death(child, cfg->anland_sock, 2000, 20000);
+  chmod(cfg->anland_sock, 0666);
   return 0;
 }
 

--- a/src/anland/display_daemon.c
+++ b/src/anland/display_daemon.c
@@ -1,0 +1,351 @@
+#include <errno.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/epoll.h>
+#include <sys/socket.h>
+#include <sys/un.h>
+#include <unistd.h>
+
+#include "display_daemon.h"
+#include "protocol.h"
+#include "socket_utils.h"
+
+#define MAX_EVENTS 16
+/* Hello fd set: { buf_ready, fence, data, shm, audio }. The daemon only relays
+ * the fds; it never interprets the slots. */
+#define MAX_FDS    5
+
+struct client {
+    int  ctrl_fd;
+    bool is_consumer;
+};
+
+struct daemon_ctx {
+    struct client *consumer;
+    struct client *producer;
+    int epoll_fd;
+    int listen_fd;
+    volatile bool running;
+
+    struct screen_info stored_screen;
+    bool has_screen_info;
+
+    int deposited_fds[MAX_FDS];
+    int deposited_fd_count;
+
+    bool producer_waiting_screen;
+    bool producer_waiting_fds;
+
+    char sock_path[sizeof(((struct sockaddr_un *)0)->sun_path)];
+};
+
+static void client_free(daemon_ctx *ctx, struct client *c)
+{
+    if (!c) return;
+    if (c->ctrl_fd >= 0) {
+        epoll_ctl(ctx->epoll_fd, EPOLL_CTL_DEL, c->ctrl_fd, NULL);
+        close(c->ctrl_fd);
+    }
+    free(c);
+}
+
+static void clear_deposited_fds(daemon_ctx *ctx)
+{
+    for (int i = 0; i < ctx->deposited_fd_count; i++)
+        close(ctx->deposited_fds[i]);
+    ctx->deposited_fd_count = 0;
+}
+
+static int send_ctrl(int fd, uint32_t type)
+{
+    struct ctrl_msg msg = { .type = type, .size = 0 };
+    return send_all(fd, &msg, sizeof(msg));
+}
+
+static int send_screen_info_msg(daemon_ctx *ctx, int fd)
+{
+    struct ctrl_msg hdr = { .type = CTRL_MSG_SCREEN_INFO, .size = sizeof(struct screen_info) };
+    uint8_t buf[sizeof(struct ctrl_msg) + sizeof(struct screen_info)];
+    memcpy(buf, &hdr, sizeof(hdr));
+    memcpy(buf + sizeof(hdr), &ctx->stored_screen, sizeof(ctx->stored_screen));
+    return send_all(fd, buf, sizeof(buf));
+}
+
+static void try_deliver_fds(daemon_ctx *ctx)
+{
+    if (!ctx->producer || ctx->deposited_fd_count < MAX_FDS) {
+        ctx->producer_waiting_fds = true;
+        return;
+    }
+
+    struct ctrl_msg msg = { .type = CTRL_MSG_FDS_READY, .size = 0 };
+    if (send_fds(ctx->producer->ctrl_fd, &msg, sizeof(msg),
+                 ctx->deposited_fds, ctx->deposited_fd_count) < 0) {
+        fprintf(stderr, "daemon: failed to send fds to producer\n");
+        ctx->producer_waiting_fds = true;
+        return;
+    }
+
+    if (ctx->consumer)
+        send_ctrl(ctx->consumer->ctrl_fd, CTRL_MSG_FDS_READY);
+
+    for (int i = 0; i < ctx->deposited_fd_count; i++)
+        close(ctx->deposited_fds[i]);
+    ctx->deposited_fd_count = 0;
+    ctx->producer_waiting_fds = false;
+
+    fprintf(stderr, "daemon: fds delivered to producer\n");
+}
+
+/*
+ * Tear down whichever role this client holds, reset the associated state, then free
+ * it. Used both for real disconnects (EPOLLHUP / recv error) and to evict a stale
+ * client when a new one takes over the same role -- whether the old client is still
+ * alive or already a ghost, finding one is reason enough to drop it.
+ *
+ * The role pointer is cleared BEFORE client_free() so that any event still queued for
+ * this client in the current epoll batch fails the "is it a current role?" guard in
+ * the main loop and is skipped instead of dereferencing freed memory.
+ */
+static void drop_client(daemon_ctx *ctx, struct client *c)
+{
+    if (!c)
+        return;
+    if (c == ctx->consumer) {
+        fprintf(stderr, "daemon: consumer disconnected\n");
+        ctx->consumer = NULL;
+        /* The deposited fds belong to the consumer that just left; a future producer
+         * must never be handed this stale set. Drop them together with the consumer. */
+        clear_deposited_fds(ctx);
+    } else if (c == ctx->producer) {
+        fprintf(stderr, "daemon: producer disconnected\n");
+        ctx->producer = NULL;
+        ctx->producer_waiting_screen = false;
+        ctx->producer_waiting_fds = false;
+    }
+    client_free(ctx, c);
+}
+
+static void handle_client_data(daemon_ctx *ctx, struct client *c)
+{
+    struct ctrl_msg hdr;
+    int fds[MAX_FDS];
+    int fd_count = 0;
+
+    int n = recv_fds(c->ctrl_fd, &hdr, sizeof(hdr), fds, MAX_FDS, &fd_count);
+    if (n <= 0) {
+        drop_client(ctx, c);
+        return;
+    }
+
+    uint8_t payload[sizeof(struct screen_info)];
+    if (hdr.size > 0) {
+        if (hdr.size > sizeof(payload) || recv_all(c->ctrl_fd, payload, hdr.size) < 0) {
+            drop_client(ctx, c);
+            return;
+        }
+    }
+
+    switch (hdr.type) {
+    case CTRL_MSG_CONSUMER_HELLO:
+        if (c == ctx->consumer && fd_count >= MAX_FDS - 1) {
+            clear_deposited_fds(ctx);
+            memcpy(ctx->deposited_fds, fds, sizeof(int) * fd_count);
+            ctx->deposited_fd_count = fd_count;
+            fprintf(stderr, "daemon: consumer re-deposited %d fds\n", fd_count);
+            if (ctx->producer_waiting_fds)
+                try_deliver_fds(ctx);
+        }
+        break;
+
+    case CTRL_MSG_SCREEN_INFO:
+        if (c == ctx->consumer && hdr.size == sizeof(struct screen_info)) {
+            struct screen_info si;
+            memcpy(&si, payload, sizeof(si));
+            /* Always accept the consumer's screen info, even if it differs from a
+             * previous connection — the Android display may have rotated or switched
+             * resolution. Overwrite and forward to any waiting producer. */
+            ctx->stored_screen = si;
+            ctx->has_screen_info = true;
+            fprintf(stderr, "daemon: screen info %ux%u fmt=%u\n",
+                    si.width, si.height, si.format);
+            if (ctx->producer_waiting_screen && ctx->producer) {
+                send_screen_info_msg(ctx, ctx->producer->ctrl_fd);
+                ctx->producer_waiting_screen = false;
+            }
+        }
+        break;
+
+    case CTRL_MSG_PICKUP_FDS:
+        if (c == ctx->producer)
+            try_deliver_fds(ctx);
+        break;
+
+    default:
+        break;
+    }
+}
+
+static void handle_new_connection(daemon_ctx *ctx, int listen_fd)
+{
+    int client_fd = accept(listen_fd, NULL, NULL);
+    if (client_fd < 0)
+        return;
+
+    struct ctrl_msg hdr;
+    int fds[MAX_FDS];
+    int fd_count = 0;
+
+    int n = recv_fds(client_fd, &hdr, sizeof(hdr), fds, MAX_FDS, &fd_count);
+    if (n < (int)sizeof(struct ctrl_msg)) {
+        close(client_fd);
+        return;
+    }
+
+    struct client *c = calloc(1, sizeof(*c));
+    if (!c) {
+        close(client_fd);
+        return;
+    }
+    c->ctrl_fd = client_fd;
+
+    if (hdr.type == CTRL_MSG_CONSUMER_HELLO) {
+        /* Evict any prior consumer (alive or ghost) and its stale deposit before this
+         * one takes over the role. */
+        if (ctx->consumer)
+            drop_client(ctx, ctx->consumer);
+        c->is_consumer = true;
+        ctx->consumer = c;
+
+        clear_deposited_fds(ctx);
+        memcpy(ctx->deposited_fds, fds, sizeof(int) * fd_count);
+        ctx->deposited_fd_count = fd_count;
+        fprintf(stderr, "daemon: consumer connected, %d fds\n", fd_count);
+
+        if (ctx->producer_waiting_fds)
+            try_deliver_fds(ctx);
+
+    } else if (hdr.type == CTRL_MSG_PRODUCER_HELLO) {
+        /* Evict any prior producer (alive or ghost) before this one takes over. */
+        if (ctx->producer)
+            drop_client(ctx, ctx->producer);
+        c->is_consumer = false;
+        ctx->producer = c;
+        ctx->producer_waiting_screen = false;
+        ctx->producer_waiting_fds = false;
+        fprintf(stderr, "daemon: producer connected\n");
+
+        if (ctx->has_screen_info)
+            send_screen_info_msg(ctx, client_fd);
+        else
+            ctx->producer_waiting_screen = true;
+
+    } else {
+        close(client_fd);
+        free(c);
+        return;
+    }
+
+    struct epoll_event ev = { .events = EPOLLIN | EPOLLHUP | EPOLLERR, .data.ptr = c };
+    epoll_ctl(ctx->epoll_fd, EPOLL_CTL_ADD, client_fd, &ev);
+}
+
+int daemon_create(daemon_ctx **out, const char *sock_path)
+{
+    daemon_ctx *ctx = calloc(1, sizeof(*ctx));
+    if (!ctx)
+        return -1;
+    ctx->epoll_fd = -1;
+    ctx->listen_fd = -1;
+    ctx->running = true;
+    strncpy(ctx->sock_path, sock_path, sizeof(ctx->sock_path) - 1);
+
+    unlink(sock_path);
+    ctx->listen_fd = socket(AF_UNIX, SOCK_STREAM, 0);
+    if (ctx->listen_fd < 0) {
+        perror("socket");
+        daemon_destroy(ctx);
+        return -1;
+    }
+
+    struct sockaddr_un addr;
+    memset(&addr, 0, sizeof(addr));
+    addr.sun_family = AF_UNIX;
+    strncpy(addr.sun_path, sock_path, sizeof(addr.sun_path) - 1);
+
+    if (bind(ctx->listen_fd, (struct sockaddr *)&addr, sizeof(addr)) < 0) {
+        perror("bind");
+        daemon_destroy(ctx);
+        return -1;
+    }
+    if (listen(ctx->listen_fd, 4) < 0) {
+        perror("listen");
+        daemon_destroy(ctx);
+        return -1;
+    }
+
+    ctx->epoll_fd = epoll_create1(0);
+    if (ctx->epoll_fd < 0) {
+        perror("epoll_create1");
+        daemon_destroy(ctx);
+        return -1;
+    }
+    struct epoll_event ev = { .events = EPOLLIN, .data.ptr = NULL };
+    epoll_ctl(ctx->epoll_fd, EPOLL_CTL_ADD, ctx->listen_fd, &ev);
+
+    fprintf(stderr, "daemon: listening on %s\n", sock_path);
+
+    *out = ctx;
+    return 0;
+}
+
+void daemon_run(daemon_ctx *ctx)
+{
+    struct epoll_event events[MAX_EVENTS];
+    while (ctx->running) {
+        int nfds = epoll_wait(ctx->epoll_fd, events, MAX_EVENTS, 1000);
+        for (int i = 0; i < nfds; i++) {
+            if (events[i].data.ptr == NULL) {
+                handle_new_connection(ctx, ctx->listen_fd);
+            } else {
+                struct client *c = events[i].data.ptr;
+                /* A client freed earlier in this same batch -- a real disconnect, or
+                 * one evicted by a new connection taking over its role -- leaves a
+                 * stale event behind. Skip anything that is no longer a current role
+                 * so we never touch freed memory. */
+                if (c != ctx->consumer && c != ctx->producer)
+                    continue;
+                if (events[i].events & (EPOLLHUP | EPOLLERR))
+                    drop_client(ctx, c);
+                else
+                    handle_client_data(ctx, c);
+            }
+        }
+    }
+}
+
+void daemon_stop(daemon_ctx *ctx)
+{
+    if (ctx)
+        ctx->running = false;
+}
+
+void daemon_destroy(daemon_ctx *ctx)
+{
+    if (!ctx)
+        return;
+
+    clear_deposited_fds(ctx);
+    client_free(ctx, ctx->consumer);
+    client_free(ctx, ctx->producer);
+    if (ctx->listen_fd >= 0)
+        close(ctx->listen_fd);
+    if (ctx->epoll_fd >= 0)
+        close(ctx->epoll_fd);
+    if (ctx->sock_path[0])
+        unlink(ctx->sock_path);
+    fprintf(stderr, "daemon: shutdown\n");
+    free(ctx);
+}

--- a/src/anland/display_daemon.h
+++ b/src/anland/display_daemon.h
@@ -1,0 +1,29 @@
+#ifndef DISPLAY_DAEMON_H
+#define DISPLAY_DAEMON_H
+
+/*
+ * Relay daemon that brokers the consumer/producer handshake: it stashes the
+ * consumer's screen info and deposited fds, then hands them to the producer.
+ *
+ * All runtime state lives in an opaque daemon_ctx, so multiple independent
+ * instances can coexist in one process. The library installs no signal handlers
+ * and touches no process-global state; the hosting program owns that (see
+ * daemon/daemon.c for the standalone ELF).
+ */
+typedef struct daemon_ctx daemon_ctx;
+
+/* Create an instance listening on sock_path (internally unlink+bind+listen and
+ * sets up epoll). Returns 0 on success, -1 on failure. */
+int  daemon_create(daemon_ctx **out, const char *sock_path);
+
+/* Run the epoll loop until daemon_stop() is called. Blocking. */
+void daemon_run(daemon_ctx *ctx);
+
+/* Request the run loop to exit. Only sets a volatile flag, so it is safe to call
+ * from a signal handler or another thread. */
+void daemon_stop(daemon_ctx *ctx);
+
+/* Close all clients and sockets, unlink the socket path, and free ctx. */
+void daemon_destroy(daemon_ctx *ctx);
+
+#endif

--- a/src/anland/protocol.h
+++ b/src/anland/protocol.h
@@ -1,0 +1,193 @@
+#ifndef DISPLAY_PROTOCOL_H
+#define DISPLAY_PROTOCOL_H
+
+#include <stdint.h>
+
+#define CTRL_MSG_CONSUMER_HELLO  1
+#define CTRL_MSG_PRODUCER_HELLO  2
+#define CTRL_MSG_SCREEN_INFO     7
+#define CTRL_MSG_REJECT          8
+#define CTRL_MSG_PICKUP_FDS      9
+#define CTRL_MSG_FDS_READY      10
+
+#define DATA_MSG_BUF_READY       100
+#define DATA_MSG_REFRESH_DONE    101
+#define DATA_MSG_INPUT_EVENT     102
+#define DATA_MSG_OUTPUT_EVENT    103
+#define DATA_MSG_INPUT_EXTEND_FDS  104
+#define DATA_MSG_BUFS_READY      200
+
+#define MAX_BUFS 8
+
+struct ctrl_msg {
+    uint32_t type;
+    uint32_t size;
+    uint8_t  payload[];
+} __attribute__((packed));
+
+struct data_msg {
+    uint32_t type;
+    uint32_t size;
+    uint8_t  payload[];
+} __attribute__((packed));
+
+struct screen_info {
+    uint32_t width;
+    uint32_t height;
+    uint32_t format;
+    uint32_t refresh;
+} __attribute__((packed));
+
+struct buf_info {
+    uint32_t stride;
+    uint32_t width;      /* buffer logical width  (consumer-side native resolution) */
+    uint32_t height;     /* buffer logical height (consumer-side native resolution) */
+    uint32_t format;
+    uint64_t modifier;
+    uint32_t offset;
+} __attribute__((packed));
+
+#define INPUT_TYPE_TOUCH          1
+#define INPUT_TYPE_KEY            2
+#define INPUT_TYPE_POINTER_MOTION 3
+#define INPUT_TYPE_POINTER_BUTTON 4
+#define INPUT_TYPE_POINTER_AXIS   5
+#define INPUT_TYPE_TOUCH_FRAME    6
+/* Not really input: the consumer reports its current display refresh rate over
+ * the same data channel so the producer can repace its RenderLoop at runtime.
+ * Deliberately reuses the InputEvent framing (DATA_MSG_INPUT_EVENT) so the
+ * producer's poll_input_event() drains it like any other event instead of
+ * stalling the stream on an unknown DATA_MSG_* header. */
+#define INPUT_TYPE_DISPLAY_REFRESH 7
+#define INPUT_TYPE_CLIPBOARD      8
+#define INPUT_TYPE_TEXT_INPUT      9
+#define INPUT_TYPE_ACTION 10
+#define INPUT_TYPE_RESOURCE 11
+#define INPUT_TYPE_RESOURCE_INVALID 12
+
+#define SERVICE_TYPE_CAMERA 1
+
+#define INPUT_ACTION_DOWN    0
+
+#define INPUT_ACTION_DOWN    0
+#define INPUT_ACTION_UP      1
+#define INPUT_ACTION_MOVE    2
+
+#define OUTPUT_TYPE_CLIPBOARD 1
+#define OUTPUT_TYPE_RESOURCES_REQUEST 2
+
+
+
+struct InputEvent {
+    uint32_t type;
+    union {
+        struct {
+            int32_t  action;
+            float    x;
+            float    y;
+            int32_t  pointer_id;
+        } touch;
+        struct {
+            int32_t  action;
+            int32_t  keycode;
+        } key;
+        struct {
+            float    x;
+            float    y;
+            float    dx;
+            float    dy;
+        } pointer_motion;
+        struct {
+            uint32_t button;
+            int32_t  pressed;
+        } pointer_button;
+        struct {
+            uint32_t axis;
+            float    value;
+            int32_t  discrete;
+        } pointer_axis;
+        struct {
+            uint32_t refresh_mhz; // current display refresh rate, milli-Hz
+        } display;
+        struct {
+            uint32_t size; //这个packet只是通知包 作为header真正数据会集中发送,这里通知随后数据的大小
+        } clipboard;
+        struct {
+            uint32_t size; //这个packet只是通知包 作为header真正数据会集中发送,这里通知随后数据的大小
+        } text_input;
+        struct {
+            uint32_t action;
+            int32_t value;
+        } input_action;
+        struct {
+            uint32_t type;
+            uint32_t fdnum;//fdnum是fd的数量,后续会有fdnum个fd跟随在这个结构体后面
+        } resource;
+        struct {
+            uint32_t padding[4];
+        };
+    };
+} __attribute__((packed));
+
+struct OutputEvent{
+    uint32_t type;
+    union {
+        struct {
+            uint32_t size; //这个packet只是通知包 作为header真正数据会集中发送,这里通知随后数据的大小
+        } clipboard;
+        struct {
+            uint32_t type;
+            uint32_t args[3]; //support 3 args
+        } resources_request;
+        struct
+        {
+            uint32_t padding[4];
+        };
+
+    };
+} __attribute__((packed));
+
+/*
+ * Audio runs on its own dedicated bidirectional socketpair (hello fd slot 4),
+ * deliberately kept off the data channel so a burst of PCM never head-of-line
+ * blocks input/clipboard. The socket is full duplex: the producer writes desktop
+ * playback PCM that the consumer reads, and the consumer writes microphone PCM
+ * that the producer reads -- each side only ever reads what the other wrote.
+ * Every direction sends one AUDIO_MSG_FORMAT, then a stream of AUDIO_MSG_PCM.
+ *
+ * PCM is interleaved per frame. For stereo (channels == 2) the sample order
+ * within each frame is LEFT then RIGHT, i.e. channel positions FL, FR -- the
+ * producer's SPA channel map and the consumer's AAudio stereo layout must both
+ * honour this order so the left/right channels are never swapped.
+ *
+ * Audio quality is negotiated, not pinned: the consumer owns the real hardware,
+ * so on connect it opens its AAudio streams, reads back the rate/channels the
+ * device actually chose, and sends one AUDIO_MSG_FORMAT per direction (tagged with
+ * role) to the producer. The producer builds its PipeWire sink/source to match,
+ * so neither side resamples blindly and the PCM byte math lines up on both ends.
+ */
+#define AUDIO_MSG_FORMAT 1
+#define AUDIO_MSG_PCM    2
+
+/* PCM sample format codes for struct audio_format.format. */
+#define AUDIO_FORMAT_S16LE 0
+
+/* Which direction a struct audio_format describes. */
+#define AUDIO_ROLE_PLAYBACK 0   /* producer -> consumer (desktop sound -> speaker) */
+#define AUDIO_ROLE_CAPTURE  1   /* consumer -> producer (mic -> virtual source)    */
+
+struct audio_format {
+    uint32_t rate;       /* frames per second the device chose, e.g. 48000 / 44100 */
+    uint32_t channels;   /* interleaved; stereo is L,R (FL,FR) */
+    uint32_t format;     /* AUDIO_FORMAT_* */
+    uint32_t role;       /* AUDIO_ROLE_* -- which direction this describes */
+    uint32_t quantum;    /* requested buffer in frames (latency preset); 0 = engine default */
+} __attribute__((packed));
+
+struct audio_msg {
+    uint32_t type;       /* AUDIO_MSG_FORMAT | AUDIO_MSG_PCM */
+    uint32_t size;       /* payload bytes that follow this header */
+} __attribute__((packed));
+
+
+#endif

--- a/src/anland/socket_utils.c
+++ b/src/anland/socket_utils.c
@@ -1,0 +1,121 @@
+#include "socket_utils.h"
+
+#include <errno.h>
+#include <stdint.h>
+#include <string.h>
+#include <sys/socket.h>
+#include <sys/un.h>
+#include <unistd.h>
+
+int send_fds(int sock, const void *data, size_t data_len,
+             const int *fds, int fd_count)
+{
+    struct iovec iov = {
+        .iov_base = (void *)data,
+        .iov_len  = data_len,
+    };
+
+    char cmsg_buf[CMSG_SPACE(sizeof(int) * fd_count)];
+    memset(cmsg_buf, 0, sizeof(cmsg_buf));
+
+    struct msghdr msg = {
+        .msg_iov        = &iov,
+        .msg_iovlen     = 1,
+        .msg_control    = cmsg_buf,
+        .msg_controllen = sizeof(cmsg_buf),
+    };
+
+    struct cmsghdr *cmsg = CMSG_FIRSTHDR(&msg);
+    cmsg->cmsg_level = SOL_SOCKET;
+    cmsg->cmsg_type  = SCM_RIGHTS;
+    cmsg->cmsg_len   = CMSG_LEN(sizeof(int) * fd_count);
+    memcpy(CMSG_DATA(cmsg), fds, sizeof(int) * fd_count);
+
+    ssize_t n = sendmsg(sock, &msg, MSG_NOSIGNAL);
+    return (n == (ssize_t)data_len) ? 0 : -1;
+}
+
+int recv_fds(int sock, void *data, size_t data_len,
+             int *fds, int fd_count, int *fds_received)
+{
+    struct iovec iov = {
+        .iov_base = data,
+        .iov_len  = data_len,
+    };
+
+    char cmsg_buf[CMSG_SPACE(sizeof(int) * fd_count)];
+    memset(cmsg_buf, 0, sizeof(cmsg_buf));
+
+    struct msghdr msg = {
+        .msg_iov        = &iov,
+        .msg_iovlen     = 1,
+        .msg_control    = cmsg_buf,
+        .msg_controllen = sizeof(cmsg_buf),
+    };
+
+    ssize_t n = recvmsg(sock, &msg, 0);
+    if (n <= 0)
+        return -1;
+
+    *fds_received = 0;
+    struct cmsghdr *cmsg = CMSG_FIRSTHDR(&msg);
+    if (cmsg && cmsg->cmsg_level == SOL_SOCKET && cmsg->cmsg_type == SCM_RIGHTS) {
+        int count = (cmsg->cmsg_len - CMSG_LEN(0)) / sizeof(int);
+        if (count > fd_count)
+            count = fd_count;
+        memcpy(fds, CMSG_DATA(cmsg), sizeof(int) * count);
+        *fds_received = count;
+    }
+
+    return (int)n;
+}
+
+int connect_unix(const char *path)
+{
+    int fd = socket(AF_UNIX, SOCK_STREAM, 0);
+    if (fd < 0)
+        return -1;
+
+    struct sockaddr_un addr;
+    memset(&addr, 0, sizeof(addr));
+    addr.sun_family = AF_UNIX;
+    strncpy(addr.sun_path, path, sizeof(addr.sun_path) - 1);
+
+    if (connect(fd, (struct sockaddr *)&addr, sizeof(addr)) < 0) {
+        close(fd);
+        return -1;
+    }
+    return fd;
+}
+
+int send_all(int fd, const void *buf, size_t len)
+{
+    const uint8_t *p = buf;
+    size_t sent = 0;
+    while (sent < len) {
+        ssize_t n = send(fd, p + sent, len - sent, MSG_NOSIGNAL);
+        if (n <= 0) {
+            if (n < 0 && errno == EINTR)
+                continue;
+            return -1;
+        }
+        sent += n;
+    }
+    return 0;
+}
+
+int recv_all(int fd, void *buf, size_t len)
+{
+    uint8_t *p = buf;
+    size_t got = 0;
+    while (got < len) {
+        ssize_t n = recv(fd, p + got, len - got, 0);
+        if (n <= 0) {
+            if (n < 0 && errno == EINTR)
+                continue;
+            return -1;
+        }
+        got += n;
+    }
+    return 0;
+}

--- a/src/anland/socket_utils.h
+++ b/src/anland/socket_utils.h
@@ -1,0 +1,18 @@
+#ifndef DISPLAY_SOCKET_UTILS_H
+#define DISPLAY_SOCKET_UTILS_H
+
+#include <stddef.h>
+
+int send_fds(int sock, const void *data, size_t data_len,
+             const int *fds, int fd_count);
+
+int recv_fds(int sock, void *data, size_t data_len,
+             int *fds, int fd_count, int *fds_received);
+
+int connect_unix(const char *path);
+
+int send_all(int fd, const void *buf, size_t len);
+
+int recv_all(int fd, void *buf, size_t len);
+
+#endif

--- a/src/config.c
+++ b/src/config.c
@@ -291,6 +291,8 @@ int ds_config_load(const char *config_path, struct ds_config *cfg) {
       cfg->virgl_extra_flags = val[0] ? strdup(val) : NULL;
     } else if (strcmp(key, "enable_pulseaudio") == 0) {
       cfg->pulseaudio = parse_bool(val);
+    } else if (strcmp(key, "enable_anland") == 0) {
+      cfg->anland = parse_bool(val);
     } else if (strcmp(key, "selinux_permissive") == 0) {
       cfg->selinux_permissive = parse_bool(val);
     } else if (strcmp(key, "volatile_mode") == 0) {
@@ -637,6 +639,7 @@ static void ds_config_serialize_known(FILE *f, struct ds_config *cfg) {
     if (cfg->virgl_extra_flags)
       fprintf(f, "virgl_extra_flags=%s\n", cfg->virgl_extra_flags);
     fprintf(f, "enable_pulseaudio=%d\n", cfg->pulseaudio);
+    fprintf(f, "enable_anland=%d\n", cfg->anland);
   }
   fprintf(f, "enable_hw_access=%d\n", cfg->hw_access);
   fprintf(f, "enable_gpu_mode=%d\n", cfg->gpu_mode);

--- a/src/config.c
+++ b/src/config.c
@@ -90,6 +90,10 @@ void parse_privileged(const char *value, struct ds_config *cfg) {
 
     token = strtok_r(NULL, ",", &saveptr);
   }
+
+  if (cfg->userns_allowed) {
+    cfg->privileged_mask |= DS_PRIV_USERNS;
+  }
 }
 
 static void parse_bind_mounts(const char *value, struct ds_config *cfg) {
@@ -295,6 +299,8 @@ int ds_config_load(const char *config_path, struct ds_config *cfg) {
       cfg->anland = parse_bool(val);
     } else if (strcmp(key, "selinux_permissive") == 0) {
       cfg->selinux_permissive = parse_bool(val);
+    } else if (strcmp(key, "allow_userns") == 0) {
+      cfg->userns_allowed = parse_bool(val);
     } else if (strcmp(key, "volatile_mode") == 0) {
       cfg->volatile_mode = parse_bool(val);
     } else if (strcmp(key, "force_cgroupv1") == 0) {
@@ -644,6 +650,7 @@ static void ds_config_serialize_known(FILE *f, struct ds_config *cfg) {
   fprintf(f, "enable_hw_access=%d\n", cfg->hw_access);
   fprintf(f, "enable_gpu_mode=%d\n", cfg->gpu_mode);
   fprintf(f, "selinux_permissive=%d\n", cfg->selinux_permissive);
+  fprintf(f, "allow_userns=%d\n", cfg->userns_allowed);
   fprintf(f, "volatile_mode=%d\n", cfg->volatile_mode);
   fprintf(f, "force_cgroupv1=%d\n", cfg->force_cgroupv1);
   fprintf(f, "block_nested_ns=%d\n", cfg->block_nested_ns);
@@ -682,6 +689,8 @@ static void ds_config_serialize_known(FILE *f, struct ds_config *cfg) {
         fprintf(f, "%sunfiltered-dev", first ? "" : ",");
         first = 0;
       }
+
+      /// Note that DS_PRIV_USERNS is controlled by allow_userns, not the privileged list, so we don't write it here. 
     }
     fprintf(f, "\n");
   }

--- a/src/container.c
+++ b/src/container.c
@@ -184,6 +184,7 @@ void cleanup_container_resources(struct ds_config *cfg, pid_t pid,
     ds_x11_daemon_stop(cfg);
     ds_virgl_daemon_stop(cfg);
     ds_pulse_daemon_stop(cfg);
+    ds_anland_daemon_stop(cfg);
     if (count_running_containers(NULL, 0) == 0) {
       android_optimizations(0);
     }
@@ -499,6 +500,14 @@ int start_rootfs(struct ds_config *cfg) {
 
   if (is_android() && cfg->pulseaudio) {
     ds_pulse_daemon_start(cfg);
+  }
+
+  /* anland display daemon: generate the per-container host socket and start the
+   * broker before fork so the socket exists when bind-mounted post-pivot. The
+   * generated cfg->anland_sock is recorded in the Pids dir (not container.config)
+   * by ds_anland_daemon_start. */
+  if (is_android() && cfg->anland) {
+    ds_anland_daemon_start(cfg);
   }
 
   /* 3. Early pre-flight for volatile mode (before any host changes) */

--- a/src/hardware.c
+++ b/src/hardware.c
@@ -806,5 +806,8 @@ int setup_hardware_access(struct ds_config *cfg) {
   /* 4. Setup PulseAudio socket (Android only) */
   ds_setup_pulse_socket(cfg);
 
+  /* 5. Setup anland display socket -> /run/display.sock (Android only) */
+  ds_setup_anland_socket(cfg);
+
   return 0;
 }

--- a/src/include/droidspace.h
+++ b/src/include/droidspace.h
@@ -325,6 +325,7 @@ struct ds_port_forward {
 #define DS_PRIV_UNFILTERED                                                     \
   (1 << 4)                  /* No device node blocking (except PTYs)           \
                              */
+#define DS_PRIV_USERNS  (1 << 5) /* Allow user namespace blocking */
 #define DS_PRIV_FULL (0xFF) /* All above */
 
 typedef enum {
@@ -370,6 +371,7 @@ struct ds_config {
   int disable_ipv6;        /* --disable-ipv6 */
   int android_storage;     /* --enable-android-storage */
   int selinux_permissive;  /* --selinux-permissive */
+  int userns_allowed;       /* --allow-userns */
   int net_bridgeless;      /* Probe result: no CONFIG_BRIDGE, use PTP NAT */
   int reboot_cycle;        /* 1 if we are in a reboot loop */
   int force_cgroupv1;  /* --force-cgroupv1: use v1 even if v2 is available */

--- a/src/include/droidspace.h
+++ b/src/include/droidspace.h
@@ -365,6 +365,7 @@ struct ds_config {
   int virgl;              /* --virgl (Android only) */
   char *virgl_extra_flags; /* --virgl-flags "..." (heap, NULL if unset) */
   int pulseaudio;          /* --pulse-audio (Android only) */
+  int anland;              /* --anland: embed anland display daemon (Android) */
   int volatile_mode;       /* --volatile */
   int disable_ipv6;        /* --disable-ipv6 */
   int android_storage;     /* --enable-android-storage */
@@ -385,6 +386,8 @@ struct ds_config {
   pid_t x11_pid;                  /* PID of the Termux-X11 server process */
   pid_t virgl_pid;                /* PID of the VirGL server process */
   pid_t pulse_pid;                /* PID of the PulseAudio daemon process */
+  pid_t anland_pid;               /* PID of the anland display daemon process */
+  char anland_sock[PATH_MAX];     /* generated host socket for the anland daemon */
   int is_img_mount;               /* 1 if rootfs was loop-mounted from .img */
   char img_mount_point[PATH_MAX]; /* where the .img was mounted */
   ds_init_type_t init_type;       /* detected container PID 1 init family */
@@ -652,6 +655,14 @@ int setup_hardware_access(struct ds_config *cfg);
 int ds_x11_daemon_start(struct ds_config *cfg);
 void ds_x11_daemon_stop(struct ds_config *cfg);
 int ds_setup_x11_socket(struct ds_config *cfg);
+
+/* ---------------------------------------------------------------------------
+ * anland/anland.c
+ * ---------------------------------------------------------------------------*/
+
+int ds_anland_daemon_start(struct ds_config *cfg);
+void ds_anland_daemon_stop(struct ds_config *cfg);
+int ds_setup_anland_socket(struct ds_config *cfg);
 
 /* ---------------------------------------------------------------------------
  * virgl-android.c

--- a/src/main.c
+++ b/src/main.c
@@ -90,7 +90,9 @@ void print_usage(void) {
       "      --virgl-flags=\"FLAGS\"   Extra flags passed to "
       "virgl_test_server_android\n"
       "      --pulse-audio         Configure PulseAudio sound server "
-      "support\n\n");
+      "support\n"
+      "      --anland              Embed the anland display daemon "
+      "(Android)\n\n");
 
   printf(
       C_BOLD
@@ -413,6 +415,7 @@ int main(int argc, char **argv) {
       {"virgl", no_argument, 0, 270},
       {"virgl-flags", required_argument, 0, 272},
       {"pulse-audio", no_argument, 0, 273},
+      {"anland", no_argument, 0, 278},
       {"gateway", required_argument, 0, 274},
       {"gateway-container", required_argument, 0, 274},
       {"gateway-net", required_argument, 0, 275},
@@ -676,6 +679,9 @@ int main(int argc, char **argv) {
       break;
     case 273:
       cfg.pulseaudio = 1;
+      break;
+    case 278:
+      cfg.anland = 1;
       break;
     case 274:
       safe_strncpy(cfg.gateway_container, optarg,

--- a/src/main.c
+++ b/src/main.c
@@ -107,7 +107,8 @@ void print_usage(void) {
       "      --cpus=COUNT          CPU limit (e.g. 1.5, 2)\n"
       "      --pids-limit=N        Max number of PIDs\n"
       "      --privileged=TAGS     Relax security: nomask, nocaps, noseccomp, "
-      "shared, unfiltered-dev, full\n\n");
+      "shared, unfiltered-dev, full\n"
+      "      --allow-userns        Allow user namespaces\n\n");
 
   printf(
       C_BOLD
@@ -397,6 +398,7 @@ int main(int argc, char **argv) {
       {"disable-ipv6", no_argument, 0, 'I'},
       {"enable-android-storage", no_argument, 0, 'S'},
       {"selinux-permissive", no_argument, 0, 'P'},
+      {"allow-userns", no_argument, 0, 279},
       {"volatile", no_argument, 0, 'V'},
       {"bind-mount", required_argument, 0, 'B'},
       {"bind", required_argument, 0, 'B'},
@@ -705,6 +707,9 @@ int main(int argc, char **argv) {
       break;
     case 'P':
       cfg.selinux_permissive = 1;
+      break;
+    case 279:
+      cfg.userns_allowed = 1;
       break;
     case 'V':
       cfg.volatile_mode = 1;

--- a/src/seccomp.c
+++ b/src/seccomp.c
@@ -99,6 +99,7 @@ int ds_seccomp_apply_minimal(int privileged_mask) {
         (struct sock_filter)BPF_STMT(BPF_RET | BPF_K, SECCOMP_RET_KILL_PROCESS);
 #endif
 
+    if (!(privileged_mask & DS_PRIV_USERNS)) {
 #ifdef __NR_clone3
     /* 6. Block clone3 */
     filter[curr++] = (struct sock_filter)BPF_JUMP(BPF_JMP | BPF_JEQ | BPF_K,
@@ -128,7 +129,7 @@ int ds_seccomp_apply_minimal(int privileged_mask) {
                                                   0x10000000, 0, 1);
     filter[curr++] = (struct sock_filter)BPF_STMT(
         BPF_RET | BPF_K, SECCOMP_RET_ERRNO | (EPERM & SECCOMP_RET_DATA));
-
+    }
     /*
      * 9. CVE-2026-31431 ("Copy Fail") - mitigation layer 2.
      *
@@ -153,7 +154,6 @@ int ds_seccomp_apply_minimal(int privileged_mask) {
     /* Reload nr for any rules that follow this block. */
     filter[curr++] = (struct sock_filter)BPF_STMT(
         BPF_LD | BPF_W | BPF_ABS, offsetof(struct seccomp_data, nr));
-
     /*
      * 10. Block host clock modification syscalls.
      *

--- a/src/utils.c
+++ b/src/utils.c
@@ -1222,7 +1222,9 @@ void ds_log_internal(const char *prefix, const char *color, int is_err,
         strncmp(raw_msg, "[DHCP]", 6) == 0 ||
         strncmp(raw_msg, "[VirGL]", 7) == 0 ||
         strncmp(raw_msg, "[PulseAudio]", 12) == 0 ||
-        strncmp(raw_msg, "[X11]", 5) == 0) {
+        strncmp(raw_msg, "[X11]", 5) == 0 ||
+        strncmp(raw_msg, "[anland]", 8) == 0
+      ) {
       return;
     }
   }


### PR DESCRIPTION
For some reason, with userns disabled, some Anland Compositors may work quite slow.
So add an option to enable userns without breaking isolation and warning.

However, this may cause container vulnerable to certain exploits like Fragnesia without a patched kernel.
