### PR TITLE
feat: add terminal dark mode toggle in Settings

### DIFF
--- a/Android/app/src/main/java/com/droidspaces/app/ui/screen/ContainerTerminalScreen.kt
+++ b/Android/app/src/main/java/com/droidspaces/app/ui/screen/ContainerTerminalScreen.kt
@@ -327,9 +327,10 @@ private fun TerminalTabView(
         PreferencesManager.getInstance(context).terminalDarkTheme
     }
     // Termux TerminalColors indices: 256 = default foreground, 257 = background,
-    // 258 = cursor.
-    val terminalForeground = if (terminalDarkTheme) Color(0xFFE2E2E6).toArgb() else MaterialTheme.colorScheme.onSurface.toArgb()
-    val terminalBackground = if (terminalDarkTheme) Color(0xFF121212).toArgb() else MaterialTheme.colorScheme.surface.toArgb()
+    // 258 = cursor. Dark mode uses the classic termux white-on-black scheme:
+    // pure white foreground on pure black background.
+    val terminalForeground = if (terminalDarkTheme) Color.WHITE.toArgb() else MaterialTheme.colorScheme.onSurface.toArgb()
+    val terminalBackground = if (terminalDarkTheme) Color.BLACK.toArgb() else MaterialTheme.colorScheme.surface.toArgb()
     val virtualKeysBackground = if (terminalDarkTheme) Color(0xFF1A1A1E) else MaterialTheme.colorScheme.surfaceContainerHighest
 
     AnimatedVisibility(

--- a/Android/app/src/main/java/com/droidspaces/app/ui/screen/ContainerTerminalScreen.kt
+++ b/Android/app/src/main/java/com/droidspaces/app/ui/screen/ContainerTerminalScreen.kt
@@ -348,6 +348,9 @@ private fun TerminalTabView(
                         setTypeface(terminalTypeface) // JetBrains Mono; null = system default
                         keepScreenOn = true
                         isFocusableInTouchMode = true
+                        // The renderer only paints cell backgrounds; the full-screen
+                        // default background comes from the View itself.
+                        setBackgroundColor(terminalBackground)
 
                         if (activity != null) {
                             val client = TerminalBackEnd(

--- a/Android/app/src/main/java/com/droidspaces/app/ui/screen/ContainerTerminalScreen.kt
+++ b/Android/app/src/main/java/com/droidspaces/app/ui/screen/ContainerTerminalScreen.kt
@@ -329,8 +329,8 @@ private fun TerminalTabView(
     // Termux TerminalColors indices: 256 = default foreground, 257 = background,
     // 258 = cursor. Dark mode uses the classic termux white-on-black scheme:
     // pure white foreground on pure black background.
-    val terminalForeground = if (terminalDarkTheme) Color.WHITE.toArgb() else MaterialTheme.colorScheme.onSurface.toArgb()
-    val terminalBackground = if (terminalDarkTheme) Color.BLACK.toArgb() else MaterialTheme.colorScheme.surface.toArgb()
+    val terminalForeground = if (terminalDarkTheme) Color.White.toArgb() else MaterialTheme.colorScheme.onSurface.toArgb()
+    val terminalBackground = if (terminalDarkTheme) Color.Black.toArgb() else MaterialTheme.colorScheme.surface.toArgb()
     val virtualKeysBackground = if (terminalDarkTheme) Color(0xFF1A1A1E) else MaterialTheme.colorScheme.surfaceContainerHighest
 
     AnimatedVisibility(

--- a/Android/app/src/main/java/com/droidspaces/app/ui/screen/ContainerTerminalScreen.kt
+++ b/Android/app/src/main/java/com/droidspaces/app/ui/screen/ContainerTerminalScreen.kt
@@ -25,6 +25,7 @@ import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
@@ -41,6 +42,7 @@ import com.droidspaces.app.ui.terminal.virtualkeys.VirtualKeysListener
 import com.droidspaces.app.ui.terminal.virtualkeys.VirtualKeysView
 import com.droidspaces.app.util.AnimationUtils
 import com.droidspaces.app.util.ContainerOSInfoManager
+import com.droidspaces.app.util.PreferencesManager
 import com.droidspaces.app.ui.util.LoadingIndicator
 import com.droidspaces.app.ui.util.LoadingSize
 import com.termux.terminal.TerminalSession
@@ -315,10 +317,20 @@ private fun TerminalTabView(
     val density = LocalDensity.current
     val defaultFontSizePx = remember { with(density) { 10.dp.roundToPx() } }
     val fontSizePx = TerminalSessionService.globalSessionList[tab.id]?.fontSizePx ?: defaultFontSizePx
-    val onSurfaceColor = MaterialTheme.colorScheme.onSurface.toArgb()
     // Loaded once per composition - null = bundled font missing, fallback to system default
     val context = androidx.compose.ui.platform.LocalContext.current
     val terminalTypeface = remember { ResourcesCompat.getFont(context, R.font.jetbrains_mono) }
+
+    // Terminal-only dark mode: renders the terminal page dark even when the rest
+    // of the app follows the light theme. Read once at entry; re-enter to apply.
+    val terminalDarkTheme = remember {
+        PreferencesManager.getInstance(context).terminalDarkTheme
+    }
+    // Termux TerminalColors indices: 256 = default foreground, 257 = background,
+    // 258 = cursor.
+    val terminalForeground = if (terminalDarkTheme) Color(0xFFE2E2E6).toArgb() else MaterialTheme.colorScheme.onSurface.toArgb()
+    val terminalBackground = if (terminalDarkTheme) Color(0xFF121212).toArgb() else MaterialTheme.colorScheme.surface.toArgb()
+    val virtualKeysBackground = if (terminalDarkTheme) Color(0xFF1A1A1E) else MaterialTheme.colorScheme.surfaceContainerHighest
 
     AnimatedVisibility(
         visible = isVisible,
@@ -364,8 +376,9 @@ private fun TerminalTabView(
                         post {
                             requestFocus()
                             mEmulator?.mColors?.mCurrentColors?.apply {
-                                set(256, onSurfaceColor)
-                                set(258, onSurfaceColor)
+                                set(256, terminalForeground)
+                                set(257, terminalBackground)
+                                set(258, terminalForeground)
                             }
                         }
                     }
@@ -387,7 +400,7 @@ private fun TerminalTabView(
                     VirtualKeysView(ctx, null).apply {
                         TerminalScreenState.virtualKeysView = WeakReference(this)
                         binder.getSession(tab.id)?.let { virtualKeysViewClient = VirtualKeysListener(it) }
-                        buttonTextColor = onSurfaceColor
+                        buttonTextColor = terminalForeground
                         try {
                             reload(VirtualKeysInfo(VIRTUAL_KEYS_LAYOUT, "", VirtualKeysConstants.CONTROL_CHARS_ALIASES))
                         } catch (e: Exception) {
@@ -398,12 +411,13 @@ private fun TerminalTabView(
                 update = { vkv ->
                     if (isVisible) {
                         TerminalScreenState.virtualKeysView = WeakReference(vkv)
+                        vkv.buttonTextColor = terminalForeground
                         binder.getSession(tab.id)?.let { vkv.virtualKeysViewClient = VirtualKeysListener(it) }
                     }
                 },
                 modifier = Modifier
                     .fillMaxWidth()
-                    .background(MaterialTheme.colorScheme.surfaceContainerHighest)
+                    .background(virtualKeysBackground)
                     .windowInsetsPadding(WindowInsets.safeDrawing.only(WindowInsetsSides.Bottom))
                     .height(64.dp)
             )

--- a/Android/app/src/main/java/com/droidspaces/app/ui/screen/SettingsScreen.kt
+++ b/Android/app/src/main/java/com/droidspaces/app/ui/screen/SettingsScreen.kt
@@ -87,6 +87,10 @@ fun SettingsScreen(
     val amoledMode = themeState.amoledMode
     val useDynamicColor = themeState.useDynamicColor
 
+    // Terminal-only dark mode - local state mirrors the preference so the switch
+    // updates immediately without waiting for a SharedPreferences listener.
+    var terminalDarkTheme by remember { mutableStateOf(prefsManager.terminalDarkTheme) }
+
     // About dialog state
     var showAboutDialog by remember { mutableStateOf(false) }
 
@@ -361,6 +365,19 @@ fun SettingsScreen(
                     }
                 )
             }
+
+            // Terminal Dark Mode - independent of the app-wide theme
+            HorizontalDivider(modifier = Modifier.padding(horizontal = 16.dp), color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.3f))
+            SwitchItem(
+                icon = Icons.Default.Terminal,
+                title = context.getString(R.string.terminal_dark_theme),
+                summary = context.getString(R.string.terminal_dark_theme_description),
+                checked = terminalDarkTheme,
+                onCheckedChange = { checked ->
+                    prefsManager.terminalDarkTheme = checked
+                    terminalDarkTheme = checked
+                }
+            )
 
             // AMOLED Mode (shown when followSystemTheme is true OR manual darkTheme is true)
             if (followSystemTheme || darkTheme) {

--- a/Android/app/src/main/java/com/droidspaces/app/util/Constants.kt
+++ b/Android/app/src/main/java/com/droidspaces/app/util/Constants.kt
@@ -42,6 +42,7 @@ object Constants {
     const val KEY_AMOLED_MODE = "amoled_mode"
     const val KEY_USE_DYNAMIC_COLOR = "use_dynamic_color"
     const val KEY_THEME_PALETTE = "theme_palette"
+    const val KEY_TERMINAL_DARK_THEME = "terminal_dark_theme"
     const val KEY_APP_LOCALE = "app_locale"
     const val KEY_BACKEND_MODE = "backend_mode"
     const val KEY_DAEMON_MODE_ENABLED = "daemon_mode_enabled"

--- a/Android/app/src/main/java/com/droidspaces/app/util/PreferencesManager.kt
+++ b/Android/app/src/main/java/com/droidspaces/app/util/PreferencesManager.kt
@@ -136,6 +136,14 @@ class PreferencesManager private constructor(context: Context) {
             prefs.edit().putString(KEY_THEME_PALETTE, value).apply()
         }
 
+    // Terminal-only dark mode - independent of the app-wide theme, so the rest
+    // of the app can stay light while the terminal page renders dark.
+    var terminalDarkTheme: Boolean
+        get() = prefs.getBoolean(KEY_TERMINAL_DARK_THEME, false)
+        set(value) {
+            prefs.edit().putBoolean(KEY_TERMINAL_DARK_THEME, value).apply()
+        }
+
     var isDaemonModeEnabled: Boolean
         get() = prefs.getBoolean(KEY_DAEMON_MODE_ENABLED, false)
         set(value) {
@@ -379,6 +387,7 @@ class PreferencesManager private constructor(context: Context) {
         private const val KEY_DARK_THEME = Constants.KEY_DARK_THEME
         private const val KEY_AMOLED_MODE = Constants.KEY_AMOLED_MODE
         private const val KEY_USE_DYNAMIC_COLOR = Constants.KEY_USE_DYNAMIC_COLOR
+        private const val KEY_TERMINAL_DARK_THEME = Constants.KEY_TERMINAL_DARK_THEME
         const val KEY_THEME_PALETTE = Constants.KEY_THEME_PALETTE
         const val KEY_DAEMON_MODE_ENABLED = Constants.KEY_DAEMON_MODE_ENABLED
         const val KEY_SYMLINK_ENABLED = Constants.KEY_SYMLINK_ENABLED

--- a/Android/app/src/main/res/values-zh-rCN/strings.xml
+++ b/Android/app/src/main/res/values-zh-rCN/strings.xml
@@ -69,6 +69,8 @@
     <string name="follow_system_theme_description">自动跟随系统主题</string>
     <string name="dark_theme">深色模式</string>
     <string name="dark_theme_description">开启深色模式</string>
+    <string name="terminal_dark_theme">终端深色模式</string>
+    <string name="terminal_dark_theme_description">仅终端页面使用深色配色</string>
     <string name="amoled_mode">AMOLED 模式</string>
     <string name="amoled_mode_description">为 OLED 屏幕提供纯黑背景</string>
     <string name="dynamic_color">使用系统默认配色方案</string>

--- a/Android/app/src/main/res/values/strings.xml
+++ b/Android/app/src/main/res/values/strings.xml
@@ -82,6 +82,8 @@
     <string name="follow_system_theme_description">Automatically match system theme</string>
     <string name="dark_theme">Dark Theme</string>
     <string name="dark_theme_description">Enable dark theme</string>
+    <string name="terminal_dark_theme">Terminal Dark Mode</string>
+    <string name="terminal_dark_theme_description">Use dark colors for the terminal page only</string>
     <string name="amoled_mode">AMOLED Mode</string>
     <string name="amoled_mode_description">Pure black background for OLED displays</string>
     <string name="dynamic_color">Apply System\'s Default Color Palette</string>


### PR DESCRIPTION
## Summary

Adds a "Terminal Dark Mode" toggle in the Appearance section of Settings. When enabled, only the terminal page renders in dark colors (pure white text on a black background, classic termux scheme) while the rest of the app keeps the light theme. When disabled, the terminal follows the app theme as before.

## Motivation

On light-themed setups the terminal area used theme-derived colors that could be hard to read, and there was no way to force a dark terminal independently of the app-wide theme. This lets users keep a light UI everywhere else while still getting a high-contrast dark terminal.

## Changes Made

- `Constants.kt`: added `KEY_TERMINAL_DARK_THEME` preference key
- `PreferencesManager.kt`: added `terminalDarkTheme` property (default `false`)
- `SettingsScreen.kt`: added a "Terminal Dark Mode" switch under Appearance
- `ContainerTerminalScreen.kt`:
  - When the toggle is on, sets the terminal foreground/cursor to pure white (`#FFFFFF`) and background to pure black (`#000000`) via the termux `TerminalColors` indices (256/257/258)
  - Sets the `TerminalView` view background directly, since the termux renderer only paints cell backgrounds and the full-screen default background comes from the View itself
  - Applies the same dark colors to the virtual keys bar

## Strings

Added `terminal_dark_theme` / `terminal_dark_theme_description` to the default (English) and Simplified Chinese string resources.

## Testing

Verified on a Xiaomi tablet: enabling the toggle turns only the terminal page dark (white on black) while the rest of the app stays light; disabling it restores the previous behavior.