### PR TITLE
feat(ui): support AMOLED mode with system theme and preserve selection

### DIFF
--- a/Android/app/src/main/java/com/droidspaces/app/ui/screen/SettingsScreen.kt
+++ b/Android/app/src/main/java/com/droidspaces/app/ui/screen/SettingsScreen.kt
@@ -332,11 +332,6 @@ fun SettingsScreen(
                 checked = followSystemTheme,
                 onCheckedChange = { checked ->
                     prefsManager.followSystemTheme = checked
-                    // Disable AMOLED mode when enabling follow system theme
-                    // Theme state updates automatically via SharedPreferences listener
-                    if (checked && amoledMode) {
-                        prefsManager.amoledMode = false
-                    }
                 }
             )
 
@@ -349,28 +344,23 @@ fun SettingsScreen(
                     checked = darkTheme,
                     onCheckedChange = { checked ->
                         prefsManager.darkTheme = checked
-                        // Disable AMOLED if dark theme is disabled
-                        // Theme state updates automatically via SharedPreferences listener
-                        if (!checked && amoledMode) {
-                            prefsManager.amoledMode = false
-                        }
                     }
                 )
+            }
 
-                // AMOLED Mode (only shown when dark theme is explicitly enabled, directly beneath Dark Theme)
-                if (darkTheme) {
-                    SwitchItem(
-                        icon = Icons.Default.RadioButtonUnchecked,
-                        title = context.getString(R.string.amoled_mode),
-                        summary = context.getString(R.string.amoled_mode_description),
-                        checked = amoledMode,
-                        enabled = true,
-                        onCheckedChange = { checked ->
-                            prefsManager.amoledMode = checked
-                            // Theme state updates automatically via SharedPreferences listener
-                        }
-                    )
-                }
+            // AMOLED Mode (shown when followSystemTheme is true OR manual darkTheme is true)
+            if (followSystemTheme || darkTheme) {
+                SwitchItem(
+                    icon = Icons.Default.RadioButtonUnchecked,
+                    title = context.getString(R.string.amoled_mode),
+                    summary = context.getString(R.string.amoled_mode_description),
+                    checked = amoledMode,
+                    enabled = true,
+                    onCheckedChange = { checked ->
+                        prefsManager.amoledMode = checked
+                        // Theme state updates automatically via SharedPreferences listener
+                    }
+                )
             }
 
             // Use Dynamic Color (Monet theming) - Only show on Android 12+

--- a/Android/app/src/main/java/com/droidspaces/app/ui/theme/ThemeStateHolder.kt
+++ b/Android/app/src/main/java/com/droidspaces/app/ui/theme/ThemeStateHolder.kt
@@ -76,14 +76,13 @@ fun rememberThemeState(): ThemeState {
 
     val systemDark = isSystemInDarkTheme()
     val effectiveDarkTheme = if (followSystemTheme) systemDark else darkTheme
-    val effectiveAmoledMode = amoledMode && effectiveDarkTheme // AMOLED only works with dark theme
 
     // Return state that triggers recomposition when any theme preference changes
     return remember(followSystemTheme, darkTheme, amoledMode, useDynamicColor, systemDark, themePalette) {
         ThemeState(
             followSystemTheme = followSystemTheme,
             darkTheme = effectiveDarkTheme,
-            amoledMode = effectiveAmoledMode,
+            amoledMode = amoledMode,
             useDynamicColor = useDynamicColor,
             themePalette = themePalette
         )


### PR DESCRIPTION
Previously, the AMOLED dark mode didn't work with the "Follow System Theme" option enabled. This PR fixes that and memorizes the state of the AMOLED dark mode even after toggling the "Follow System Theme" or the "Dark Theme" option.
I've added screen recordings for a before and after comparison.

https://github.com/user-attachments/assets/219441b4-cdb9-42ad-a632-ecc590205d17


https://github.com/user-attachments/assets/e6306c0a-b8b6-4fd3-ae4f-2146d85a26bf

