### PR TITLE
fix(monitor): drain console PTY master in background mode

### DIFF
--- a/src/monitor.c
+++ b/src/monitor.c
@@ -8,6 +8,50 @@
 #include "droidspace.h"
 
 /* ---------------------------------------------------------------------------
+ * ds_console_drain - Empty the container's console PTY master.
+ *
+ * In BACKGROUND mode the monitor is the only process holding the console PTY
+ * master, and nothing reads it (foreground mode drives it from the parent via
+ * console_monitor_loop). If it is never read, a chatty container init that
+ * writes past the ~64 KiB PTY buffer blocks forever in n_tty_write and the
+ * whole container wedges. So the monitor must keep this master drained for the
+ * container's entire lifetime.
+ *
+ * Drained bytes are appended to the per-container console log when one is open
+ * (log_fd >= 0), which also makes background boot/console output visible for
+ * debugging. Draining continues even if the log write fails: keeping the PTY
+ * buffer empty is the load-bearing part; logging is best-effort.
+ *
+ * master_fd must be O_NONBLOCK so read() returns EAGAIN once drained.
+ * ---------------------------------------------------------------------------*/
+static void ds_console_drain(int master_fd, int log_fd, size_t *logged) {
+  char buf[4096];
+  ssize_t n;
+
+  while ((n = read(master_fd, buf, sizeof(buf))) > 0) {
+    if (log_fd < 0)
+      continue;
+
+    /* Bound the console log: truncate at 2 MiB. The fd was opened O_APPEND,
+     * so subsequent writes still land correctly after the truncation. */
+    if (logged && *logged >= 2u * 1024 * 1024) {
+      if (ftruncate(log_fd, 0) == 0)
+        *logged = 0;
+    }
+
+    size_t off = 0;
+    while (off < (size_t)n) {
+      ssize_t w = write(log_fd, buf + off, (size_t)n - off);
+      if (w <= 0)
+        break;
+      off += (size_t)w;
+    }
+    if (logged)
+      *logged += off;
+  }
+}
+
+/* ---------------------------------------------------------------------------
  * ds_monitor_run - Supervisor process for a single container instance.
  *
  * Called immediately after fork() in start_rootfs(). Never returns - always
@@ -149,6 +193,33 @@ void ds_monitor_run(struct ds_config *cfg, int sync_pipe_write) {
     ds_die("unshare failed: %s", strerror(errno));
 
   int stdio_redirected = 0;
+
+  /* Background console-drain setup (see ds_console_drain).
+   * Runs once, before the reboot loop, so a single log fd survives internal
+   * reboot cycles. In background mode the monitor is the only reader of the
+   * console PTY master: make it non-blocking and open a per-container console
+   * log so the heartbeat loop below keeps the PTY buffer drained. Foreground
+   * mode leaves the master untouched - the parent's console_monitor_loop
+   * drives it. */
+  int console_log_fd = -1;
+  size_t console_logged = 0;
+  if (!cfg->foreground && cfg->console.master >= 0) {
+    int fl = fcntl(cfg->console.master, F_GETFL, 0);
+    if (fl >= 0)
+      (void)fcntl(cfg->console.master, F_SETFL, fl | O_NONBLOCK);
+
+    char safe_name[256];
+    char log_dir[PATH_MAX];
+    char log_path[PATH_MAX];
+    sanitize_container_name(cfg->container_name, safe_name, sizeof(safe_name));
+    snprintf(log_dir, sizeof(log_dir), "%.2048s/" DS_LOGS_SUBDIR "/%.256s",
+             get_workspace_dir(), safe_name);
+    mkdir_p(log_dir, 0755);
+    snprintf(log_path, sizeof(log_path), "%.4080s/console", log_dir);
+    rotate_log(log_path, 2 * 1024 * 1024);
+    console_log_fd =
+        open(log_path, O_WRONLY | O_CREAT | O_APPEND | O_CLOEXEC, 0644);
+  }
 
   /* Reboot-aware boot loop
    * Each iteration forks an intermediate child that creates a fresh PID
@@ -500,14 +571,35 @@ reboot_loop:;
 
       ds_virtualize_update(cfg);
 
+      /* Poll the signalfd and, in background mode, the console PTY master.
+       * poll() wakes immediately when the master becomes readable, so draining
+       * is effectively real-time - a container init that fills the PTY buffer
+       * is unblocked at once instead of wedging forever in n_tty_write. */
+      struct pollfd pfds[2];
+      int npfd = 0;
+      int sfd_slot = -1;
+      int con_slot = -1;
       if (sfd >= 0) {
-        struct pollfd pfd = {.fd = sfd, .events = POLLIN};
-        poll(&pfd, 1, 500);
-        if (pfd.revents & POLLIN) {
+        pfds[npfd].fd = sfd;
+        pfds[npfd].events = POLLIN;
+        sfd_slot = npfd++;
+      }
+      if (!cfg->foreground && cfg->console.master >= 0) {
+        pfds[npfd].fd = cfg->console.master;
+        pfds[npfd].events = POLLIN;
+        con_slot = npfd++;
+      }
+      if (npfd > 0) {
+        poll(pfds, (nfds_t)npfd, 500);
+        if (sfd_slot >= 0 && (pfds[sfd_slot].revents & POLLIN)) {
           struct signalfd_siginfo si;
           while (read(sfd, &si, sizeof(si)) == (ssize_t)sizeof(si))
             ; /* drain */
         }
+        if (con_slot >= 0 &&
+            (pfds[con_slot].revents & (POLLIN | POLLHUP | POLLERR)))
+          ds_console_drain(cfg->console.master, console_log_fd,
+                           &console_logged);
       } else {
         usleep(500000);
       }
@@ -673,6 +765,12 @@ reboot_loop:;
   cleanup_container_resources(cfg, 0, 0, 0);
 
 monitor_cleanup_and_exit:
+  /* Capture any final console output, then close the background console log. */
+  if (!cfg->foreground && cfg->console.master >= 0)
+    ds_console_drain(cfg->console.master, console_log_fd, &console_logged);
+  if (console_log_fd >= 0)
+    close(console_log_fd);
+
   /* Free dynamically allocated configuration members before exit */
   ds_config_free(cfg);
   _exit(WIFEXITED(status) ? WEXITSTATUS(status) : 0);


### PR DESCRIPTION
## Problem

In background mode (`foreground=0`), nothing ever reads the container's console PTY **master**. The container's `/dev/console` is the matching **slave**. Once the container's init writes more than the kernel's PTY buffer (~64 KiB) to `/dev/console`, the write blocks forever in `n_tty_write`, and because the buffer never drains, every subsequent console write blocks too. The container wedges permanently and can only be killed with SIGKILL.

This is independent of guest distro and any sufficiently chatty init triggers it. It reproduces trivially with a bare `dd`. All early boot/console output is also lost in background mode, since it dies in the undrained master, so there's no way to see why a container failed to come up.

### Root cause

- Foreground path drains the master via `console_monitor_loop` (`src/console.c`), called from `src/container.c`.
- Background path never calls it — `src/container.c` just polls for the boot marker and returns.
- The monitor (`src/monitor.c`) inherits the master fd but only redirects its own stdio to `/dev/null`, then sits in its `waitpid`/virtualize heartbeat loop. It never reads the master.

## Fix

The monitor already runs a 500ms heartbeat `poll()` loop. This adds the console master to that poll set (in background mode only) and drains it whenever readable — `poll()` wakes immediately on readability, so draining is effectively real-time. Drained bytes are appended to a per-container console log (`Logs/<name>/console`, capped at 2 MiB), which also recovers the previously-lost background boot logs. Draining continues even if the log write fails — keeping the buffer empty is the load-bearing part.

Foreground mode is untouched. Change is confined to `src/monitor.c`.

## Terminal output

**Before the fix** — write 1 MiB to a background container's console, it never returns:

```
# dd if=/dev/zero of=/dev/pts/24 bs=1024 count=1024
(hangs forever)

# cat /proc/<dd-pid>/stack
[<...>] wait_woken
[<...>] n_tty_write+0x36c/0x444
[<...>] tty_write+0x23c/0x2f0
[<...>] do_iter_write / vfs_writev / do_writev / SyS_writev
```

**After the fix** — same write, on both test devices:

```
# kernel 4.14
monitor=495328  console_slave=/dev/pts/24  wchan=do_sys_poll
RESULT: COMPLETED in 100ms -> DRAIN WORKS, no deadlock
console log size=1056426 bytes

# kernel 6.12
monitor=190859  console_slave=/dev/pts/1  wchan=do_sys_poll
RESULT: COMPLETED in 51ms -> DRAIN WORKS, no deadlock
console log size=1060785 bytes
```

## Tested environments

- Android/arm64, kernel 4.14.357, MediaTek, LineageOS 23.2, background-mode Ubuntu container.
- Android/arm64, kernel 6.12.23, Qualcomm, Xiaomi HyperOS 3, background-mode Ubuntu container.

Same result on both — rules out this being specific to an old/vendor kernel.

## No regressions

- Foreground mode path is untouched (no changes to `console_monitor_loop` or its callers).
- Known-good background containers on both devices started, ran, and stopped (including a normal graceful shutdown) with no change in behavior other than the
  fix itself.

## Notes

- The buffer limit is the kernel PTY/tty default (~64 KiB); the exact figure doesn't matter. Any bound is exceeded by a sufficiently chatty boot, and once full it never drains today.
- The console log is drained continuously and self-truncates at 2 MiB, so a runaway console producer can't fill the disk.
- This bug was originally identified through Claude, then reproduced and verified on real hardware (both devices above) using the steps in this PR.