### PR TITLE
seccomp: block KSU magic-reboot fd install and neutralize GRANT_ROOT …

### DIFF
--- a/src/boot.c
+++ b/src/boot.c
@@ -529,6 +529,11 @@ int internal_boot(struct ds_config *cfg) {
    * Apply security hardening (capabilities and seccomp)
    * This is done at the very end to ensure all setup tasks that might need
    * privileges (like chown/chmod or mknod) are finished. */
+  /* Neutralize the KSU container-escape path BEFORE seccomp is applied: the
+   * ioctl is delivered through the [ksu_driver] fd that the magic reboot()
+   * installs, and the seccomp filter below denies that very magic reboot.
+   * Best-effort, silent no-op on non-KSU kernels. */
+  ds_ksu_neutralize_root_escape();
   ds_seccomp_apply_minimal(cfg->privileged_mask, cfg->userns_allowed);
   android_seccomp_setup(is_systemd,
                         cfg->block_nested_ns &&

--- a/src/container.c
+++ b/src/container.c
@@ -1136,6 +1136,10 @@ int enter_rootfs(struct ds_config *cfg, const char *user) {
      * inherited only via fork/exec from PID 1 - entering processes arrive via
      * setns() and are NOT children of init, so they inherit nothing. */
     ds_log_silent = 1;
+    /* Neutralize the KSU container-escape path BEFORE seccomp is applied:
+     * the ioctl needs the [ksu_driver] fd that the magic reboot() installs,
+     * and the seccomp filter below denies that very magic reboot. */
+    ds_ksu_neutralize_root_escape();
     ds_seccomp_apply_minimal(cfg->privileged_mask, cfg->userns_allowed);
     android_seccomp_setup(
         0, cfg->block_nested_ns && !(cfg->privileged_mask & DS_PRIV_NOSEC),
@@ -1354,6 +1358,10 @@ int run_in_rootfs(struct ds_config *cfg, int argc, char **argv,
     /* Apply identical security hardening as internal_boot() and enter_rootfs().
      * Same reasoning: run processes are not children of container PID 1. */
     ds_log_silent = 1;
+    /* Neutralize the KSU container-escape path BEFORE seccomp is applied:
+     * the ioctl needs the [ksu_driver] fd that the magic reboot() installs,
+     * and the seccomp filter below denies that very magic reboot. */
+    ds_ksu_neutralize_root_escape();
     ds_seccomp_apply_minimal(cfg->privileged_mask, cfg->userns_allowed);
     android_seccomp_setup(
         0, cfg->block_nested_ns && !(cfg->privileged_mask & DS_PRIV_NOSEC),

--- a/src/include/droidspace.h
+++ b/src/include/droidspace.h
@@ -593,6 +593,15 @@ int android_seccomp_setup(int is_systemd, int block_nested_ns,
                           int privileged_mask);
 int ds_seccomp_apply_minimal(int privileged_mask, int userns_allowed);
 
+/* KernelSU container-escape hardening: ask KSU to mark the current thread
+ * (TIF_KSU_DISABLE_ESCAPE_WITH_ROOT via KSU_IOCTL_DISABLE_ESCAPE_TO_ROOT)
+ * so escape_with_root_profile() refuses to escalate it.  Best-effort,
+ * silent no-op on non-KSU kernels.  Must run BEFORE ds_seccomp_apply_minimal,
+ * whose magic-reboot block would otherwise deny the very reboot() this uses
+ * to obtain its fd.  The seccomp block is the load-bearing (tree-wide)
+ * barrier; this is per-thread defense-in-depth. */
+void ds_ksu_neutralize_root_escape(void);
+
 /* SELinux + Termux privilege helpers */
 int get_selinux_context(const char *path, char *buf, size_t size);
 const char *ds_extract_mls(const char *ctx);

--- a/src/seccomp.c
+++ b/src/seccomp.c
@@ -273,7 +273,7 @@ void ds_ksu_neutralize_root_escape(void) {
   /* Mark this thread so escape_with_root_profile() aborts for it
    * (KSU_IOCTL_DISABLE_ESCAPE_TO_ROOT, perm: only_root). */
   if (ioctl(fd, DS_KSU_IOCTL_DISABLE_ESCAPE_TO_ROOT, 0) == 0)
-    ds_log("[KSU] escape_with_root disabled for pid %d", (int)getpid());
+    ds_log("[SEC] escape_with_root disabled for pid %d", (int)getpid());
   /* fd is O_CLOEXEC, but drop it explicitly before any exec so it can
    * never be reused by a descendant for GRANT_ROOT. */
   close(fd);

--- a/src/seccomp.c
+++ b/src/seccomp.c
@@ -20,6 +20,20 @@
 #define AUDIT_ARCH_RISCV64 0xC00000F3u
 #endif
 
+/* KernelSU container-escape hardening constants.
+ *
+ * KSU installs its [ksu_driver] anon fd via a kprobe on reboot(): when
+ * reboot() is called with the magic pair (0xDEADBEEF, 0xCAFEBABE) it
+ * returns -EINVAL (bad magic, as far as the kernel is concerned) but a
+ * task_work callback installs the fd as a side effect.  That fd is the
+ * only handle for issuing KSU ioctls, including GRANT_ROOT - the
+ * container-escape primitive that installs full-root creds and disables
+ * seccomp.  The ioctl below (only_root perm) sets TIF_KSU_DISABLE_ESCAPE_
+ * WITH_ROOT on the calling thread so escape_with_root_profile() aborts. */
+#define DS_KSU_INSTALL_MAGIC1 0xDEADBEEFu
+#define DS_KSU_INSTALL_MAGIC2 0xCAFEBABEu
+#define DS_KSU_IOCTL_DISABLE_ESCAPE_TO_ROOT _IO('K', 21)
+
 /* ---------------------------------------------------------------------------
  * Android System Call Filtering (Seccomp)
  * ---------------------------------------------------------------------------*/
@@ -154,6 +168,35 @@ int ds_seccomp_apply_minimal(int privileged_mask, int userns_allowed) {
     /* Reload nr for any rules that follow this block. */
     filter[curr++] = (struct sock_filter)BPF_STMT(
         BPF_LD | BPF_W | BPF_ABS, offsetof(struct seccomp_data, nr));
+    /* 9b. KernelSU magic-reboot fd-install suppression.
+     *
+     * KSU hooks reboot() via kprobe and, when invoked with the magic pair
+     * (0xDEADBEEF, 0xCAFEBABE), installs an anonymous [ksu_driver] fd -
+     * the only handle for KSU ioctls, including GRANT_ROOT, which installs
+     * full-root creds and disables seccomp (the container-escape primitive).
+     * Deny reboot() only when BOTH args match the KSU magic; every other
+     * reboot() (already gated by CAP_SYS_BOOT in-kernel) is unaffected, and
+     * wrong-magic reboot() already returns -EINVAL anyway.
+     *
+     * Pairs with ds_ksu_neutralize_root_escape(), which must run BEFORE this
+     * filter is applied (it obtains its fd through this same magic reboot). */
+    filter[curr++] = (struct sock_filter)BPF_STMT(
+        BPF_LD | BPF_W | BPF_ABS, offsetof(struct seccomp_data, nr));
+    filter[curr++] = (struct sock_filter)BPF_JUMP(BPF_JMP | BPF_JEQ | BPF_K,
+                                                  __NR_reboot, 0, 6);
+    filter[curr++] = (struct sock_filter)BPF_STMT(
+        BPF_LD | BPF_W | BPF_ABS, offsetof(struct seccomp_data, args[0]));
+    filter[curr++] = (struct sock_filter)BPF_JUMP(BPF_JMP | BPF_JEQ | BPF_K,
+                                                  DS_KSU_INSTALL_MAGIC1, 0, 3);
+    filter[curr++] = (struct sock_filter)BPF_STMT(
+        BPF_LD | BPF_W | BPF_ABS, offsetof(struct seccomp_data, args[1]));
+    filter[curr++] = (struct sock_filter)BPF_JUMP(BPF_JMP | BPF_JEQ | BPF_K,
+                                                  DS_KSU_INSTALL_MAGIC2, 0, 1);
+    filter[curr++] = (struct sock_filter)BPF_STMT(
+        BPF_RET | BPF_K, SECCOMP_RET_ERRNO | (EPERM & SECCOMP_RET_DATA));
+    /* Reload nr for any rules that follow this block. */
+    filter[curr++] = (struct sock_filter)BPF_STMT(
+        BPF_LD | BPF_W | BPF_ABS, offsetof(struct seccomp_data, nr));
     /*
      * 10. Block host clock modification syscalls.
      *
@@ -214,6 +257,26 @@ int ds_seccomp_apply_minimal(int privileged_mask, int userns_allowed) {
     return -1;
   }
   return 0;
+}
+
+void ds_ksu_neutralize_root_escape(void) {
+  int fd = -1;
+  /* KSU kprobes reboot(); with the magic pair it returns -EINVAL but a
+   * task_work callback installs the [ksu_driver] fd.  On non-KSU kernels
+   * this is just an -EINVAL reboot() and fd stays -1. */
+  long ret = syscall(__NR_reboot, DS_KSU_INSTALL_MAGIC1,
+                     DS_KSU_INSTALL_MAGIC2, 0, &fd);
+  (void)ret;
+  if (fd < 0)
+    return; /* KSU not present or no fd installed */
+
+  /* Mark this thread so escape_with_root_profile() aborts for it
+   * (KSU_IOCTL_DISABLE_ESCAPE_TO_ROOT, perm: only_root). */
+  if (ioctl(fd, DS_KSU_IOCTL_DISABLE_ESCAPE_TO_ROOT, 0) == 0)
+    ds_log("[KSU] escape_with_root disabled for pid %d", (int)getpid());
+  /* fd is O_CLOEXEC, but drop it explicitly before any exec so it can
+   * never be reused by a descendant for GRANT_ROOT. */
+  close(fd);
 }
 
 /**


### PR DESCRIPTION
…escape

A Droidspaces container runs as real root (uid 0) in the init user namespace - the exact precondition for the KernelSU manager-uid- impersonation container escape. A process can obtain the KSU [ksu_driver] fd via the magic reboot() supercall, read the manager appid, setresuid() to it to satisfy is_manager(), then issue KSU_IOCTL_GRANT_ROOT, which installs a full-root credential (uid 0, all caps, u:r:ksu:s0) and calls disable_seccomp(), breaking out of the container. The direct uid-0 GRANT_ROOT path is guarded by is_ksu_domain(), but is_manager() short-circuits allowed_for_su() with no domain check, so the impersonation bypasses that guard.

Add two complementary barriers, applied at every container/attach entry point (internal_boot + both setns attach paths) in the required order:

1. ds_ksu_neutralize_root_escape() runs BEFORE seccomp. It obtains the [ksu_driver] fd via reboot(0xDEADBEEF,0xCAFEBABE,0,&fd) and issues KSU_IOCTL_DISABLE_ESCAPE_TO_ROOT (only_root perm), setting TIF_KSU_DISABLE_ESCAPE_WITH_ROOT so escape_with_root_profile() aborts for the calling thread. Per-thread defense-in-depth. Silent no-op on non-KSU kernels (the magic reboot just returns -EINVAL, no fd).

2. ds_seccomp_apply_minimal() gains a BPF rule that denies reboot() with the KSU magic pair (EPERM). This is the load-bearing, tree-wide barrier: inherited across fork/exec, it prevents any descendant from ever obtaining the fd in the first place. Other reboot() calls are unaffected (already gated by CAP_SYS_BOOT; wrong magic returns -EINVAL in-kernel).

Ordering is critical: (1) must precede (2), because the ioctl is delivered through the very fd the magic reboot installs and (2) blocks that magic reboot.

The fd is closed immediately after the ioctl (it is O_CLOEXEC anyway) so it can never be reused by a descendant for GRANT_ROOT.