### PR TITLE
post: Implement Devuan-specific umount script patches

### DIFF
--- a/Android/app/src/main/assets/post_extract_fixes.sh
+++ b/Android/app/src/main/assets/post_extract_fixes.sh
@@ -269,7 +269,26 @@ if $TEST -f "$ROOTFS_PATH/etc/dhcpcd.conf"; then
     fi
 fi
 
-# --- 4. Miscellaneous Fixes ---
+# --- 4. Devuan-specific Fixes ---
+
+if $TEST -f "$ROOTFS_PATH/etc/os-release" &&
+   $GREP -q '^ID=devuan$' "$ROOTFS_PATH/etc/os-release"; then
+    log "Devuan detected, patching umount init scripts..."
+
+    for f in "$ROOTFS_PATH"/etc/init.d/umount*; do
+        $TEST -f "$f" || continue
+
+        # Avoid inserting the workaround multiple times
+        if ! $GREP -q '^exit 0$' "$f"; then
+            $SED -i '/^### END INIT INFO$/a exit 0' "$f"
+        fi
+
+        $CHMOD +x "$f"
+    done
+fi
+
+
+# --- 5. Miscellaneous Fixes ---
 
 # Configure logrotate
 log "Configuring logrotate for Android..."


### PR DESCRIPTION
This PR adds a small Devuan-specific post-install fix for Android containers.

Devuan's default `umount*` init scripts try to unmount Android-provided storage during shutdown, which can interfere with the host filesystem. The fix detects `ID=devuan` from `/etc/os-release` and patches the affected scripts to safely skip that behavior inside the container, without affecting other distributions.
