### PR TITLE
Add Anland toggle in installation flow

### DIFF
--- a/Android/app/src/main/java/com/droidspaces/app/ui/navigation/DroidspacesNavigation.kt
+++ b/Android/app/src/main/java/com/droidspaces/app/ui/navigation/DroidspacesNavigation.kt
@@ -346,6 +346,7 @@ fun DroidspacesNavigation(
                 initialEnableGpuMode = viewModel.enableGpuMode,
                 initialEnableTermuxX11 = viewModel.enableTermuxX11,
                 initialTx11ExtraFlags = viewModel.tx11ExtraFlags,
+                initialEnableAnland = viewModel.enableAnland,
                 initialEnableVirgl = viewModel.enableVirgl,
                 initialVirglExtraFlags = viewModel.virglExtraFlags,
                 initialEnablePulseaudio = viewModel.enablePulseaudio,
@@ -369,8 +370,8 @@ fun DroidspacesNavigation(
                 initialGatewayBridge = viewModel.gatewayBridge,
                 containerName = viewModel.containerName,
                 installedContainers = sharedContainerViewModel.containerList,
-                onNext = { netMode, disableIPv6, enableAndroidStorage, enableHwAccess, enableGpuMode, enableTermuxX11, tx11ExtraFlags, enableVirgl, virglExtraFlags, enablePulseaudio, selinuxPermissive, allowUserns, volatileMode, bindMounts, dnsServers, runAtBoot, customInit, staticNatIp, forceCgroupv1, blockNestedNs, privileged, envFileContent, upstreamInterfaces, portForwards, gatewayContainer, gatewayNet, gatewayIface, gatewayBridge ->
-                    viewModel.setConfig(netMode, disableIPv6, enableAndroidStorage, enableHwAccess, enableGpuMode, enableTermuxX11, tx11ExtraFlags, enableVirgl, virglExtraFlags, enablePulseaudio, selinuxPermissive, allowUserns, volatileMode, bindMounts, dnsServers, runAtBoot, customInit, staticNatIp, envFileContent, upstreamInterfaces, portForwards, forceCgroupv1, blockNestedNs, privileged, gatewayContainer, gatewayNet, gatewayIface, gatewayBridge)
+                onNext = { netMode, disableIPv6, enableAndroidStorage, enableHwAccess, enableGpuMode, enableTermuxX11, tx11ExtraFlags, enableAnland, enableVirgl, virglExtraFlags, enablePulseaudio, selinuxPermissive, allowUserns, volatileMode, bindMounts, dnsServers, runAtBoot, customInit, staticNatIp, forceCgroupv1, blockNestedNs, privileged, envFileContent, upstreamInterfaces, portForwards, gatewayContainer, gatewayNet, gatewayIface, gatewayBridge ->
+                    viewModel.setConfig(netMode, disableIPv6, enableAndroidStorage, enableHwAccess, enableGpuMode, enableTermuxX11, tx11ExtraFlags, enableAnland, enableVirgl, virglExtraFlags, enablePulseaudio, selinuxPermissive, allowUserns, volatileMode, bindMounts, dnsServers, runAtBoot, customInit, staticNatIp, envFileContent, upstreamInterfaces, portForwards, forceCgroupv1, blockNestedNs, privileged, gatewayContainer, gatewayNet, gatewayIface, gatewayBridge)
                     navController.navigate(Screen.SparseImageConfig.route)
                 },
                 onBack = {

--- a/Android/app/src/main/java/com/droidspaces/app/ui/screen/ContainerConfigScreen.kt
+++ b/Android/app/src/main/java/com/droidspaces/app/ui/screen/ContainerConfigScreen.kt
@@ -62,6 +62,7 @@ fun ContainerConfigScreen(
     initialEnableGpuMode: Boolean = false,
     initialEnableTermuxX11: Boolean = false,
     initialTx11ExtraFlags: String = "",
+    initialEnableAnland: Boolean = false,
     initialEnableVirgl: Boolean = false,
     initialVirglExtraFlags: String = "",
     initialEnablePulseaudio: Boolean = false,
@@ -93,6 +94,7 @@ fun ContainerConfigScreen(
         enableGpuMode: Boolean,
         enableTermuxX11: Boolean,
         tx11ExtraFlags: String,
+        enableAnland: Boolean,
         enableVirgl: Boolean,
         virglExtraFlags: String,
         enablePulseaudio: Boolean,
@@ -124,6 +126,7 @@ fun ContainerConfigScreen(
     var enableGpuMode by remember { mutableStateOf(initialEnableGpuMode) }
     var enableTermuxX11 by remember { mutableStateOf(initialEnableTermuxX11) }
     var tx11ExtraFlags by remember { mutableStateOf(initialTx11ExtraFlags) }
+    var enableAnland by remember { mutableStateOf(initialEnableAnland) }
     var enableVirgl by remember { mutableStateOf(initialEnableVirgl) }
     var virglExtraFlags by remember { mutableStateOf(initialVirglExtraFlags) }
     var enablePulseaudio by remember { mutableStateOf(initialEnablePulseaudio) }
@@ -332,7 +335,7 @@ fun ContainerConfigScreen(
                             .clickable(
                                 enabled = canProceed,
                                 onClick = {
-                                    onNext(netMode, disableIPv6, enableAndroidStorage, enableHwAccess, enableGpuMode, enableTermuxX11, tx11ExtraFlags, enableVirgl, virglExtraFlags, enablePulseaudio, selinuxPermissive, allowUserns, volatileMode, bindMounts, dnsServers, runAtBoot, customInit, staticNatIp, forceCgroupv1, blockNestedNs, privileged, if (envFileContent.isBlank()) null else envFileContent, upstreamInterfaces, portForwards, gatewayContainer, gatewayNet, gatewayIface, gatewayBridge)
+                                    onNext(netMode, disableIPv6, enableAndroidStorage, enableHwAccess, enableGpuMode, enableTermuxX11, tx11ExtraFlags, enableAnland, enableVirgl, virglExtraFlags, enablePulseaudio, selinuxPermissive, allowUserns, volatileMode, bindMounts, dnsServers, runAtBoot, customInit, staticNatIp, forceCgroupv1, blockNestedNs, privileged, if (envFileContent.isBlank()) null else envFileContent, upstreamInterfaces, portForwards, gatewayContainer, gatewayNet, gatewayIface, gatewayBridge)
                                 },
                                 indication = androidx.compose.material.ripple.rememberRipple(bounded = true),
                                 interactionSource = remember { androidx.compose.foundation.interaction.MutableInteractionSource() }
@@ -670,6 +673,15 @@ fun ContainerConfigScreen(
                 description = context.getString(R.string.termux_x11_description),
                 checked = enableTermuxX11,
                 onCheckedChange = { enableTermuxX11 = it },
+                enabled = true
+            )
+
+            ToggleCard(
+                icon = Icons.Default.DesktopWindows,
+                title = context.getString(R.string.enable_anland),
+                description = context.getString(R.string.enable_anland_description),
+                checked = enableAnland,
+                onCheckedChange = { enableAnland = it },
                 enabled = true
             )
 

--- a/Android/app/src/main/java/com/droidspaces/app/ui/screen/InstallationSummaryScreen.kt
+++ b/Android/app/src/main/java/com/droidspaces/app/ui/screen/InstallationSummaryScreen.kt
@@ -168,6 +168,7 @@ fun InstallationSummaryScreen(
                     if (config.enableHwAccess) SummaryItem(stringResource(R.string.hardware_access), stringResource(R.string.enabled_legend), Icons.Default.Devices)
                     if (!config.enableHwAccess && config.enableGpuMode) SummaryItem(stringResource(R.string.gpu_access), stringResource(R.string.enabled_legend), Icons.Default.Memory)
                     if (config.enableTermuxX11) SummaryItem(stringResource(R.string.termux_x11), stringResource(R.string.enabled_legend), painterResource(id = R.drawable.ic_x11))
+                    if (config.enableAnland) SummaryItem(stringResource(R.string.enable_anland), stringResource(R.string.enabled_legend), Icons.Default.DesktopWindows)
                     if (config.enableVirgl) SummaryItem(stringResource(R.string.enable_virgl), stringResource(R.string.enabled_legend), Icons.Default.Layers)
                     if (config.enablePulseaudio) SummaryItem(stringResource(R.string.enable_pulseaudio), stringResource(R.string.enabled_legend), Icons.AutoMirrored.Filled.VolumeUp)
                     if (config.selinuxPermissive) SummaryItem(stringResource(R.string.selinux_permissive), stringResource(R.string.enabled_legend), Icons.Default.Security)
@@ -210,7 +211,7 @@ fun InstallationSummaryScreen(
                         !config.enableHwAccess && !config.enableGpuMode && !config.selinuxPermissive &&
                         !config.allowUserns && !config.volatileMode && config.bindMounts.isEmpty() &&
                         !config.runAtBoot && !config.disableIPv6 &&
-                        !config.enableTermuxX11 && !config.enableVirgl && !config.enablePulseaudio &&
+                        !config.enableTermuxX11 && !config.enableAnland && !config.enableVirgl && !config.enablePulseaudio &&
                         !config.forceCgroupv1 && !config.blockNestedNs &&
                         config.upstreamInterfaces.isEmpty() && config.portForwards.isEmpty() &&
                         config.envFileContent.isNullOrBlank()) {

--- a/Android/app/src/main/java/com/droidspaces/app/ui/viewmodel/ContainerInstallationViewModel.kt
+++ b/Android/app/src/main/java/com/droidspaces/app/ui/viewmodel/ContainerInstallationViewModel.kt
@@ -45,6 +45,9 @@ class ContainerInstallationViewModel : ViewModel() {
     var tx11ExtraFlags: String by mutableStateOf("")
         private set
 
+    var enableAnland: Boolean by mutableStateOf(false)
+        private set
+
     var enableVirgl: Boolean by mutableStateOf(false)
         private set
 
@@ -136,6 +139,7 @@ class ContainerInstallationViewModel : ViewModel() {
         enableGpuMode: Boolean,
         enableTermuxX11: Boolean,
         tx11ExtraFlags: String,
+        enableAnland: Boolean,
         enableVirgl: Boolean,
         virglExtraFlags: String,
         enablePulseaudio: Boolean,
@@ -165,6 +169,7 @@ class ContainerInstallationViewModel : ViewModel() {
         this.enableGpuMode = enableGpuMode
         this.enableTermuxX11 = enableTermuxX11
         this.tx11ExtraFlags = tx11ExtraFlags
+        this.enableAnland = enableAnland
         this.enableVirgl = enableVirgl
         this.virglExtraFlags = virglExtraFlags
         this.enablePulseaudio = enablePulseaudio
@@ -207,6 +212,7 @@ class ContainerInstallationViewModel : ViewModel() {
             enableGpuMode = enableGpuMode,
             enableTermuxX11 = enableTermuxX11,
             tx11ExtraFlags = tx11ExtraFlags,
+            enableAnland = enableAnland,
             enableVirgl = enableVirgl,
             virglExtraFlags = virglExtraFlags,
             enablePulseaudio = enablePulseaudio,
@@ -245,6 +251,7 @@ class ContainerInstallationViewModel : ViewModel() {
         enableGpuMode = false
         enableTermuxX11 = false
         tx11ExtraFlags = ""
+        enableAnland = false
         enableVirgl = false
         virglExtraFlags = ""
         enablePulseaudio = false


### PR DESCRIPTION
Introduce `enableAnland` support across the install flow. Adds state and default in ContainerInstallationViewModel, threads the flag through DroidspacesNavigation, exposes a toggle in ContainerConfigScreen (with icon/strings), and shows the selection in InstallationSummaryScreen (and in the 'no options' emptiness check).