### PR TITLE
feat(systemd): add unit inspection and override.conf editing

### DIFF
--- a/Android/app/src/main/assets/chksystemd.sh
+++ b/Android/app/src/main/assets/chksystemd.sh
@@ -2,26 +2,26 @@
 case "$1" in
 --running)
 systemctl list-units --type=service --state=running --no-legend --no-pager 2>/dev/null | while read -r line; do
-name=$(echo "$line" | awk '{print $1}' | sed 's/\.service$//')
+name=$(echo "$line" | awk '{print $1}')
 desc=$(echo "$line" | awk '{$1=$2=$3=$4=""; print $0}' | sed 's/^[[:space:]]*//')
 echo "${name}|${desc}"
 done
 ;;
 --enabled)
-systemctl list-unit-files --type=service --state=enabled --no-legend --no-pager 2>/dev/null | awk '{print $1}' | sed 's/\.service$//'
+systemctl list-unit-files --type=service --state=enabled --no-legend --no-pager 2>/dev/null | awk '{print $1}'
 ;;
 --disabled)
-systemctl list-unit-files --type=service --state=disabled --no-legend --no-pager 2>/dev/null | awk '{print $1}' | sed 's/\.service$//'
+systemctl list-unit-files --type=service --state=disabled --no-legend --no-pager 2>/dev/null | awk '{print $1}'
 ;;
 --masked)
-systemctl list-unit-files --type=service --state=masked --no-legend --no-pager 2>/dev/null | awk '{print $1}' | sed 's/\.service$//'
+systemctl list-unit-files --type=service --state=masked --no-legend --no-pager 2>/dev/null | awk '{print $1}'
 ;;
 --static)
-systemctl list-unit-files --type=service --state=static --no-legend --no-pager 2>/dev/null | awk '{print $1}' | sed 's/\.service$//'
+systemctl list-unit-files --type=service --state=static --no-legend --no-pager 2>/dev/null | awk '{print $1}'
 ;;
 --all)
 systemctl list-unit-files --type=service --no-legend --no-pager 2>/dev/null | while read -r line; do
-name=$(echo "$line" | awk '{print $1}' | sed 's/\.service$//')
+name=$(echo "$line" | awk '{print $1}')
 state=$(echo "$line" | awk '{print $2}')
 echo "${name}|${state}"
 done

--- a/Android/app/src/main/java/com/droidspaces/app/ui/navigation/DroidspacesNavigation.kt
+++ b/Android/app/src/main/java/com/droidspaces/app/ui/navigation/DroidspacesNavigation.kt
@@ -35,6 +35,8 @@ import com.droidspaces.app.ui.screen.InstallationProgressScreen
 import com.droidspaces.app.ui.screen.EditContainerScreen
 import com.droidspaces.app.ui.screen.ContainerDetailsScreen
 import com.droidspaces.app.ui.screen.SystemdScreen
+import com.droidspaces.app.ui.screen.UnitDetailScreen
+import com.droidspaces.app.ui.screen.OverrideEditorScreen
 import com.droidspaces.app.ui.screen.ProcdScreen
 import com.droidspaces.app.ui.screen.OpenRCScreen
 import com.droidspaces.app.ui.screen.ContainerTerminalScreen
