### PR TITLE
Fix blurry launcher icon on Xiaomi tablet desktop and dock

### DIFF
--- a/Android/app/src/main/res/drawable/ic_launcher_foreground.xml
+++ b/Android/app/src/main/res/drawable/ic_launcher_foreground.xml
@@ -1,6 +1,6 @@
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
-    android:width="24dp"
-    android:height="24dp"
+    android:width="108dp"
+    android:height="108dp"
     android:viewportWidth="48"
     android:viewportHeight="48">
     <group


### PR DESCRIPTION
## Summary

The launcher icon appears blurry on Xiaomi tablet's desktop and dock bar, while it displays correctly in Settings > All Apps. This fix addresses the root cause by ensuring the adaptive icon foreground vector has the correct canvas size.

## Root Cause

The `ic_launcher_foreground.xml` vector drawable was configured with an intrinsic size of **24dp × 24dp**, while the standard Android adaptive icon canvas size is **108dp × 108dp**. 

On Xiaomi's MIUI/HyperOS launcher, the icon rendering pipeline rasterizes the vector at its intrinsic size first, then scales it up to the target size (108dp), resulting in a 4.5x magnification and visible blurriness. The Settings app uses a different rendering path that directly renders the vector at the target size, which is why it appears sharp there.

## Changes Made

- Modified `Android/app/src/main/res/drawable/ic_launcher_foreground.xml`:
  - Changed `android:width` from `24dp` to `108dp`
  - Changed `android:height` from `24dp` to `108dp`
  - `viewportWidth` and `viewportHeight` remain at `48` (vector coordinate system)
  - The `scaleX="0.68"` and `scaleY="0.68"` transforms remain unchanged to maintain proper icon positioning within the safe zone