@@ -93,6 +95,14 @@ sealed class Screen(val route: String) {
     }
     data object Systemd : Screen("systemd/{containerName}") {
         fun createRoute(containerName: String) = "systemd/${Uri.encode(containerName)}"
+    }
+    data object UnitDetail : Screen("unit-detail/{containerName}/{unitName}") {
+        fun createRoute(containerName: String, unitName: String) =
+            "unit-detail/${Uri.encode(containerName)}/${Uri.encode(unitName)}"
+    }
+    data object OverrideEditor : Screen("unit-override/{containerName}/{unitName}") {
+        fun createRoute(containerName: String, unitName: String) =
+            "unit-override/${Uri.encode(containerName)}/${Uri.encode(unitName)}"
     }
     data object Procd : Screen("procd/{containerName}") {
         fun createRoute(containerName: String) = "procd/${Uri.encode(containerName)}"
@@ -608,6 +618,45 @@ fun DroidspacesNavigation(
             val containerName = backStackEntry.arguments?.getString("containerName") ?: ""
             SystemdScreen(
                 containerName = containerName,
+                onNavigateBack = { navController.popBackStack() },
+                onInspectUnit = { unitName -> navController.navigate(Screen.UnitDetail.createRoute(containerName, unitName)) },
+                onEditOverride = { unitName -> navController.navigate(Screen.OverrideEditor.createRoute(containerName, unitName)) }
+            )
+        }
+
+        composable(
+            route = Screen.UnitDetail.route,
+            arguments = listOf(
+                navArgument("containerName") { type = NavType.StringType },
+                navArgument("unitName") { type = NavType.StringType }
+            ),
+            enterTransition = defaultEnterTransition,
+            exitTransition = defaultExitTransition
+        ) { backStackEntry ->
+            val containerName = backStackEntry.arguments?.getString("containerName") ?: ""
+            val unitName = backStackEntry.arguments?.getString("unitName") ?: ""
+            UnitDetailScreen(
+                containerName = containerName,
+                unitName = unitName,
+                onNavigateBack = { navController.popBackStack() },
+                onEditOverride = { navController.navigate(Screen.OverrideEditor.createRoute(containerName, unitName)) }
+            )
+        }
+
+        composable(
+            route = Screen.OverrideEditor.route,
+            arguments = listOf(
+                navArgument("containerName") { type = NavType.StringType },
+                navArgument("unitName") { type = NavType.StringType }
+            ),
+            enterTransition = defaultEnterTransition,
+            exitTransition = defaultExitTransition
+        ) { backStackEntry ->
+            val containerName = backStackEntry.arguments?.getString("containerName") ?: ""
+            val unitName = backStackEntry.arguments?.getString("unitName") ?: ""
+            OverrideEditorScreen(
+                containerName = containerName,
+                unitName = unitName,
                 onNavigateBack = { navController.popBackStack() }
             )
         }

--- a/Android/app/src/main/java/com/droidspaces/app/ui/screen/InitServiceScreen.kt
+++ b/Android/app/src/main/java/com/droidspaces/app/ui/screen/InitServiceScreen.kt
@@ -62,12 +62,25 @@ enum class InitServiceUiStatus {
 /** Manager-agnostic command result. */
 data class InitCommandResult(val isSuccess: Boolean, val output: List<String>, val error: List<String>)
 
-/** An overflow-menu action (restart / mask / reload / …). */
-data class InitServiceMenuAction(
-    val labelRes: Int,
-    val icon: ImageVector,
-    val run: suspend () -> InitCommandResult,
-)
+/**
+ * An overflow-menu action. [Command] fires a suspend action (restart / mask /
+ * reload / …) through the shared executeAction pipeline (progress dialog +
+ * snackbar + refetch). [Navigate] opens a dedicated screen (e.g. unit
+ * inspection, override.conf editor) and does not touch the command pipeline.
+ */
+sealed class InitServiceMenuAction(val labelRes: Int, val icon: ImageVector) {
+    class Command(
+        labelRes: Int,
+        icon: ImageVector,
+        val run: suspend () -> InitCommandResult,
+    ) : InitServiceMenuAction(labelRes, icon)
+
+    class Navigate(
+        labelRes: Int,
+        icon: ImageVector,
+        val onClick: () -> Unit,
+    ) : InitServiceMenuAction(labelRes, icon)
+}
 
 /** One service row plus the actions applicable to it. */
 data class InitServiceRow(
@@ -532,7 +545,13 @@ private fun InitServiceCard(
                                                 DropdownMenuItem(
                                                     text = { Text(context.getString(item.labelRes)) },
                                                     leadingIcon = { Icon(item.icon, null) },
-                                                    onClick = { showMenu = false; onAction(context.getString(item.labelRes), item.run) }
+                                                    onClick = {
+                                                        showMenu = false
+                                                        when (item) {
+                                                            is InitServiceMenuAction.Command -> onAction(context.getString(item.labelRes), item.run)
+                                                            is InitServiceMenuAction.Navigate -> item.onClick()
+                                                        }
+                                                    }
                                                 )
                                             }
                                         }

--- a/Android/app/src/main/java/com/droidspaces/app/ui/screen/OpenRCScreen.kt
+++ b/Android/app/src/main/java/com/droidspaces/app/ui/screen/OpenRCScreen.kt
@@ -31,7 +31,7 @@ private fun ContainerOpenRCManager.ServiceInfo.toRow(containerName: String): Ini
         enableDisable = { (if (isEnabled) ContainerOpenRCManager.disableService(containerName, name) else ContainerOpenRCManager.enableService(containerName, name)).toInit() },
         unmask = null,
         menu = buildList {
-            if (isRunning) add(InitServiceMenuAction(R.string.restart_service, Icons.Default.Refresh) { ContainerOpenRCManager.restartService(containerName, name).toInit() })
+            if (isRunning) add(InitServiceMenuAction.Command(R.string.restart_service, Icons.Default.Refresh) { ContainerOpenRCManager.restartService(containerName, name).toInit() })
         }
     )
 }

--- a/Android/app/src/main/java/com/droidspaces/app/ui/screen/OverrideEditorScreen.kt
+++ b/Android/app/src/main/java/com/droidspaces/app/ui/screen/OverrideEditorScreen.kt
@@ -1,0 +1,143 @@
+package com.droidspaces.app.ui.screen
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material.icons.filled.Save
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.font.Font
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontWeight
+import com.droidspaces.app.R
+import com.droidspaces.app.ui.util.FullScreenLoading
+import com.droidspaces.app.ui.util.ProgressDialog
+import com.droidspaces.app.ui.util.showError
+import com.droidspaces.app.ui.util.showSuccess
+import com.droidspaces.app.util.ContainerSystemdManager
+import kotlinx.coroutines.launch
+
+private val OverrideEditorMono = FontFamily(Font(R.font.jetbrains_mono_regular, FontWeight.Normal))
+
+private const val OVERRIDE_TEMPLATE = "[Service]\n"
+
+/**
+ * Editor for a unit's override.conf drop-in (`/etc/systemd/system/<unit>.d/override.conf`),
+ * equivalent to `systemctl edit <unit>` from the CLI. Reached from the
+ * "Edit override" overflow-menu item on [SystemdScreen], or the edit icon on
+ * [UnitDetailScreen].
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun OverrideEditorScreen(
+    containerName: String,
+    unitName: String,
+    onNavigateBack: () -> Unit,
+) {
+    val context = LocalContext.current
+    val scope = rememberCoroutineScope()
+    val snackbarHostState = remember { SnackbarHostState() }
+
+    var isLoading by remember { mutableStateOf(true) }
+    var isSaving by remember { mutableStateOf(false) }
+    var hasExistingOverride by remember { mutableStateOf(false) }
+    var text by remember { mutableStateOf("") }
+
+    LaunchedEffect(containerName, unitName) {
+        val existing = ContainerSystemdManager.getOverrideConf(containerName, unitName)
+        hasExistingOverride = existing != null
+        text = existing ?: OVERRIDE_TEMPLATE
+        isLoading = false
+    }
+
+    fun save() {
+        isSaving = true
+        scope.launch {
+            val result = ContainerSystemdManager.setOverrideConf(containerName, unitName, text)
+            isSaving = false
+            if (result.isSuccess) {
+                hasExistingOverride = true
+                snackbarHostState.showSuccess("Override saved. Restart the unit to apply the change.")
+            } else {
+                val message = (result.output + result.error).firstOrNull() ?: "Failed to save override"
+                snackbarHostState.showError(message)
+            }
+        }
+    }
+
+    fun delete() {
+        isSaving = true
+        scope.launch {
+            val result = ContainerSystemdManager.deleteOverrideConf(containerName, unitName)
+            isSaving = false
+            if (result.isSuccess) {
+                text = OVERRIDE_TEMPLATE
+                hasExistingOverride = false
+                snackbarHostState.showSuccess("Override removed.")
+            } else {
+                val message = (result.output + result.error).firstOrNull() ?: "Failed to remove override"
+                snackbarHostState.showError(message)
+            }
+        }
+    }
+
+    Surface(modifier = Modifier.fillMaxSize(), color = MaterialTheme.colorScheme.background) {
+        Scaffold(
+            topBar = {
+                CenterAlignedTopAppBar(
+                    title = {
+                        Text(
+                            "Edit Override · $unitName",
+                            style = MaterialTheme.typography.titleSmall,
+                            fontWeight = FontWeight.Bold,
+                            maxLines = 1
+                        )
+                    },
+                    navigationIcon = {
+                        IconButton(onClick = onNavigateBack) {
+                            Icon(Icons.AutoMirrored.Filled.ArrowBack, context.getString(R.string.back))
+                        }
+                    },
+                    actions = {
+                        if (hasExistingOverride) {
+                            IconButton(onClick = { delete() }, enabled = !isSaving) {
+                                Icon(Icons.Default.Delete, "Delete override")
+                            }
+                        }
+                        IconButton(onClick = { save() }, enabled = !isSaving) {
+                            Icon(Icons.Default.Save, "Save override")
+                        }
+                    },
+                    colors = TopAppBarDefaults.centerAlignedTopAppBarColors(containerColor = Color.Transparent)
+                )
+            },
+            snackbarHost = { SnackbarHost(snackbarHostState) },
+            containerColor = Color.Transparent
+        ) { padding ->
+            Box(modifier = Modifier.padding(padding).fillMaxSize().padding(16.dp)) {
+                if (isLoading) {
+                    FullScreenLoading()
+                } else {
+                    OutlinedTextField(
+                        value = text,
+                        onValueChange = { text = it },
+                        modifier = Modifier.fillMaxSize(),
+                        textStyle = MaterialTheme.typography.bodyMedium.copy(fontFamily = OverrideEditorMono),
+                        shape = RoundedCornerShape(16.dp),
+                        placeholder = { Text("[Service]\nEnvironment=FOO=bar") }
+                    )
+                }
+            }
+        }
+    }
+
+    if (isSaving) {
+        ProgressDialog(message = if (hasExistingOverride) "Saving override…" else "Applying override…")
+    }
+}

--- a/Android/app/src/main/java/com/droidspaces/app/ui/screen/ProcdScreen.kt
+++ b/Android/app/src/main/java/com/droidspaces/app/ui/screen/ProcdScreen.kt
@@ -32,8 +32,8 @@ private fun ContainerProcdManager.ServiceInfo.toRow(containerName: String): Init
         enableDisable = { (if (isEnabled) ContainerProcdManager.disableService(containerName, name) else ContainerProcdManager.enableService(containerName, name)).toInit() },
         unmask = null,
         menu = listOf(
-            InitServiceMenuAction(R.string.restart_service, Icons.Default.Refresh) { ContainerProcdManager.restartService(containerName, name).toInit() },
-            InitServiceMenuAction(R.string.reload_service, Icons.Default.Refresh) { ContainerProcdManager.reloadService(containerName, name).toInit() },
+            InitServiceMenuAction.Command(R.string.restart_service, Icons.Default.Refresh) { ContainerProcdManager.restartService(containerName, name).toInit() },
+            InitServiceMenuAction.Command(R.string.reload_service, Icons.Default.Refresh) { ContainerProcdManager.reloadService(containerName, name).toInit() },
         )
     )
 }

--- a/Android/app/src/main/java/com/droidspaces/app/ui/screen/SystemdScreen.kt
+++ b/Android/app/src/main/java/com/droidspaces/app/ui/screen/SystemdScreen.kt
@@ -1,6 +1,8 @@
 package com.droidspaces.app.ui.screen
 
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Edit
+import androidx.compose.material.icons.filled.Info
 import androidx.compose.material.icons.filled.Lock
 import androidx.compose.material.icons.filled.Refresh
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -14,7 +16,11 @@ import com.droidspaces.app.util.ContainerSystemdManager
 
 private fun ContainerSystemdManager.CommandResult.toInit() = InitCommandResult(isSuccess, output, error)
 
-private fun ContainerSystemdManager.ServiceInfo.toRow(containerName: String): InitServiceRow {
+private fun ContainerSystemdManager.ServiceInfo.toRow(
+    containerName: String,
+    onInspectUnit: (String) -> Unit,
+    onEditOverride: (String) -> Unit,
+): InitServiceRow {
     val uiStatus = when (status) {
         ContainerSystemdManager.ServiceStatus.ENABLED_RUNNING -> InitServiceUiStatus.ENABLED_RUNNING
         ContainerSystemdManager.ServiceStatus.ENABLED_STOPPED -> InitServiceUiStatus.ENABLED_STOPPED
@@ -35,8 +41,10 @@ private fun ContainerSystemdManager.ServiceInfo.toRow(containerName: String): In
         enableDisable = { (if (isEnabled) ContainerSystemdManager.disableService(containerName, name) else ContainerSystemdManager.enableService(containerName, name)).toInit() },
         unmask = if (isMasked) { { ContainerSystemdManager.unmaskService(containerName, name).toInit() } } else null,
         menu = buildList {
-            if (isRunning) add(InitServiceMenuAction(R.string.restart_service, Icons.Default.Refresh) { ContainerSystemdManager.restartService(containerName, name).toInit() })
-            add(InitServiceMenuAction(R.string.mask_service, Icons.Default.Lock) { ContainerSystemdManager.maskService(containerName, name).toInit() })
+            if (isRunning) add(InitServiceMenuAction.Command(R.string.restart_service, Icons.Default.Refresh) { ContainerSystemdManager.restartService(containerName, name).toInit() })
+            add(InitServiceMenuAction.Command(R.string.mask_service, Icons.Default.Lock) { ContainerSystemdManager.maskService(containerName, name).toInit() })
+            add(InitServiceMenuAction.Navigate(R.string.inspect_unit, Icons.Default.Info) { onInspectUnit(name) })
+            add(InitServiceMenuAction.Navigate(R.string.edit_override, Icons.Default.Edit) { onEditOverride(name) })
         }
     )
 }
@@ -45,7 +53,9 @@ private fun ContainerSystemdManager.ServiceInfo.toRow(containerName: String): In
 @Composable
 fun SystemdScreen(
     containerName: String,
-    onNavigateBack: () -> Unit
+    onNavigateBack: () -> Unit,
+    onInspectUnit: (String) -> Unit,
+    onEditOverride: (String) -> Unit,
 ) {
     val context = LocalContext.current
     LaunchedEffect(Unit) { ContainerSystemdManager.initialize(context) }
@@ -66,7 +76,7 @@ fun SystemdScreen(
         titleRes = R.string.systemd_services,
         onNavigateBack = onNavigateBack,
         isAvailable = { cn -> ContainerSystemdManager.isSystemdAvailable(cn) },
-        fetchRows = { cn -> ContainerSystemdManager.getAllServices(cn).map { it.toRow(cn) } },
+        fetchRows = { cn -> ContainerSystemdManager.getAllServices(cn).map { it.toRow(cn, onInspectUnit, onEditOverride) } },
         filters = filters,
         defaultFilterId = "RUNNING",
     )

--- a/Android/app/src/main/java/com/droidspaces/app/ui/screen/UnitDetailScreen.kt
+++ b/Android/app/src/main/java/com/droidspaces/app/ui/screen/UnitDetailScreen.kt
@@ -1,0 +1,216 @@
+package com.droidspaces.app.ui.screen
+
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Edit
+import androidx.compose.material.icons.filled.Refresh
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.font.Font
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.droidspaces.app.R
+import com.droidspaces.app.ui.util.FullScreenLoading
+import com.droidspaces.app.util.ContainerSystemdManager
+import kotlinx.coroutines.launch
+
+private val UnitDetailMono = FontFamily(
+    Font(R.font.jetbrains_mono_regular, FontWeight.Normal),
+    Font(R.font.jetbrains_mono_bold, FontWeight.Bold)
+)
+
+/** Human-friendly labels for the raw systemd property keys `inspectUnit` fetches. */
+private val PROPERTY_LABELS = linkedMapOf(
+    "Description" to "Description",
+    "LoadState" to "Load State",
+    "ActiveState" to "Active State",
+    "SubState" to "Sub State",
+    "UnitFileState" to "Enablement",
+    "FragmentPath" to "Unit File",
+    "DropInPaths" to "Drop-ins",
+    "MainPID" to "Main PID",
+    "ExecMainStartTimestamp" to "Started At",
+    "Restart" to "Restart Policy",
+    "MemoryCurrent" to "Memory",
+    "CPUUsageNSec" to "CPU Time (ns)",
+)
+
+private sealed class UnitDetailState {
+    data object Loading : UnitDetailState()
+    data object Error : UnitDetailState()
+    data class Ready(val inspection: ContainerSystemdManager.UnitInspection) : UnitDetailState()
+}
+
+/**
+ * Read-only inspection screen for a single systemd unit: parsed properties,
+ * raw `systemctl status` text, and its dependency tree. Reached from the
+ * "Inspect unit" overflow-menu item on [SystemdScreen].
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun UnitDetailScreen(
+    containerName: String,
+    unitName: String,
+    onNavigateBack: () -> Unit,
+    onEditOverride: () -> Unit,
+) {
+    val context = LocalContext.current
+    val scope = rememberCoroutineScope()
+    var state by remember { mutableStateOf<UnitDetailState>(UnitDetailState.Loading) }
+
+    fun load() {
+        state = UnitDetailState.Loading
+        scope.launch {
+            val inspection = ContainerSystemdManager.inspectUnit(containerName, unitName)
+            state = if (inspection != null) UnitDetailState.Ready(inspection) else UnitDetailState.Error
+        }
+    }
+
+    LaunchedEffect(containerName, unitName) { load() }
+
+    Surface(modifier = Modifier.fillMaxSize(), color = MaterialTheme.colorScheme.background) {
+        Scaffold(
+            topBar = {
+                CenterAlignedTopAppBar(
+                    title = {
+                        Text(
+                            unitName,
+                            style = MaterialTheme.typography.titleMedium.copy(fontFamily = UnitDetailMono),
+                            fontWeight = FontWeight.Bold,
+                            maxLines = 1
+                        )
+                    },
+                    navigationIcon = {
+                        IconButton(onClick = onNavigateBack) {
+                            Icon(Icons.AutoMirrored.Filled.ArrowBack, context.getString(R.string.back))
+                        }
+                    },
+                    actions = {
+                        IconButton(onClick = { load() }) { Icon(Icons.Default.Refresh, context.getString(R.string.refresh)) }
+                        IconButton(onClick = onEditOverride) { Icon(Icons.Default.Edit, context.getString(R.string.edit_override)) }
+                    },
+                    colors = TopAppBarDefaults.centerAlignedTopAppBarColors(containerColor = Color.Transparent)
+                )
+            },
+            containerColor = Color.Transparent
+        ) { padding ->
+            Box(modifier = Modifier.padding(padding).fillMaxSize()) {
+                when (val s = state) {
+                    is UnitDetailState.Loading -> FullScreenLoading(message = context.getString(R.string.fetching_services))
+                    is UnitDetailState.Error -> UnitDetailError(onRetry = { load() })
+                    is UnitDetailState.Ready -> UnitDetailContent(s.inspection)
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun UnitDetailError(onRetry: () -> Unit) {
+    Column(
+        modifier = Modifier.fillMaxSize().padding(32.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Center
+    ) {
+        Text("Couldn't load unit details", style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.Bold)
+        Spacer(Modifier.height(8.dp))
+        Text(
+            "The unit may no longer exist, or the container may be unreachable.",
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            textAlign = TextAlign.Center
+        )
+        Spacer(Modifier.height(16.dp))
+        FilledTonalButton(onClick = onRetry) { Text("Retry") }
+    }
+}
+
+@Composable
+private fun SectionCard(title: String, content: @Composable ColumnScope.() -> Unit) {
+    Surface(
+        modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp, vertical = 8.dp),
+        shape = RoundedCornerShape(20.dp),
+        color = MaterialTheme.colorScheme.surfaceContainer,
+        border = BorderStroke(1.dp, MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.35f))
+    ) {
+        Column(modifier = Modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(12.dp)) {
+            Text(title, style = MaterialTheme.typography.titleSmall, fontWeight = FontWeight.Bold, color = MaterialTheme.colorScheme.primary)
+            content()
+        }
+    }
+}
+
+@Composable
+private fun UnitDetailContent(inspection: ContainerSystemdManager.UnitInspection) {
+    LazyColumn(modifier = Modifier.fillMaxSize(), contentPadding = PaddingValues(vertical = 16.dp)) {
+        item {
+            SectionCard(title = "Properties") {
+                PROPERTY_LABELS.forEach { (key, label) ->
+                    val rawValue = inspection.properties[key]
+                    val value = rawValue?.takeIf { it.isNotBlank() && it != "0" && it != "n/a" }
+                    if (value != null) {
+                        Row(
+                            modifier = Modifier.fillMaxWidth().padding(vertical = 2.dp),
+                            horizontalArrangement = Arrangement.SpaceBetween,
+                            verticalAlignment = Alignment.Top
+                        ) {
+                            Text(
+                                label,
+                                style = MaterialTheme.typography.bodyMedium,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                modifier = Modifier.weight(0.4f)
+                            )
+                            Spacer(Modifier.width(12.dp))
+                            Text(
+                                if (key == "DropInPaths") value.replace(" ", "\n") else value,
+                                style = MaterialTheme.typography.bodySmall.copy(
+                                    fontFamily = UnitDetailMono,
+                                    lineHeight = 16.sp
+                                ),
+                                fontWeight = FontWeight.Medium,
+                                textAlign = TextAlign.End,
+                                modifier = Modifier.weight(0.6f)
+                            )
+                        }
+                    }
+                }
+            }
+        }
+
+        if (inspection.dependencies.isNotEmpty()) {
+            item {
+                SectionCard(title = "Dependencies") {
+                    inspection.dependencies.forEach { dep ->
+                        Text(dep, style = MaterialTheme.typography.bodySmall.copy(fontFamily = UnitDetailMono))
+                    }
+                }
+            }
+        }
+
+        item {
+            SectionCard(title = "systemctl status") {
+                Surface(
+                    color = MaterialTheme.colorScheme.surfaceContainerHighest,
+                    shape = RoundedCornerShape(12.dp)
+                ) {
+                    Column(modifier = Modifier.padding(12.dp)) {
+                        inspection.statusText.forEach { line ->
+                            Text(line, style = MaterialTheme.typography.bodySmall.copy(fontFamily = UnitDetailMono))
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/Android/app/src/main/java/com/droidspaces/app/util/ContainerSystemdManager.kt
+++ b/Android/app/src/main/java/com/droidspaces/app/util/ContainerSystemdManager.kt
@@ -61,6 +61,16 @@ object ContainerSystemdManager {
     }
 
     /**
+     * Result of inspecting a single unit: parsed `systemctl show` properties,
+     * raw `systemctl status` text, and its dependency tree.
+     */
+    data class UnitInspection(
+        val properties: Map<String, String>,
+        val statusText: List<String>,
+        val dependencies: List<String>
+    )
+
+    /**
      * Command result with exit code for proper handling.
      */
     data class CommandResult(
@@ -321,4 +331,98 @@ object ContainerSystemdManager {
 
     suspend fun unmaskService(containerName: String, serviceName: String) =
         runSystemctl(containerName, "unmask", serviceName)
+
+    // ── Unit inspection ──────────────────────────────────────────────────────
+
+    /**
+     * Inspect a single unit: key properties (via `systemctl show -p`), the raw
+     * `systemctl status` text, and its dependency tree. Returns null if the
+     * unit name fails the shared safety check.
+     */
+    suspend fun inspectUnit(containerName: String, unitName: String): UnitInspection? {
+        if (!ServiceManagerBase.isSafeServiceName(unitName)) return null
+
+        val propsResult = executeSystemctlCommand(
+            containerName,
+            "show $unitName --no-pager -p " +
+                "Description,LoadState,ActiveState,SubState,UnitFileState,FragmentPath," +
+                "DropInPaths,MainPID,ExecMainStartTimestamp,Restart,MemoryCurrent,CPUUsageNSec"
+        )
+        val statusResult = executeSystemctlCommand(containerName, "status $unitName --no-pager -l")
+        val depsResult = executeSystemctlCommand(containerName, "list-dependencies $unitName --no-pager --plain")
+
+        val properties = propsResult.output
+            .mapNotNull { line ->
+                val idx = line.indexOf('=')
+                if (idx > 0) line.substring(0, idx) to line.substring(idx + 1) else null
+            }
+            .toMap()
+
+        return UnitInspection(
+            properties = properties,
+            statusText = statusResult.output,
+            dependencies = depsResult.output.map { it.trim() }.filter { it.isNotBlank() }
+        )
+    }
+
+    // ── Override (drop-in) management ────────────────────────────────────────
+    // Mirrors `systemctl edit <unit>` — writes/reads/removes
+    // /etc/systemd/system/<unit>.d/override.conf inside the container.
+
+    private fun overrideDirPath(unitName: String) = "/etc/systemd/system/$unitName.d"
+    private fun overridePath(unitName: String) = "${overrideDirPath(unitName)}/override.conf"
+
+    /** Read the current override.conf for a unit. Null if unsafe, missing, or read fails. */
+    suspend fun getOverrideConf(containerName: String, unitName: String): String? =
+        withContext(Dispatchers.IO) {
+            if (!ServiceManagerBase.isSafeServiceName(unitName)) return@withContext null
+            try {
+                val path = overridePath(unitName)
+                val cmd = "${Constants.DROIDSPACES_BINARY_PATH} --name=${ContainerCommandBuilder.quote(containerName)} " +
+                    "run '[ -f $path ] && cat $path'"
+                val result = Shell.cmd(cmd).exec()
+                if (result.isSuccess && result.out.isNotEmpty()) result.out.joinToString("\n") else null
+            } catch (e: Exception) {
+                Log.e(TAG, "Error reading override.conf for $unitName", e)
+                null
+            }
+        }
+
+    /**
+     * Write (create or replace) override.conf for a unit, then reload systemd.
+     * Content is base64-streamed — same safe pattern [runScript] already uses —
+     * so arbitrary user-typed conf text (quotes, `$`, backticks, etc.) can never
+     * break out of the single-quoted `run '...'` shell payload.
+     */
+    suspend fun setOverrideConf(
+        containerName: String,
+        unitName: String,
+        content: String
+    ): CommandResult = withContext(Dispatchers.IO) {
+        if (!ServiceManagerBase.isSafeServiceName(unitName)) {
+            return@withContext CommandResult(2, emptyList(), listOf("Invalid unit name: $unitName"))
+        }
+        val dir = overrideDirPath(unitName)
+        val path = overridePath(unitName)
+        val b64 = Base64.encodeToString(content.toByteArray(), Base64.NO_WRAP)
+
+        val cmd = "${Constants.DROIDSPACES_BINARY_PATH} --name=${ContainerCommandBuilder.quote(containerName)} " +
+            "run 'mkdir -p $dir && echo $b64 | base64 -d > $path && systemctl daemon-reload 2>&1'"
+
+        val result = Shell.cmd(cmd).exec()
+        CommandResult(result.code, result.out, result.err)
+    }
+
+    /** Remove override.conf (and its drop-in dir, if now empty) then reload systemd. */
+    suspend fun deleteOverrideConf(containerName: String, unitName: String): CommandResult =
+        withContext(Dispatchers.IO) {
+            if (!ServiceManagerBase.isSafeServiceName(unitName)) {
+                return@withContext CommandResult(2, emptyList(), listOf("Invalid unit name: $unitName"))
+            }
+            val dir = overrideDirPath(unitName)
+            val cmd = "${Constants.DROIDSPACES_BINARY_PATH} --name=${ContainerCommandBuilder.quote(containerName)} " +
+                "run 'rm -f ${overridePath(unitName)} && rmdir --ignore-fail-on-non-empty $dir 2>/dev/null; systemctl daemon-reload 2>&1'"
+            val result = Shell.cmd(cmd).exec()
+            CommandResult(result.code, result.out, result.err)
+        }
 }

--- a/Android/app/src/main/res/values/strings.xml
+++ b/Android/app/src/main/res/values/strings.xml
@@ -416,6 +416,8 @@
     <string name="restart_service">Restart service</string>
     <string name="reload_service">Reload service</string>
     <string name="mask_service">Mask service</string>
+    <string name="inspect_unit">Inspect unit</string>
+    <string name="edit_override">Edit override</string>
     <string name="action_successful">%1$s %2$s successful</string>
     <string name="failed_to_action">Failed to %1$s %2$s</string>
     <string name="error_unknown">Error: %1$s</string>

--- a/Android/app/src/main/res/xml/locales_config.xml
+++ b/Android/app/src/main/res/xml/locales_config.xml
@@ -3,6 +3,7 @@
     <locale android:name="en" />
     <locale android:name="cbk-PH" />
     <locale android:name="ceb-PH" />
+    <locale android:name="cs" />
     <locale android:name="de" />
     <locale android:name="es" />
     <locale android:name="fil" />


### PR DESCRIPTION
Extends the systemd management screen beyond start/stop/restart:

- ContainerSystemdManager: add inspectUnit() (systemctl show properties, status text, dependency tree) and getOverrideConf/setOverrideConf/ deleteOverrideConf, mirroring 'systemctl edit <unit>' at /etc/systemd/system/<unit>.d/override.conf. Override writes go through the existing base64-streaming pattern to stay safe against shell injection via unit names.
- InitServiceMenuAction: convert to a sealed class (Command / Navigate) so overflow-menu items can open a screen instead of only running a systemctl action. Updates OpenRCScreen/ProcdScreen call sites accordingly.
- Add UnitDetailScreen and OverrideEditorScreen, wired into DroidspacesNavigation with two new routes.
- SystemdScreen: add 'Inspect unit' and 'Edit override' to the per-service overflow menu.