### PR TITLE
Storage: support external volumes, existing image import, and relocation

### DIFF
--- a/Android/app/src/main/assets/boot-module/service.sh
+++ b/Android/app/src/main/assets/boot-module/service.sh
@@ -197,6 +197,21 @@ gateway_available() {
 
 # Start one container; returns 0 if it ends up with a live PID
 boot_container() {
+    # Ensure basic loop devices and external storage mounts are ready
+    for i in 0 1 2 3 4 5 6 7; do
+        [ -e "/dev/block/loop$i" ] || mknod "/dev/block/loop$i" b 7 "$i" 2>/dev/null || true
+        [ -e "/dev/loop$i" ] || mknod "/dev/loop$i" b 7 "$i" 2>/dev/null || true
+    done
+    for d in /mnt/media_rw/*; do
+        if [ -d "$d" ]; then
+            vol=$(${BUSYBOX_BINARY} basename "$d")
+            if [ "$vol" != "*" ] && [ "$vol" != "emulated" ] && [ "$vol" != "self" ]; then
+                mkdir -p "/storage/$vol" 2>/dev/null
+                mountpoint -q "/storage/$vol" 2>/dev/null || mount --bind "$d" "/storage/$vol" 2>/dev/null || true
+            fi
+        fi
+    done
+
     "${DROIDSPACE_BINARY}" --config "$1" start 2>&1 | \
         ${BUSYBOX_BINARY} sed "s/$(${BUSYBOX_BINARY} printf '\033')\[[0-9;]*[mK]//g"
     bpid=$("${DROIDSPACE_BINARY}" --config "$1" pid 2>/dev/null)

--- a/Android/app/src/main/java/com/droidspaces/app/ui/component/ContainerCard.kt
+++ b/Android/app/src/main/java/com/droidspaces/app/ui/component/ContainerCard.kt
@@ -51,6 +51,7 @@ data class ContainerCardActions(
     val onMigrate: () -> Unit = {},
     val onResize: () -> Unit = {},
     val onExport: () -> Unit = {},
+    val onMoveStorage: () -> Unit = {},
     val onToggleExpand: () -> Unit = {},
     val onShowLogs: () -> Unit = {},
 )
@@ -73,6 +74,7 @@ fun ContainerCard(
     val onMigrate = actions.onMigrate
     val onResize = actions.onResize
     val onExport = actions.onExport
+    val onMoveStorage = actions.onMoveStorage
     val onToggleExpand = actions.onToggleExpand
     val onShowLogs = actions.onShowLogs
     val context = LocalContext.current
@@ -293,6 +295,13 @@ fun ContainerCard(
                         label = context.getString(R.string.edit_container_configuration),
                         tint = MaterialTheme.colorScheme.primary,
                         onClick = { onEdit() }
+                    )
+
+                    ActionItem(
+                        icon = Icons.Default.DriveFileMove,
+                        label = "Move storage location",
+                        tint = MaterialTheme.colorScheme.secondary,
+                        onClick = { onMoveStorage() }
                     )
 
                     if (!container.useSparseImage) {

--- a/Android/app/src/main/java/com/droidspaces/app/ui/component/FilePickerDialog.kt
+++ b/Android/app/src/main/java/com/droidspaces/app/ui/component/FilePickerDialog.kt
@@ -29,6 +29,7 @@ import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.input.pointer.pointerInput
 import com.droidspaces.app.util.ContainerCommandBuilder
+import com.droidspaces.app.util.RootNamespace
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.draw.clip
@@ -130,7 +131,11 @@ fun FilePickerDialog(
             }
             if (targetDir != currentPath && targetDir.isNotEmpty()) {
                 val exists = withContext(Dispatchers.IO) {
-                    val result = Shell.cmd("[ -d ${ContainerCommandBuilder.quote(targetDir)} ] && echo yes").exec()
+                    val result = RootNamespace.exec(
+                        "[ -d ${ContainerCommandBuilder.quote(targetDir)} ] && echo yes",
+                        targetPath = targetDir,
+                        forceNsenter = targetDir.startsWith("/storage")
+                    )
                     result.isSuccess && result.out.firstOrNull() == "yes"
                 }
                 if (exists) {
@@ -352,7 +357,11 @@ private fun FileItemRow(
 }
 
 private suspend fun fetchItems(path: String, showFiles: Boolean): List<FileItem> = withContext(Dispatchers.IO) {
-    val result = Shell.cmd("ls -F ${ContainerCommandBuilder.quote(path)} 2>/dev/null").exec()
+    val result = RootNamespace.exec(
+        "ls -F ${ContainerCommandBuilder.quote(path)} 2>/dev/null",
+        targetPath = path,
+        forceNsenter = path.startsWith("/storage")
+    )
     if (!result.isSuccess) return@withContext emptyList()
 
     result.out.mapNotNull { line ->

--- a/Android/app/src/main/java/com/droidspaces/app/ui/component/StorageDestinationPicker.kt
+++ b/Android/app/src/main/java/com/droidspaces/app/ui/component/StorageDestinationPicker.kt
@@ -1,0 +1,171 @@
+package com.droidspaces.app.ui.component
+
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Folder
+import androidx.compose.material.icons.filled.FolderOpen
+import androidx.compose.material.icons.filled.Shield
+import androidx.compose.material.icons.filled.Terminal
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.FilterChip
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextFieldColors
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.unit.dp
+import com.droidspaces.app.util.SafPathResolver
+import com.droidspaces.app.util.StorageChecker
+
+/**
+ * How the user wants to browse for an external storage folder.
+ */
+enum class StorageAccessMode {
+    /** Browse using the root shell (libsu), via [FilePickerDialog]. Some
+     *  USB-OTG / removable volumes aren't reachable this way until Android has
+     *  registered them for the root mount namespace -- [SAF] works around that. */
+    ROOT_EXPLORER,
+
+    /** Use Android's system document-tree picker (Storage Access Framework).
+     *  Goes through Android's own storage stack, so it can reach USB drives
+     *  and SD cards the root browser can't see. */
+    SAF
+}
+
+/**
+ * A storage path field with a folder-browse button that can use either the
+ * app's root-shell file browser ([FilePickerDialog]) or Android's Storage
+ * Access Framework picker. Shared by the container-creation wizard's
+ * StorageLocationScreen and the "Move storage" dialog so both offer the exact
+ * same browsing experience.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun StorageDestinationPicker(
+    path: String,
+    onPathChange: (String) -> Unit,
+    modifier: Modifier = Modifier,
+    label: String = "Storage path",
+    placeholder: String = "/storage/1234-5678/Droidspaces",
+    isError: Boolean = false,
+    supportingText: (@Composable () -> Unit)? = null,
+    trailingStatusIcon: (@Composable () -> Unit)? = null,
+    colors: TextFieldColors = DsTextFieldDefaults.colors(),
+    dialogTitle: String = "Select Storage Location"
+) {
+    var accessMode by remember { mutableStateOf(StorageAccessMode.ROOT_EXPLORER) }
+    var showRootPicker by remember { mutableStateOf(false) }
+    var safError by remember { mutableStateOf<String?>(null) }
+    val context = LocalContext.current
+
+    val safLauncher = rememberLauncherForActivityResult(
+        contract = ActivityResultContracts.OpenDocumentTree()
+    ) { uri ->
+        if (uri == null) return@rememberLauncherForActivityResult
+        SafPathResolver.takePersistablePermission(context, uri)
+        val resolved = SafPathResolver.resolvePathFromUri(context, uri)
+        if (resolved != null) {
+            safError = null
+            onPathChange(resolved)
+        } else {
+            safError = "Couldn't get a filesystem path for that pick. Try a different " +
+                "folder, or switch to Root Explorer."
+        }
+    }
+
+    Column(modifier = modifier, verticalArrangement = Arrangement.spacedBy(8.dp)) {
+        Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+            FilterChip(
+                selected = accessMode == StorageAccessMode.ROOT_EXPLORER,
+                onClick = { accessMode = StorageAccessMode.ROOT_EXPLORER; safError = null },
+                label = { Text("Root Explorer", style = MaterialTheme.typography.labelMedium) },
+                leadingIcon = {
+                    Icon(Icons.Default.Terminal, contentDescription = null, modifier = Modifier.size(16.dp))
+                }
+            )
+            FilterChip(
+                selected = accessMode == StorageAccessMode.SAF,
+                onClick = { accessMode = StorageAccessMode.SAF; safError = null },
+                label = { Text("SAF (USB access)", style = MaterialTheme.typography.labelMedium) },
+                leadingIcon = {
+                    Icon(Icons.Default.Shield, contentDescription = null, modifier = Modifier.size(16.dp))
+                }
+            )
+        }
+
+        if (accessMode == StorageAccessMode.SAF) {
+            Text(
+                text = "Use this if your USB drive doesn't show up in Root Explorer. " +
+                    "Android will ask you to grant access to the folder you pick, then " +
+                    "we'll use that location.",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.7f)
+            )
+        }
+
+        OutlinedTextField(
+            value = path,
+            onValueChange = {
+                onPathChange(it)
+                safError = null
+            },
+            label = { Text(label) },
+            placeholder = { Text(placeholder) },
+            singleLine = true,
+            isError = isError || safError != null,
+            supportingText = {
+                val error = safError
+                if (error != null) {
+                    Text(error, color = MaterialTheme.colorScheme.error)
+                } else {
+                    supportingText?.invoke()
+                }
+            },
+            shape = RoundedCornerShape(16.dp),
+            colors = colors,
+            modifier = Modifier.fillMaxWidth(),
+            leadingIcon = { Icon(Icons.Default.Folder, contentDescription = null) },
+            trailingIcon = {
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    trailingStatusIcon?.invoke()
+                    IconButton(onClick = {
+                        when (accessMode) {
+                            StorageAccessMode.ROOT_EXPLORER -> showRootPicker = true
+                            StorageAccessMode.SAF -> safLauncher.launch(null)
+                        }
+                    }) {
+                        Icon(Icons.Default.FolderOpen, contentDescription = "Browse storage")
+                    }
+                }
+            }
+        )
+    }
+
+    if (showRootPicker) {
+        FilePickerDialog(
+            title = dialogTitle,
+            showFiles = false,
+            onDismiss = { showRootPicker = false },
+            onConfirm = { picked ->
+                onPathChange(StorageChecker.normalizeStorageDir(picked))
+                showRootPicker = false
+            }
+        )
+    }
+}

--- a/Android/app/src/main/java/com/droidspaces/app/ui/navigation/DroidspacesNavigation.kt
+++ b/Android/app/src/main/java/com/droidspaces/app/ui/navigation/DroidspacesNavigation.kt
@@ -29,6 +29,7 @@ import com.droidspaces.app.ui.screen.AutoBootPriorityScreen
 import com.droidspaces.app.ui.screen.WelcomeScreen
 import com.droidspaces.app.ui.screen.ContainerNameScreen
 import com.droidspaces.app.ui.screen.SparseImageConfigScreen
+import com.droidspaces.app.ui.screen.StorageLocationScreen
 import com.droidspaces.app.ui.screen.ContainerConfigScreen
 import com.droidspaces.app.ui.screen.InstallationSummaryScreen
 import com.droidspaces.app.ui.screen.InstallationProgressScreen
@@ -44,6 +45,7 @@ import com.droidspaces.app.ui.viewmodel.ContainerInstallationViewModel
 import com.droidspaces.app.ui.viewmodel.ContainerViewModel
 import com.droidspaces.app.util.ContainerManager
 import com.droidspaces.app.util.FilePickerUtils
+import com.droidspaces.app.util.SafPathResolver
 import androidx.compose.ui.Alignment
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
@@ -80,6 +82,7 @@ sealed class Screen(val route: String) {
         fun createRoute(tarballUri: String) = "container_name/${Uri.encode(tarballUri)}"
     }
     data object SparseImageConfig : Screen("sparse_image_config")
+    data object StorageLocation : Screen("storage_location")
     data object ContainerConfig : Screen("container_config")
     data object InstallationSummary : Screen("installation_summary")
     data object InstallationProgress : Screen("installation_progress")
@@ -333,9 +336,20 @@ fun DroidspacesNavigation(
             val viewModel: ContainerInstallationViewModel = viewModel(backStackEntry)
             val tarballUriString = backStackEntry.arguments?.getString("tarballUri") ?: ""
             val tarballUri = Uri.parse(tarballUriString)
+            val ctx = LocalContext.current
 
             LaunchedEffect(tarballUri) {
                 viewModel.setTarball(tarballUri)
+                // Check if the picked file is already an ext4 .img file
+                val fileName = FilePickerUtils.getFileName(ctx, tarballUri)?.lowercase() ?: ""
+                if (fileName.endsWith(".img")) {
+                    val resolved = SafPathResolver.resolvePathFromUri(ctx, tarballUri) ?: SafPathResolver.normalizePath(tarballUri.path ?: "")
+                    if (!resolved.isNullOrBlank()) {
+                        viewModel.updateImageSourceMode(com.droidspaces.app.ui.viewmodel.ImageSourceMode.EXISTING_SPARSE_IMAGE)
+                        viewModel.setExistingImage(resolved)
+                        viewModel.inspectImage(ctx, resolved)
+                    }
+                }
             }
 
             ContainerNameScreen(
@@ -344,30 +358,9 @@ fun DroidspacesNavigation(
                 existingContainerNames = sharedContainerViewModel.containerList.map { it.name },
                 onNext = { name, hostname ->
                     viewModel.setName(name, hostname)
-                    navController.navigate(Screen.ContainerConfig.route)
-                },
-                onClose = {
-                    navController.popBackStack()
-                }
-            )
-        }
-
-        composable(
-            route = Screen.ContainerConfig.route,
-            enterTransition = defaultEnterTransition,
-            exitTransition = defaultExitTransition
-        ) { backStackEntry ->
-            val viewModel = wizardScopedViewModel(navController, backStackEntry)
-
-            ContainerConfigScreen(
-                initialState = viewModel.configState,
-                containerName = viewModel.containerName,
-                installedContainers = sharedContainerViewModel.containerList,
-                onNext = { state ->
-                    viewModel.setConfig(state)
                     navController.navigate(Screen.SparseImageConfig.route)
                 },
-                onBack = {
+                onClose = {
                     navController.popBackStack()
                 }
             )
@@ -379,12 +372,92 @@ fun DroidspacesNavigation(
             exitTransition = defaultExitTransition
         ) { backStackEntry ->
             val viewModel = wizardScopedViewModel(navController, backStackEntry)
+            val ctx = LocalContext.current
+            val scope = androidx.compose.runtime.rememberCoroutineScope()
 
             SparseImageConfigScreen(
-                initialUseSparseImage = viewModel.useSparseImage,
+                initialMode = viewModel.imageSourceMode,
                 initialSizeGB = viewModel.sparseImageSizeGB,
-                onNext = { useSparseImage, sizeGB ->
-                    viewModel.setSparseImageConfig(useSparseImage, sizeGB)
+                initialExistingImagePath = viewModel.existingImagePath,
+                initialInspection = viewModel.existingImageInspection,
+                isInspecting = viewModel.isInspectingImage,
+                useEmbeddedConfig = viewModel.useEmbeddedConfig,
+                onModeChange = { mode ->
+                    viewModel.updateImageSourceMode(mode)
+                },
+                onInspectImage = { path ->
+                    scope.launch {
+                        viewModel.setExistingImage(path, null)
+                        viewModel.inspectImage(ctx, path)
+                    }
+                },
+                onApplyImportedConfig = { apply ->
+                    viewModel.applyImportedConfig(apply)
+                },
+                onNext = { mode, sizeGB, existingPath ->
+                    viewModel.updateImageSourceMode(mode)
+                    if (mode == com.droidspaces.app.ui.viewmodel.ImageSourceMode.EXISTING_SPARSE_IMAGE) {
+                        viewModel.setExistingImage(existingPath, viewModel.existingImageInspection)
+                        // If existing image is on external path, save its parent dir
+                        if (!existingPath.isNullOrBlank() && (existingPath.startsWith("/storage/") || existingPath.startsWith("/mnt/media_rw/"))) {
+                            val parentDir = existingPath.substringBeforeLast("/")
+                            viewModel.setStorageLocation(parentDir)
+                        }
+                        // Existing image is already its own storage location - skip StorageLocationScreen
+                        navController.navigate(Screen.ContainerConfig.route)
+                    } else {
+                        if (mode == com.droidspaces.app.ui.viewmodel.ImageSourceMode.NEW_SPARSE_IMAGE) {
+                            viewModel.setSparseImageConfig(true, sizeGB)
+                        } else {
+                            viewModel.setSparseImageConfig(false, 8)
+                        }
+                        navController.navigate(Screen.StorageLocation.route)
+                    }
+                },
+                onBack = {
+                    navController.popBackStack()
+                }
+            )
+        }
+
+        composable(
+            route = Screen.StorageLocation.route,
+            enterTransition = defaultEnterTransition,
+            exitTransition = defaultExitTransition
+        ) { backStackEntry ->
+            val viewModel = wizardScopedViewModel(navController, backStackEntry)
+
+            StorageLocationScreen(
+                initialPath = viewModel.customStorageLocation,
+                useSparseImage = viewModel.useSparseImage,
+                onSwitchToSparseImage = {
+                    viewModel.setSparseImageConfig(true, 8)
+                },
+                onNext = { path ->
+                    viewModel.setStorageLocation(path)
+                    navController.navigate(Screen.ContainerConfig.route)
+                },
+                onBack = {
+                    navController.popBackStack()
+                }
+            )
+        }
+
+        composable(
+            route = Screen.ContainerConfig.route,
+            enterTransition = defaultEnterTransition,
+            exitTransition = defaultExitTransition
+        ) { backStackEntry ->
+            val viewModel = wizardScopedViewModel(navController, backStackEntry)
+            val isOverride = viewModel.isExistingImage && (viewModel.importedImageConfig != null || viewModel.existingImageInspection?.embeddedConfig != null)
+
+            ContainerConfigScreen(
+                initialState = viewModel.configState,
+                containerName = viewModel.containerName,
+                installedContainers = sharedContainerViewModel.containerList,
+                isOverrideMode = isOverride,
+                onNext = { state ->
+                    viewModel.setConfig(state)
                     navController.navigate(Screen.InstallationSummary.route)
                 },
                 onBack = {
@@ -401,18 +474,23 @@ fun DroidspacesNavigation(
             val viewModel = wizardScopedViewModel(navController, backStackEntry)
             val config = viewModel.buildConfig()
             val tarballUri = viewModel.tarballUri
+            val isExisting = viewModel.isExistingImage
+            val existingPath = viewModel.existingImagePath
             val ctx = LocalContext.current
 
-            if (config != null && tarballUri != null) {
-                // Extract filename from URI using FilePickerUtils (handles recent files properly)
-                var tarballName by remember { mutableStateOf<String?>(null) }
+            if (config != null && (isExisting || tarballUri != null)) {
+                var displayName by remember { mutableStateOf<String?>(null) }
 
-                LaunchedEffect(tarballUri) {
-                    tarballName = FilePickerUtils.getFileName(ctx, tarballUri) ?: "container.tar.gz"
+                LaunchedEffect(tarballUri, isExisting, existingPath) {
+                    if (isExisting) {
+                        displayName = existingPath?.substringAfterLast("/") ?: "rootfs.img"
+                    } else if (tarballUri != null) {
+                        displayName = FilePickerUtils.getFileName(ctx, tarballUri) ?: "container.tar.gz"
+                    }
                 }
 
                 // Show loading while extracting filename
-                if (tarballName == null) {
+                if (displayName == null) {
                     Box(
                         modifier = Modifier.fillMaxSize(),
                         contentAlignment = Alignment.Center
@@ -422,7 +500,9 @@ fun DroidspacesNavigation(
                 } else {
                     InstallationSummaryScreen(
                         config = config,
-                        tarballName = tarballName!!,
+                        tarballName = displayName!!,
+                        isExistingImage = isExisting,
+                        existingImagePath = existingPath,
                         onInstall = {
                             navController.navigate(Screen.InstallationProgress.route)
                         },
@@ -447,10 +527,13 @@ fun DroidspacesNavigation(
             val viewModel = wizardScopedViewModel(navController, backStackEntry)
             val config = viewModel.buildConfig()
             val tarballUri = viewModel.tarballUri
+            val isExisting = viewModel.isExistingImage
+            val existingPath = viewModel.existingImagePath
 
-            if (config != null && tarballUri != null) {
+            if (config != null && (isExisting || tarballUri != null)) {
                 InstallationProgressScreen(
                     tarballUri = tarballUri,
+                    existingImagePath = if (isExisting) existingPath else null,
                     config = config,
                     onSuccess = {
                         viewModel.reset()

--- a/Android/app/src/main/java/com/droidspaces/app/ui/screen/ContainerConfigScreen.kt
+++ b/Android/app/src/main/java/com/droidspaces/app/ui/screen/ContainerConfigScreen.kt
@@ -17,6 +17,7 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.automirrored.filled.ArrowForward
+import androidx.compose.material.icons.filled.Settings
 import androidx.compose.material.ripple.rememberRipple
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
@@ -51,6 +52,7 @@ fun ContainerConfigScreen(
     initialState: ContainerConfigState = ContainerConfigState(),
     containerName: String = "",
     installedContainers: List<ContainerInfo> = emptyList(),
+    isOverrideMode: Boolean = false,
     onNext: (ContainerConfigState) -> Unit,
     onBack: () -> Unit
 ) {
@@ -77,7 +79,12 @@ fun ContainerConfigScreen(
     Scaffold(
         topBar = {
             TopAppBar(
-                title = { Text(context.getString(R.string.configuration_title)) },
+                title = {
+                    Text(
+                        if (isOverrideMode) context.getString(R.string.config_override_title)
+                        else context.getString(R.string.configuration_title)
+                    )
+                },
                 navigationIcon = {
                     IconButton(onClick = onBack) {
                         Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = context.getString(R.string.back))
@@ -125,7 +132,7 @@ fun ContainerConfigScreen(
                                     tint = if (canProceed) MaterialTheme.colorScheme.onPrimary else MaterialTheme.colorScheme.onSurface.copy(alpha = 0.38f)
                                 )
                                 Text(
-                                    context.getString(R.string.next_storage),
+                                    context.getString(R.string.next_summary),
                                     style = MaterialTheme.typography.labelLarge,
                                     fontWeight = FontWeight.SemiBold,
                                     color = if (canProceed) MaterialTheme.colorScheme.onPrimary else MaterialTheme.colorScheme.onSurface.copy(alpha = 0.38f)
@@ -152,11 +159,52 @@ fun ContainerConfigScreen(
                 collisionContainer = collisionContainer,
                 modifier = Modifier.fillMaxSize(),
                 leadingContent = {
-                    Text(
-                        text = context.getString(R.string.container_options),
-                        style = MaterialTheme.typography.headlineSmall,
-                        fontWeight = FontWeight.Bold
-                    )
+                    Column(
+                        modifier = Modifier.fillMaxWidth(),
+                        verticalArrangement = Arrangement.spacedBy(16.dp)
+                    ) {
+                        if (isOverrideMode) {
+                            Surface(
+                                shape = RoundedCornerShape(16.dp),
+                                color = MaterialTheme.colorScheme.primaryContainer.copy(alpha = 0.45f),
+                                border = androidx.compose.foundation.BorderStroke(
+                                    1.dp,
+                                    MaterialTheme.colorScheme.primary.copy(alpha = 0.35f)
+                                ),
+                                modifier = Modifier.fillMaxWidth()
+                            ) {
+                                Row(
+                                    modifier = Modifier.padding(16.dp),
+                                    horizontalArrangement = Arrangement.spacedBy(12.dp)
+                                ) {
+                                    Icon(
+                                        imageVector = Icons.Default.Settings,
+                                        contentDescription = null,
+                                        tint = MaterialTheme.colorScheme.primary,
+                                        modifier = Modifier.size(24.dp)
+                                    )
+                                    Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
+                                        Text(
+                                            text = context.getString(R.string.config_override_banner_title),
+                                            style = MaterialTheme.typography.titleMedium,
+                                            fontWeight = FontWeight.Bold,
+                                            color = MaterialTheme.colorScheme.onPrimaryContainer
+                                        )
+                                        Text(
+                                            text = context.getString(R.string.config_override_banner_desc),
+                                            style = MaterialTheme.typography.bodySmall,
+                                            color = MaterialTheme.colorScheme.onPrimaryContainer.copy(alpha = 0.85f)
+                                        )
+                                    }
+                                }
+                            }
+                        }
+                        Text(
+                            text = if (isOverrideMode) "Override Settings" else context.getString(R.string.container_options),
+                            style = MaterialTheme.typography.headlineSmall,
+                            fontWeight = FontWeight.Bold
+                        )
+                    }
                 }
             )
         }

--- a/Android/app/src/main/java/com/droidspaces/app/ui/screen/ContainerNameScreen.kt
+++ b/Android/app/src/main/java/com/droidspaces/app/ui/screen/ContainerNameScreen.kt
@@ -103,7 +103,7 @@ fun ContainerNameScreen(
         bottomBar = {
             val isNextValid = containerName.isNotBlank() && nameError == null && hostnameError == null
             PrimaryActionBottomBar(
-                label = context.getString(R.string.next_configuration),
+                label = context.getString(R.string.next_storage),
                 icon = Icons.AutoMirrored.Filled.ArrowForward,
                 onClick = {
                     clearFocus()

--- a/Android/app/src/main/java/com/droidspaces/app/ui/screen/ContainerTerminalScreen.kt
+++ b/Android/app/src/main/java/com/droidspaces/app/ui/screen/ContainerTerminalScreen.kt
@@ -330,11 +330,7 @@ private fun TerminalTabView(
     // 258 = cursor. Dark mode uses the classic termux white-on-black scheme:
     // pure white foreground on pure black background.
     val terminalForeground = if (terminalDarkTheme) Color.White.toArgb() else MaterialTheme.colorScheme.onSurface.toArgb()
-    // Only dark mode explicitly overrides the full-screen background (View paint)
-    // and the default background color (index 257). In light mode we keep the
-    // pre-PR behavior: the Activity background shows through and the Termux
-    // default background color is left untouched.
-    val terminalBackground = if (terminalDarkTheme) Color.Black.toArgb() else 0
+    val terminalBackground = if (terminalDarkTheme) Color.Black.toArgb() else MaterialTheme.colorScheme.surface.toArgb()
     val virtualKeysBackground = if (terminalDarkTheme) Color(0xFF1A1A1E) else MaterialTheme.colorScheme.surfaceContainerHighest
 
     AnimatedVisibility(
@@ -355,9 +351,7 @@ private fun TerminalTabView(
                         isFocusableInTouchMode = true
                         // The renderer only paints cell backgrounds; the full-screen
                         // default background comes from the View itself.
-                        if (terminalDarkTheme) {
-                            setBackgroundColor(terminalBackground)
-                        }
+                        setBackgroundColor(terminalBackground)
 
                         if (activity != null) {
                             val client = TerminalBackEnd(
@@ -387,10 +381,8 @@ private fun TerminalTabView(
                             requestFocus()
                             mEmulator?.mColors?.mCurrentColors?.apply {
                                 set(256, terminalForeground)
+                                set(257, terminalBackground)
                                 set(258, terminalForeground)
-                                if (terminalDarkTheme) {
-                                    set(257, terminalBackground)
-                                }
                             }
                         }
                     }

--- a/Android/app/src/main/java/com/droidspaces/app/ui/screen/ContainersScreen.kt
+++ b/Android/app/src/main/java/com/droidspaces/app/ui/screen/ContainersScreen.kt
@@ -53,6 +53,7 @@ import com.droidspaces.app.ui.component.RootfsRepoSheet
 import com.droidspaces.app.ui.viewmodel.ContainerViewModel
 import com.droidspaces.app.ui.viewmodel.ContainerOperationsViewModel
 import com.droidspaces.app.ui.viewmodel.UninstallState
+import com.droidspaces.app.ui.viewmodel.MoveStorageState
 import com.droidspaces.app.ui.viewmodel.SparseOperation
 import androidx.compose.foundation.clickable
 import androidx.compose.ui.draw.clip
@@ -85,6 +86,7 @@ fun ContainersScreen(
     // UI-only state (dialog triggers / pending pickers).
     var showUninstallConfirmation by remember { mutableStateOf<ContainerInfo?>(null) }
     var pendingSparseOperation by remember { mutableStateOf<SparseOperation?>(null) }
+    var pendingMoveStorageContainer by remember { mutableStateOf<ContainerInfo?>(null) }
     var pendingExportContainer by remember { mutableStateOf<ContainerInfo?>(null) }
     var showRepoSheet by remember { mutableStateOf(false) }
 
@@ -246,6 +248,10 @@ fun ContainersScreen(
                                 val fileName = "${container.name}_${timestamp}.tar.gz"
                                 pendingExportContainer = container
                                 exportFileLauncher.launch(fileName)
+                            },
+                            onMoveStorage = {
+                                onExpandedContainerNameChange(null)
+                                pendingMoveStorageContainer = container
                             }
                             )
                         )
@@ -407,6 +413,39 @@ fun ContainersScreen(
                     }
                 },
                 onDismiss = { pendingSparseOperation = null }
+            )
+        }
+
+        // Move-storage location picker dialog
+        pendingMoveStorageContainer?.let { container ->
+            MoveStorageDialog(
+                container = container,
+                onConfirm = { newPath ->
+                    pendingMoveStorageContainer = null
+                    scope.launch {
+                        opsViewModel.executeMoveStorage(
+                            container,
+                            newPath,
+                            onError = { msg -> scope.showError(snackbarHostState, msg) },
+                            onSuccess = { msg -> scope.showSuccess(snackbarHostState, msg) },
+                            onRefresh = { containerViewModel.refresh() }
+                        )
+                    }
+                },
+                onDismiss = { pendingMoveStorageContainer = null }
+            )
+        }
+
+        // Move-storage progress dialog
+        (opsViewModel.moveStorageState as? MoveStorageState.InProgress)?.let { state ->
+            ProgressDialog(message = state.message)
+        }
+
+        // Move-storage logs dialog (only on failure without a clear error message)
+        opsViewModel.moveStorageLogsDialog?.let { logs ->
+            ErrorLogsDialog(
+                logs = logs,
+                onDismiss = { opsViewModel.dismissMoveStorageLogs() }
             )
         }
     }
@@ -597,6 +636,220 @@ private fun UninstallConfirmationDialog(
                                 style = MaterialTheme.typography.labelLarge,
                                 fontWeight = FontWeight.Bold,
                                 color = if (isConfirmed) MaterialTheme.colorScheme.onError else MaterialTheme.colorScheme.onSurface.copy(alpha = 0.38f)
+                            )
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+/**
+ * Lets the user relocate an existing container's rootfs: internal (default) or an
+ * external/custom path, mirroring [StorageLocationScreen]'s choice but as a compact
+ * dialog for an existing container instead of a full wizard step. Only offered when
+ * the underlying data move (and config rewrite) is confirmed here -- the actual
+ * move happens in [ContainerOperationsViewModel.executeMoveStorage].
+ */
+/** Local validation state for [MoveStorageDialog]'s custom path field. */
+private sealed class MoveStoragePathCheck {
+    data object Idle : MoveStoragePathCheck()
+    data object Checking : MoveStoragePathCheck()
+    data object Valid : MoveStoragePathCheck()
+    data class Invalid(val reason: String) : MoveStoragePathCheck()
+}
+
+@OptIn(androidx.compose.foundation.layout.ExperimentalLayoutApi::class)
+@Composable
+private fun MoveStorageDialog(
+    container: com.droidspaces.app.util.ContainerInfo,
+    onConfirm: (newPath: String?) -> Unit,
+    onDismiss: () -> Unit
+) {
+    val dialogShape = RoundedCornerShape(24.dp)
+    val currentDir = container.rootfsPath.substringBeforeLast("/", "")
+    var useCustomLocation by remember { mutableStateOf(false) }
+    val context = LocalContext.current
+    var customPath by remember { mutableStateOf("") }
+    var detectedVolumes by remember { mutableStateOf<List<String>>(emptyList()) }
+    var sharedStoragePath by remember { mutableStateOf<String?>(null) }
+    var pathCheck by remember { mutableStateOf<MoveStoragePathCheck>(MoveStoragePathCheck.Idle) }
+    val scope = rememberCoroutineScope()
+
+    LaunchedEffect(Unit) {
+        detectedVolumes = com.droidspaces.app.util.StorageChecker.listStorageVolumes()
+        sharedStoragePath = com.droidspaces.app.util.StorageChecker.getSharedStoragePath()
+    }
+
+    // Debounced writability check, same as the creation wizard's StorageLocationScreen --
+    // catches a bad/mistyped path here with a clear message instead of deep in the move.
+    LaunchedEffect(customPath, useCustomLocation) {
+        if (!useCustomLocation || customPath.trim().isEmpty()) {
+            pathCheck = MoveStoragePathCheck.Idle
+            return@LaunchedEffect
+        }
+        pathCheck = MoveStoragePathCheck.Checking
+        kotlinx.coroutines.delay(500)
+        val result = com.droidspaces.app.util.StorageChecker.validateWritablePath(customPath.trim())
+        pathCheck = if (result.isSuccess) {
+            if (!container.useSparseImage) {
+                val report = com.droidspaces.app.util.StorageChecker.inspectFilesystemCapabilities(customPath.trim(), context)
+                if (!report.isFullyCompatibleWithDirectoryMode) {
+                    MoveStoragePathCheck.Invalid("Incompatible '${report.fsType}' filesystem. Directory mode requires POSIX ext4/f2fs. Migrate container to sparse image first.")
+                } else {
+                    MoveStoragePathCheck.Valid
+                }
+            } else {
+                MoveStoragePathCheck.Valid
+            }
+        } else {
+            MoveStoragePathCheck.Invalid(result.exceptionOrNull()?.message ?: "Can't write to this path")
+        }
+    }
+
+    val isValid = !useCustomLocation ||
+        (customPath.trim().isNotEmpty() && pathCheck !is MoveStoragePathCheck.Invalid)
+
+    Dialog(
+        onDismissRequest = onDismiss,
+        properties = androidx.compose.ui.window.DialogProperties(usePlatformDefaultWidth = false)
+    ) {
+        Surface(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 24.dp)
+                .imePadding(),
+            shape = dialogShape,
+            color = MaterialTheme.colorScheme.surfaceContainer,
+            border = androidx.compose.foundation.BorderStroke(1.dp, MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.4f)),
+            tonalElevation = 0.dp
+        ) {
+            Column(modifier = Modifier.padding(24.dp), verticalArrangement = Arrangement.spacedBy(16.dp)) {
+                Text("Move Storage", fontWeight = FontWeight.Bold, style = MaterialTheme.typography.titleLarge)
+                Text(
+                    "Move \"${container.name}\"'s data to a different location. The container will be stopped first if it's running.",
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+                Text(
+                    "Current location: $currentDir",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.7f)
+                )
+
+                if (!container.useSparseImage) {
+                    Surface(
+                        modifier = Modifier.fillMaxWidth(),
+                        shape = RoundedCornerShape(14.dp),
+                        color = MaterialTheme.colorScheme.errorContainer.copy(alpha = 0.4f)
+                    ) {
+                        Text(
+                            "This container uses directory-mode rootfs. Moving it to a FAT32/exFAT SD card or USB drive will break it -- only move it to another ext4/f2fs-formatted location.",
+                            modifier = Modifier.padding(12.dp),
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant
+                        )
+                    }
+                }
+
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    RadioButton(selected = !useCustomLocation, onClick = { useCustomLocation = false })
+                    Text("Internal storage (default)", style = MaterialTheme.typography.bodyMedium)
+                }
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    RadioButton(selected = useCustomLocation, onClick = { useCustomLocation = true })
+                    Text("External / custom location", style = MaterialTheme.typography.bodyMedium)
+                }
+
+                if (useCustomLocation) {
+                    com.droidspaces.app.ui.component.StorageDestinationPicker(
+                        path = customPath,
+                        onPathChange = { customPath = it },
+                        placeholder = "/storage/1234-5678/Droidspaces",
+                        isError = pathCheck is MoveStoragePathCheck.Invalid,
+                        trailingStatusIcon = {
+                            when (pathCheck) {
+                                is MoveStoragePathCheck.Checking -> CircularProgressIndicator(
+                                    modifier = Modifier.size(18.dp),
+                                    strokeWidth = 2.dp
+                                )
+                                is MoveStoragePathCheck.Valid -> Icon(
+                                    Icons.Default.CheckCircle,
+                                    contentDescription = null,
+                                    tint = MaterialTheme.colorScheme.primary
+                                )
+                                is MoveStoragePathCheck.Invalid -> Icon(
+                                    Icons.Default.Error,
+                                    contentDescription = null,
+                                    tint = MaterialTheme.colorScheme.error
+                                )
+                                else -> {}
+                            }
+                        },
+                        supportingText = {
+                            val check = pathCheck
+                            when (check) {
+                                is MoveStoragePathCheck.Invalid -> Text(check.reason, color = MaterialTheme.colorScheme.error)
+                                is MoveStoragePathCheck.Valid -> Text("Path is writable", color = MaterialTheme.colorScheme.primary)
+                                else -> {}
+                            }
+                        },
+                        colors = DsTextFieldDefaults.colors(),
+                        dialogTitle = "Select Storage Location"
+                    )
+
+                    if (detectedVolumes.isNotEmpty() || sharedStoragePath != null) {
+                        androidx.compose.foundation.layout.FlowRow(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                            sharedStoragePath?.let { shared ->
+                                AssistChip(
+                                    onClick = { customPath = "$shared/Droidspaces" },
+                                    label = { Text("This device's storage") },
+                                    leadingIcon = {
+                                        Icon(Icons.Default.Smartphone, contentDescription = null, modifier = Modifier.size(18.dp))
+                                    }
+                                )
+                            }
+                            detectedVolumes.forEach { volume ->
+                                AssistChip(
+                                    onClick = { customPath = "$volume/Droidspaces" },
+                                    label = { Text(volume.substringAfterLast("/")) }
+                                )
+                            }
+                        }
+                    }
+                }
+
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.spacedBy(12.dp)
+                ) {
+                    Surface(
+                        modifier = Modifier.weight(1f).clip(RoundedCornerShape(14.dp)).clickable(onClick = onDismiss),
+                        shape = RoundedCornerShape(14.dp),
+                        color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.06f),
+                        border = androidx.compose.foundation.BorderStroke(1.dp, MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.4f)),
+                        tonalElevation = 0.dp
+                    ) {
+                        Box(modifier = Modifier.padding(14.dp), contentAlignment = Alignment.Center) {
+                            Text("Cancel", style = MaterialTheme.typography.labelLarge, fontWeight = FontWeight.SemiBold)
+                        }
+                    }
+                    Surface(
+                        modifier = Modifier.weight(1f).clip(RoundedCornerShape(14.dp)).clickable(
+                            enabled = isValid,
+                            onClick = { onConfirm(if (useCustomLocation) customPath.trim() else null) }
+                        ),
+                        shape = RoundedCornerShape(14.dp),
+                        color = if (isValid) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.onSurface.copy(alpha = 0.12f),
+                        tonalElevation = 0.dp
+                    ) {
+                        Box(modifier = Modifier.padding(14.dp), contentAlignment = Alignment.Center) {
+                            Text(
+                                "Move",
+                                style = MaterialTheme.typography.labelLarge,
+                                fontWeight = FontWeight.SemiBold,
+                                color = if (isValid) MaterialTheme.colorScheme.onPrimary else MaterialTheme.colorScheme.onSurface.copy(alpha = 0.38f)
                             )
                         }
                     }

--- a/Android/app/src/main/java/com/droidspaces/app/ui/screen/InstallationProgressScreen.kt
+++ b/Android/app/src/main/java/com/droidspaces/app/ui/screen/InstallationProgressScreen.kt
@@ -37,7 +37,8 @@ enum class InstallationState {
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun InstallationProgressScreen(
-    tarballUri: Uri,
+    tarballUri: Uri? = null,
+    existingImagePath: String? = null,
     config: ContainerInfo,
     onSuccess: () -> Unit,
     onError: () -> Unit
@@ -73,15 +74,27 @@ fun InstallationProgressScreen(
             logger.i("Starting container installation...")
             logger.i("Container: ${config.name}")
             logger.i("Hostname: ${config.hostname}")
-            val tarballName = FilePickerUtils.getFileName(context, tarballUri) ?: tarballUri.toString()
-            logger.i("Tarball: $tarballName")
 
-            val result = ContainerInstaller.installContainer(
-                context = context,
-                tarballUri = tarballUri,
-                config = config,
-                logger = logger
-            )
+            val result = if (!existingImagePath.isNullOrBlank()) {
+                logger.i("Source: Existing Image (${existingImagePath.substringAfterLast("/")})")
+                ContainerInstaller.installFromExistingImage(
+                    context = context,
+                    config = config,
+                    existingImagePath = existingImagePath,
+                    logger = logger
+                )
+            } else if (tarballUri != null) {
+                val tarballName = FilePickerUtils.getFileName(context, tarballUri) ?: tarballUri.toString()
+                logger.i("Tarball: $tarballName")
+                ContainerInstaller.installContainer(
+                    context = context,
+                    tarballUri = tarballUri,
+                    config = config,
+                    logger = logger
+                )
+            } else {
+                Result.failure(Exception("No tarball or existing image provided"))
+            }
 
             installationState = if (result.isSuccess) {
                 logger.i("Installation completed successfully!")

--- a/Android/app/src/main/java/com/droidspaces/app/ui/screen/InstallationSummaryScreen.kt
+++ b/Android/app/src/main/java/com/droidspaces/app/ui/screen/InstallationSummaryScreen.kt
@@ -34,6 +34,8 @@ import androidx.compose.ui.res.stringResource
 fun InstallationSummaryScreen(
     config: ContainerInfo,
     tarballName: String,
+    isExistingImage: Boolean = false,
+    existingImagePath: String? = null,
     onInstall: () -> Unit,
     onBack: () -> Unit
 ) {
@@ -88,7 +90,19 @@ fun InstallationSummaryScreen(
                         .padding(20.dp),
                     verticalArrangement = Arrangement.spacedBy(8.dp)
                 ) {
-                    SummaryItem(stringResource(R.string.tarball_label), tarballName, Icons.Default.Archive)
+                    if (isExistingImage) {
+                        val imgDisplay = existingImagePath?.substringAfterLast("/") ?: tarballName
+                        SummaryItem(stringResource(R.string.existing_image_label), imgDisplay, Icons.Default.SdCard)
+                        SummaryItem(stringResource(R.string.storage_configuration), stringResource(R.string.install_mode_existing), Icons.Default.MoveToInbox)
+                    } else {
+                        SummaryItem(stringResource(R.string.tarball_label), tarballName, Icons.Default.Archive)
+                        if (config.useSparseImage && config.sparseImageSizeGB != null) {
+                            SummaryItem(stringResource(R.string.storage_configuration), "${stringResource(R.string.sparse_image_configuration)} (${config.sparseImageSizeGB}GB)", Icons.Default.Storage)
+                        } else {
+                            SummaryItem(stringResource(R.string.storage_configuration), stringResource(R.string.directory_label), Icons.Default.Folder)
+                        }
+                    }
+
                     SummaryItem(stringResource(R.string.container_singular), config.name, Icons.Default.Storage)
                     SummaryItem(stringResource(R.string.hostname), config.hostname, Icons.Default.Computer)
                     SummaryItem(
@@ -99,12 +113,28 @@ fun InstallationSummaryScreen(
                     if (config.netMode == "nat" && config.staticNatIp.isNotEmpty()) {
                         SummaryItem(stringResource(R.string.static_ip_address), config.staticNatIp, Icons.Default.NetworkCheck)
                     }
-                    if (config.useSparseImage && config.sparseImageSizeGB != null) {
-                        SummaryItem(stringResource(R.string.storage_configuration), "${stringResource(R.string.sparse_image_configuration)} (${config.sparseImageSizeGB}GB)", Icons.Default.Storage)
+
+                    // Reflect the actual chosen rootfs location
+                    if (isExistingImage) {
+                        val fullPath = existingImagePath ?: config.rootfsPath
+                        SummaryItem(
+                            stringResource(R.string.existing_path_label),
+                            fullPath,
+                            Icons.Default.SdCard
+                        )
                     } else {
-                        SummaryItem(stringResource(R.string.storage_configuration), stringResource(R.string.directory_label), Icons.Default.Folder)
+                        val rootfsParentDir = config.rootfsPath.substringBeforeLast("/", "")
+                        val defaultContainerDir = "${Constants.CONTAINERS_BASE_PATH}/${com.droidspaces.app.util.ContainerManager.sanitizeContainerName(config.name)}"
+                        val isExternalStorage = rootfsParentDir.isNotEmpty() && rootfsParentDir != defaultContainerDir
+                        SummaryItem(
+                            stringResource(R.string.installation_path_label),
+                            if (isExternalStorage) rootfsParentDir else defaultContainerDir,
+                            Icons.Default.Folder
+                        )
+                        if (isExternalStorage) {
+                            SummaryItem("Storage type", "External / custom location", Icons.Default.Usb)
+                        }
                     }
-                    SummaryItem(stringResource(R.string.installation_path_label), "${Constants.CONTAINERS_BASE_PATH}/${com.droidspaces.app.util.ContainerManager.sanitizeContainerName(config.name)}", Icons.Default.Folder)
 
                     HorizontalDivider(
                         modifier = Modifier.padding(vertical = 8.dp),

--- a/Android/app/src/main/java/com/droidspaces/app/ui/screen/SparseImageConfigScreen.kt
+++ b/Android/app/src/main/java/com/droidspaces/app/ui/screen/SparseImageConfigScreen.kt
@@ -1,12 +1,11 @@
 package com.droidspaces.app.ui.screen
 
-import com.droidspaces.app.ui.component.DsTextFieldDefaults
-
-import com.droidspaces.app.ui.component.PrimaryActionBottomBar
-import androidx.compose.ui.graphics.Color
-import androidx.compose.foundation.layout.ExperimentalLayoutApi
-import androidx.compose.foundation.layout.consumeWindowInsets
-
+import android.net.Uri
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
@@ -18,58 +17,127 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.automirrored.filled.ArrowForward
 import androidx.compose.material.icons.filled.*
-import androidx.compose.material.ripple.rememberRipple
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.platform.LocalContext
 import com.droidspaces.app.R
+import com.droidspaces.app.ui.component.DsTextFieldDefaults
+import com.droidspaces.app.ui.component.FilePickerDialog
+import com.droidspaces.app.ui.component.PrimaryActionBottomBar
+import com.droidspaces.app.ui.component.StorageAccessMode
+import com.droidspaces.app.ui.util.LoadingIndicator
+import com.droidspaces.app.ui.util.LoadingSize
+import com.droidspaces.app.ui.viewmodel.ImageSourceMode
+import com.droidspaces.app.util.ContainerInfo
+import com.droidspaces.app.util.ImageInspectionResult
+import com.droidspaces.app.util.SafPathResolver
 
 @OptIn(ExperimentalMaterial3Api::class, ExperimentalLayoutApi::class)
 @Composable
 fun SparseImageConfigScreen(
-    initialUseSparseImage: Boolean = true,
+    initialMode: ImageSourceMode = ImageSourceMode.NEW_SPARSE_IMAGE,
     initialSizeGB: Int = 8,
-    onNext: (useSparseImage: Boolean, sizeGB: Int) -> Unit,
+    initialExistingImagePath: String? = null,
+    initialInspection: ImageInspectionResult? = null,
+    isInspecting: Boolean = false,
+    useEmbeddedConfig: Boolean = false,
+    onModeChange: (ImageSourceMode) -> Unit = {},
+    onInspectImage: (String) -> Unit = {},
+    onApplyImportedConfig: (Boolean) -> Unit = {},
+    onNext: (mode: ImageSourceMode, sizeGB: Int, existingImagePath: String?) -> Unit,
     onBack: () -> Unit
 ) {
     val context = LocalContext.current
-    var useSparseImage by remember { mutableStateOf(initialUseSparseImage) }
+    var selectedMode by remember { mutableStateOf(initialMode) }
     var sizeGB by remember { mutableStateOf(initialSizeGB.toString()) }
     var sizeError by remember { mutableStateOf<String?>(null) }
+    var existingImagePath by remember { mutableStateOf(initialExistingImagePath ?: "") }
+    var showRootPicker by remember { mutableStateOf(false) }
 
     val fieldShape = RoundedCornerShape(16.dp)
     val fieldColors = DsTextFieldDefaults.colors()
 
-    val isNextEnabled = !useSparseImage || (sizeGB.toIntOrNull()?.let { it in 4..512 } == true)
+    // SAF Document picker for picking .img file from external/system documents
+    val safDocLauncher = rememberLauncherForActivityResult(
+        contract = ActivityResultContracts.OpenDocument()
+    ) { uri: Uri? ->
+        if (uri != null) {
+            SafPathResolver.takePersistablePermission(context, uri)
+            val resolved = SafPathResolver.resolvePathFromUri(context, uri) ?: SafPathResolver.normalizePath(uri.path ?: "")
+            if (resolved.isNotBlank()) {
+                existingImagePath = resolved
+                onInspectImage(resolved)
+            }
+        }
+    }
+
+    if (showRootPicker) {
+        FilePickerDialog(
+            title = stringResource(R.string.browse_existing_image),
+            showFiles = true,
+            onDismiss = { showRootPicker = false },
+            onConfirm = { picked ->
+                existingImagePath = picked
+                showRootPicker = false
+                onInspectImage(picked)
+            }
+        )
+    }
+
+    // Auto-inspect if initial path is provided and inspection is null
+    LaunchedEffect(existingImagePath) {
+        if (existingImagePath.isNotBlank() && initialInspection == null && !isInspecting) {
+            onInspectImage(existingImagePath)
+        }
+    }
+
+    val isNextEnabled = when (selectedMode) {
+        ImageSourceMode.NEW_SPARSE_IMAGE -> sizeGB.toIntOrNull()?.let { it in 4..512 } == true
+        ImageSourceMode.EXISTING_SPARSE_IMAGE -> existingImagePath.isNotBlank() && (initialInspection == null || initialInspection.isValid)
+        ImageSourceMode.DIRECTORY -> true
+    }
 
     Scaffold(
         containerColor = Color.Transparent,
         topBar = {
             TopAppBar(
-                title = { Text(context.getString(R.string.sparse_image_configuration)) },
+                title = { Text(stringResource(R.string.sparse_image_configuration)) },
                 navigationIcon = {
                     IconButton(onClick = onBack) {
-                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = context.getString(R.string.back))
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = stringResource(R.string.back))
                     }
                 }
             )
         },
         bottomBar = {
+            val nextLabel = if (selectedMode == ImageSourceMode.EXISTING_SPARSE_IMAGE) {
+                stringResource(R.string.next_configuration)
+            } else {
+                stringResource(R.string.next_storage)
+            }
             PrimaryActionBottomBar(
-                label = context.getString(R.string.next_configuration),
+                label = nextLabel,
                 icon = Icons.AutoMirrored.Filled.ArrowForward,
                 onClick = {
-                    if (useSparseImage) {
-                        val s = sizeGB.toIntOrNull()
-                        if (s != null && s in 4..512) onNext(true, s)
-                    } else {
-                        onNext(false, 8)
+                    when (selectedMode) {
+                        ImageSourceMode.NEW_SPARSE_IMAGE -> {
+                            val s = sizeGB.toIntOrNull() ?: 8
+                            onNext(ImageSourceMode.NEW_SPARSE_IMAGE, s, null)
+                        }
+                        ImageSourceMode.EXISTING_SPARSE_IMAGE -> {
+                            val s = initialInspection?.sizeGB ?: 8
+                            onNext(ImageSourceMode.EXISTING_SPARSE_IMAGE, s, existingImagePath)
+                        }
+                        ImageSourceMode.DIRECTORY -> {
+                            onNext(ImageSourceMode.DIRECTORY, 8, null)
+                        }
                     }
                 },
                 enabled = isNextEnabled
@@ -83,180 +151,456 @@ fun SparseImageConfigScreen(
                 .consumeWindowInsets(innerPadding)
                 .imePadding()
                 .padding(horizontal = 24.dp)
-                .padding(top = 24.dp)
+                .padding(top = 16.dp)
                 .verticalScroll(rememberScrollState()),
-            verticalArrangement = Arrangement.spacedBy(20.dp)
+            verticalArrangement = Arrangement.spacedBy(16.dp)
         ) {
             Text(
-                text = context.getString(R.string.storage_configuration),
+                text = stringResource(R.string.storage_configuration),
                 style = MaterialTheme.typography.headlineSmall,
                 fontWeight = FontWeight.Bold
             )
 
-            // Info card
-            Surface(
-                modifier = Modifier.fillMaxWidth(),
-                shape = RoundedCornerShape(20.dp),
-                color = MaterialTheme.colorScheme.primary.copy(alpha = 0.06f),
-                border = BorderStroke(1.dp, MaterialTheme.colorScheme.primary.copy(alpha = 0.2f)),
-                tonalElevation = 0.dp
-            ) {
-                Column(
-                    modifier = Modifier.padding(20.dp),
-                    verticalArrangement = Arrangement.spacedBy(12.dp)
-                ) {
-                    Row(
-                        verticalAlignment = Alignment.CenterVertically,
-                        horizontalArrangement = Arrangement.spacedBy(12.dp)
-                    ) {
-                        Icon(
-                            imageVector = Icons.Default.Info,
-                            contentDescription = null,
-                            modifier = Modifier.size(22.dp),
-                            tint = MaterialTheme.colorScheme.primary
-                        )
-                        Text(
-                            text = context.getString(R.string.about_sparse_images),
-                            style = MaterialTheme.typography.titleMedium,
-                            fontWeight = FontWeight.SemiBold,
-                            color = MaterialTheme.colorScheme.primary
-                        )
-                    }
-                    Text(
-                        text = context.getString(R.string.sparse_images_recommended),
-                        style = MaterialTheme.typography.bodyMedium,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant
-                    )
-                    Text(
-                        text = context.getString(R.string.sparse_images_description),
-                        style = MaterialTheme.typography.bodySmall,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.8f)
-                    )
+            // Mode Selector Cards
+            StorageModeOptionCard(
+                title = stringResource(R.string.storage_mode_new_image),
+                description = stringResource(R.string.storage_mode_new_image_desc),
+                icon = Icons.Default.AddCircleOutline,
+                isSelected = selectedMode == ImageSourceMode.NEW_SPARSE_IMAGE,
+                onClick = {
+                    selectedMode = ImageSourceMode.NEW_SPARSE_IMAGE
+                    onModeChange(ImageSourceMode.NEW_SPARSE_IMAGE)
                 }
-            }
+            )
 
-            // Toggle
-            Surface(
-                modifier = Modifier.fillMaxWidth(),
-                onClick = { useSparseImage = !useSparseImage },
-                shape = RoundedCornerShape(20.dp),
-                color = MaterialTheme.colorScheme.surfaceContainerHigh,
-                border = BorderStroke(1.dp, MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.5f)),
-                tonalElevation = 0.dp
-            ) {
-                Row(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(20.dp),
-                    horizontalArrangement = Arrangement.SpaceBetween,
-                    verticalAlignment = Alignment.CenterVertically
-                ) {
-                    Row(
-                        verticalAlignment = Alignment.CenterVertically,
-                        horizontalArrangement = Arrangement.spacedBy(16.dp),
-                        modifier = Modifier.weight(1f)
+            StorageModeOptionCard(
+                title = stringResource(R.string.storage_mode_existing_image),
+                description = stringResource(R.string.storage_mode_existing_image_desc),
+                icon = Icons.Default.SdCard,
+                isSelected = selectedMode == ImageSourceMode.EXISTING_SPARSE_IMAGE,
+                onClick = {
+                    selectedMode = ImageSourceMode.EXISTING_SPARSE_IMAGE
+                    onModeChange(ImageSourceMode.EXISTING_SPARSE_IMAGE)
+                }
+            )
+
+            StorageModeOptionCard(
+                title = stringResource(R.string.storage_mode_directory),
+                description = stringResource(R.string.storage_mode_directory_desc),
+                icon = Icons.Default.Folder,
+                isSelected = selectedMode == ImageSourceMode.DIRECTORY,
+                onClick = {
+                    selectedMode = ImageSourceMode.DIRECTORY
+                    onModeChange(ImageSourceMode.DIRECTORY)
+                }
+            )
+
+            // Configuration section based on mode
+            when (selectedMode) {
+                ImageSourceMode.NEW_SPARSE_IMAGE -> {
+                    Surface(
+                        modifier = Modifier.fillMaxWidth(),
+                        shape = RoundedCornerShape(20.dp),
+                        color = MaterialTheme.colorScheme.surfaceContainerHigh,
+                        border = BorderStroke(1.dp, MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.5f)),
+                        tonalElevation = 0.dp
                     ) {
-                        Icon(
-                            imageVector = Icons.Default.Storage,
-                            contentDescription = null,
-                            modifier = Modifier.size(24.dp),
-                            tint = MaterialTheme.colorScheme.primary
-                        )
                         Column(
-                            modifier = Modifier.weight(1f),
-                            verticalArrangement = Arrangement.spacedBy(4.dp)
+                            modifier = Modifier.fillMaxWidth().padding(20.dp),
+                            verticalArrangement = Arrangement.spacedBy(12.dp)
                         ) {
-                            Text(
-                                text = context.getString(R.string.use_sparse_image),
-                                style = MaterialTheme.typography.titleMedium,
-                                fontWeight = FontWeight.SemiBold
-                            )
-                            Text(
-                                text = context.getString(R.string.use_sparse_image_description),
-                                style = MaterialTheme.typography.bodySmall,
-                                color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.7f)
-                            )
-                        }
-                    }
-                    Switch(
-                        checked = useSparseImage,
-                        onCheckedChange = { useSparseImage = it },
-                        colors = SwitchDefaults.colors(
-                            checkedThumbColor = MaterialTheme.colorScheme.onPrimary,
-                            checkedTrackColor = MaterialTheme.colorScheme.primary,
-                            uncheckedThumbColor = MaterialTheme.colorScheme.outline.copy(alpha = 0.8f),
-                            uncheckedTrackColor = MaterialTheme.colorScheme.surfaceVariant,
-                            uncheckedBorderColor = MaterialTheme.colorScheme.outline.copy(alpha = 0.2f)
-                        )
-                    )
-                }
-            }
-
-            // Size input
-            if (useSparseImage) {
-                Surface(
-                    modifier = Modifier.fillMaxWidth(),
-                    shape = RoundedCornerShape(20.dp),
-                    color = MaterialTheme.colorScheme.surfaceContainerHigh,
-                    border = BorderStroke(1.dp, MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.5f)),
-                    tonalElevation = 0.dp
-                ) {
-                    Column(
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .padding(20.dp),
-                        verticalArrangement = Arrangement.spacedBy(12.dp)
-                    ) {
-                        Row(
-                            verticalAlignment = Alignment.CenterVertically,
-                            horizontalArrangement = Arrangement.spacedBy(12.dp)
-                        ) {
-                            Icon(
-                                imageVector = Icons.Default.Settings,
-                                contentDescription = null,
-                                modifier = Modifier.size(22.dp),
-                                tint = MaterialTheme.colorScheme.primary
-                            )
-                            Text(
-                                text = context.getString(R.string.image_size),
-                                style = MaterialTheme.typography.titleMedium,
-                                fontWeight = FontWeight.SemiBold
-                            )
-                        }
-
-                        OutlinedTextField(
-                            value = sizeGB,
-                            onValueChange = { newValue ->
-                                sizeGB = newValue
-                                val sizeInt = newValue.toIntOrNull()
-                                sizeError = when {
-                                    newValue.isEmpty() -> context.getString(R.string.size_required)
-                                    sizeInt == null -> context.getString(R.string.invalid_number)
-                                    sizeInt < 4 -> context.getString(R.string.minimum_size_4gb)
-                                    sizeInt > 512 -> context.getString(R.string.maximum_size_512gb)
-                                    else -> null
-                                }
-                            },
-                            label = { Text(context.getString(R.string.size_gb)) },
-                            placeholder = { Text(context.getString(R.string.default_size_gb_hint)) },
-                            isError = sizeError != null,
-                            supportingText = sizeError?.let { { Text(it) } } ?: {
-                                Text(context.getString(R.string.enter_size_between_4_512_gb))
-                            },
-                            modifier = Modifier.fillMaxWidth(),
-                            singleLine = true,
-                            shape = fieldShape,
-                            colors = fieldColors,
-                            keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
-                            leadingIcon = {
-                                Icon(Icons.Default.Settings, contentDescription = null)
+                            Row(
+                                verticalAlignment = Alignment.CenterVertically,
+                                horizontalArrangement = Arrangement.spacedBy(12.dp)
+                            ) {
+                                Icon(
+                                    imageVector = Icons.Default.Settings,
+                                    contentDescription = null,
+                                    modifier = Modifier.size(22.dp),
+                                    tint = MaterialTheme.colorScheme.primary
+                                )
+                                Text(
+                                    text = stringResource(R.string.image_size),
+                                    style = MaterialTheme.typography.titleMedium,
+                                    fontWeight = FontWeight.SemiBold
+                                )
                             }
-                        )
+
+                            OutlinedTextField(
+                                value = sizeGB,
+                                onValueChange = { newValue ->
+                                    sizeGB = newValue
+                                    val sizeInt = newValue.toIntOrNull()
+                                    sizeError = when {
+                                        newValue.isEmpty() -> context.getString(R.string.size_required)
+                                        sizeInt == null -> context.getString(R.string.invalid_number)
+                                        sizeInt < 4 -> context.getString(R.string.minimum_size_4gb)
+                                        sizeInt > 512 -> context.getString(R.string.maximum_size_512gb)
+                                        else -> null
+                                    }
+                                },
+                                label = { Text(stringResource(R.string.size_gb)) },
+                                placeholder = { Text(stringResource(R.string.default_size_gb_hint)) },
+                                isError = sizeError != null,
+                                supportingText = sizeError?.let { { Text(it) } } ?: {
+                                    Text(stringResource(R.string.enter_size_between_4_512_gb))
+                                },
+                                modifier = Modifier.fillMaxWidth(),
+                                singleLine = true,
+                                shape = fieldShape,
+                                colors = fieldColors,
+                                keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
+                                leadingIcon = {
+                                    Icon(Icons.Default.Settings, contentDescription = null)
+                                }
+                            )
+                        }
+                    }
+                }
+
+                ImageSourceMode.EXISTING_SPARSE_IMAGE -> {
+                    Surface(
+                        modifier = Modifier.fillMaxWidth(),
+                        shape = RoundedCornerShape(20.dp),
+                        color = MaterialTheme.colorScheme.surfaceContainerHigh,
+                        border = BorderStroke(1.dp, MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.5f)),
+                        tonalElevation = 0.dp
+                    ) {
+                        Column(
+                            modifier = Modifier.fillMaxWidth().padding(20.dp),
+                            verticalArrangement = Arrangement.spacedBy(14.dp)
+                        ) {
+                            Text(
+                                text = stringResource(R.string.existing_image_path),
+                                style = MaterialTheme.typography.titleMedium,
+                                fontWeight = FontWeight.SemiBold
+                            )
+
+                            // Browser Buttons
+                            Row(
+                                modifier = Modifier.fillMaxWidth(),
+                                horizontalArrangement = Arrangement.spacedBy(8.dp)
+                            ) {
+                                FilterChip(
+                                    selected = false,
+                                    onClick = { showRootPicker = true },
+                                    label = { Text("Root Explorer") },
+                                    leadingIcon = {
+                                        Icon(Icons.Default.FolderOpen, contentDescription = null, modifier = Modifier.size(18.dp))
+                                    },
+                                    modifier = Modifier.weight(1f)
+                                )
+
+                                FilterChip(
+                                    selected = false,
+                                    onClick = {
+                                        safDocLauncher.launch(arrayOf("application/octet-stream", "*/*"))
+                                    },
+                                    label = { Text("SAF (USB/Files)") },
+                                    leadingIcon = {
+                                        Icon(Icons.Default.Usb, contentDescription = null, modifier = Modifier.size(18.dp))
+                                    },
+                                    modifier = Modifier.weight(1f)
+                                )
+                            }
+
+                            // Path Input Field
+                            OutlinedTextField(
+                                value = existingImagePath,
+                                onValueChange = { newValue ->
+                                    val normalized = SafPathResolver.normalizePath(newValue)
+                                    existingImagePath = normalized
+                                    if (normalized.endsWith(".img") && normalized.startsWith("/")) {
+                                        onInspectImage(normalized)
+                                    }
+                                },
+                                label = { Text(stringResource(R.string.existing_image_path)) },
+                                placeholder = { Text(stringResource(R.string.existing_image_path_hint)) },
+                                modifier = Modifier.fillMaxWidth(),
+                                singleLine = true,
+                                shape = fieldShape,
+                                colors = fieldColors,
+                                leadingIcon = {
+                                    Icon(Icons.Default.Storage, contentDescription = null)
+                                },
+                                trailingIcon = {
+                                    if (existingImagePath.isNotBlank()) {
+                                        IconButton(onClick = { onInspectImage(existingImagePath) }) {
+                                            Icon(Icons.Default.Refresh, contentDescription = stringResource(R.string.refresh))
+                                        }
+                                    }
+                                }
+                            )
+
+                            // Inspection status & details
+                            if (isInspecting) {
+                                Row(
+                                    modifier = Modifier.fillMaxWidth().padding(vertical = 8.dp),
+                                    verticalAlignment = Alignment.CenterVertically,
+                                    horizontalArrangement = Arrangement.spacedBy(12.dp)
+                                ) {
+                                    LoadingIndicator(size = LoadingSize.Small)
+                                    Text(
+                                        text = stringResource(R.string.inspecting_image),
+                                        style = MaterialTheme.typography.bodyMedium,
+                                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                                    )
+                                }
+                            } else if (initialInspection != null) {
+                                val inspection = initialInspection
+                                if (inspection.isValid) {
+                                    // Valid Image Card
+                                    Surface(
+                                        shape = RoundedCornerShape(14.dp),
+                                        color = MaterialTheme.colorScheme.primary.copy(alpha = 0.08f),
+                                        border = BorderStroke(1.dp, MaterialTheme.colorScheme.primary.copy(alpha = 0.3f)),
+                                        modifier = Modifier.fillMaxWidth()
+                                    ) {
+                                        Column(
+                                            modifier = Modifier.padding(14.dp),
+                                            verticalArrangement = Arrangement.spacedBy(6.dp)
+                                        ) {
+                                            Row(
+                                                verticalAlignment = Alignment.CenterVertically,
+                                                horizontalArrangement = Arrangement.spacedBy(8.dp)
+                                            ) {
+                                                Icon(
+                                                    imageVector = Icons.Default.CheckCircle,
+                                                    contentDescription = null,
+                                                    tint = MaterialTheme.colorScheme.primary,
+                                                    modifier = Modifier.size(20.dp)
+                                                )
+                                                Text(
+                                                    text = stringResource(R.string.valid_ext4_image),
+                                                    style = MaterialTheme.typography.titleSmall,
+                                                    fontWeight = FontWeight.Bold,
+                                                    color = MaterialTheme.colorScheme.primary
+                                                )
+                                            }
+
+                                            Text(
+                                                text = stringResource(R.string.image_size_info, inspection.sizeGB, inspection.path.substringAfterLast("/")),
+                                                style = MaterialTheme.typography.bodySmall,
+                                                color = MaterialTheme.colorScheme.onSurfaceVariant
+                                            )
+
+                                            val os = inspection.osName
+                                            if (!os.isNullOrBlank()) {
+                                                Text(
+                                                    text = stringResource(R.string.os_detected, os),
+                                                    style = MaterialTheme.typography.bodySmall,
+                                                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                                                )
+                                            }
+                                        }
+                                    }
+
+                                    // Embedded Config Card
+                                    if (inspection.embeddedConfig != null) {
+                                        val embedded = inspection.embeddedConfig
+                                        Surface(
+                                            shape = RoundedCornerShape(14.dp),
+                                            color = MaterialTheme.colorScheme.secondaryContainer.copy(alpha = 0.6f),
+                                            border = BorderStroke(1.dp, MaterialTheme.colorScheme.secondary.copy(alpha = 0.4f)),
+                                            modifier = Modifier.fillMaxWidth()
+                                        ) {
+                                            Column(
+                                                modifier = Modifier.padding(14.dp),
+                                                verticalArrangement = Arrangement.spacedBy(10.dp)
+                                            ) {
+                                                Row(
+                                                    verticalAlignment = Alignment.CenterVertically,
+                                                    horizontalArrangement = Arrangement.spacedBy(8.dp)
+                                                ) {
+                                                    Icon(
+                                                        imageVector = Icons.Default.AutoAwesome,
+                                                        contentDescription = null,
+                                                        tint = MaterialTheme.colorScheme.secondary,
+                                                        modifier = Modifier.size(20.dp)
+                                                    )
+                                                    Text(
+                                                        text = stringResource(R.string.embedded_config_found),
+                                                        style = MaterialTheme.typography.titleSmall,
+                                                        fontWeight = FontWeight.Bold,
+                                                        color = MaterialTheme.colorScheme.onSecondaryContainer
+                                                    )
+                                                }
+
+                                                Text(
+                                                    text = stringResource(R.string.embedded_config_desc),
+                                                    style = MaterialTheme.typography.bodySmall,
+                                                    color = MaterialTheme.colorScheme.onSecondaryContainer.copy(alpha = 0.8f)
+                                                )
+
+                                                // Summary details of embedded config
+                                                Row(
+                                                    modifier = Modifier.fillMaxWidth(),
+                                                    horizontalArrangement = Arrangement.SpaceBetween,
+                                                    verticalAlignment = Alignment.CenterVertically
+                                                ) {
+                                                    Column(verticalArrangement = Arrangement.spacedBy(2.dp)) {
+                                                        Text(
+                                                            text = "Hostname: ${embedded.hostname} · Net: ${embedded.netMode}",
+                                                            style = MaterialTheme.typography.labelMedium,
+                                                            fontWeight = FontWeight.SemiBold
+                                                        )
+                                                        if (embedded.portForwards.isNotEmpty()) {
+                                                            Text(
+                                                                text = "${embedded.portForwards.size} Port Forward(s) configured",
+                                                                style = MaterialTheme.typography.labelSmall,
+                                                                color = MaterialTheme.colorScheme.onSecondaryContainer.copy(alpha = 0.7f)
+                                                            )
+                                                        }
+                                                    }
+
+                                                    Switch(
+                                                        checked = useEmbeddedConfig,
+                                                        onCheckedChange = { onApplyImportedConfig(it) }
+                                                    )
+                                                }
+                                            }
+                                        }
+                                    }
+                                } else {
+                                    // Error Card
+                                    Surface(
+                                        shape = RoundedCornerShape(14.dp),
+                                        color = MaterialTheme.colorScheme.errorContainer.copy(alpha = 0.4f),
+                                        border = BorderStroke(1.dp, MaterialTheme.colorScheme.error.copy(alpha = 0.3f)),
+                                        modifier = Modifier.fillMaxWidth()
+                                    ) {
+                                        Row(
+                                            modifier = Modifier.padding(14.dp),
+                                            verticalAlignment = Alignment.CenterVertically,
+                                            horizontalArrangement = Arrangement.spacedBy(10.dp)
+                                        ) {
+                                            Icon(
+                                                imageVector = Icons.Default.ErrorOutline,
+                                                contentDescription = null,
+                                                tint = MaterialTheme.colorScheme.error,
+                                                modifier = Modifier.size(22.dp)
+                                            )
+                                            Text(
+                                                text = inspection.errorMessage ?: stringResource(R.string.invalid_existing_image),
+                                                style = MaterialTheme.typography.bodySmall,
+                                                color = MaterialTheme.colorScheme.onErrorContainer
+                                            )
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+
+                ImageSourceMode.DIRECTORY -> {
+                    Surface(
+                        modifier = Modifier.fillMaxWidth(),
+                        shape = RoundedCornerShape(20.dp),
+                        color = MaterialTheme.colorScheme.primary.copy(alpha = 0.06f),
+                        border = BorderStroke(1.dp, MaterialTheme.colorScheme.primary.copy(alpha = 0.2f)),
+                        tonalElevation = 0.dp
+                    ) {
+                        Column(
+                            modifier = Modifier.padding(20.dp),
+                            verticalArrangement = Arrangement.spacedBy(10.dp)
+                        ) {
+                            Row(
+                                verticalAlignment = Alignment.CenterVertically,
+                                horizontalArrangement = Arrangement.spacedBy(10.dp)
+                            ) {
+                                Icon(
+                                    imageVector = Icons.Default.Info,
+                                    contentDescription = null,
+                                    tint = MaterialTheme.colorScheme.primary,
+                                    modifier = Modifier.size(22.dp)
+                                )
+                                Text(
+                                    text = stringResource(R.string.storage_mode_directory),
+                                    style = MaterialTheme.typography.titleMedium,
+                                    fontWeight = FontWeight.SemiBold,
+                                    color = MaterialTheme.colorScheme.primary
+                                )
+                            }
+                            Text(
+                                text = "Directory mode unpacks the container root filesystem directly into a folder. Note: This requires a POSIX-compliant filesystem (ext4/f2fs). For USB drives formatted as FAT32/exFAT, use a Sparse Image instead.",
+                                style = MaterialTheme.typography.bodySmall,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant
+                            )
+                        }
                     }
                 }
             }
 
-            Spacer(modifier = Modifier.height(8.dp))
+            Spacer(modifier = Modifier.height(16.dp))
+        }
+    }
+}
+
+@Composable
+private fun StorageModeOptionCard(
+    title: String,
+    description: String,
+    icon: androidx.compose.ui.graphics.vector.ImageVector,
+    isSelected: Boolean,
+    onClick: () -> Unit
+) {
+    Surface(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable(onClick = onClick),
+        shape = RoundedCornerShape(20.dp),
+        color = if (isSelected) MaterialTheme.colorScheme.primary.copy(alpha = 0.12f) else MaterialTheme.colorScheme.surfaceContainerHigh,
+        border = BorderStroke(
+            if (isSelected) 2.dp else 1.dp,
+            if (isSelected) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.5f)
+        ),
+        tonalElevation = 0.dp
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(18.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(16.dp)
+        ) {
+            Surface(
+                shape = RoundedCornerShape(12.dp),
+                color = if (isSelected) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.onSurface.copy(alpha = 0.08f),
+                tonalElevation = 0.dp
+            ) {
+                Icon(
+                    imageVector = icon,
+                    contentDescription = null,
+                    modifier = Modifier.padding(10.dp).size(22.dp),
+                    tint = if (isSelected) MaterialTheme.colorScheme.onPrimary else MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            }
+
+            Column(
+                modifier = Modifier.weight(1f),
+                verticalArrangement = Arrangement.spacedBy(4.dp)
+            ) {
+                Text(
+                    text = title,
+                    style = MaterialTheme.typography.titleMedium,
+                    fontWeight = FontWeight.Bold,
+                    color = if (isSelected) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.onSurface
+                )
+                Text(
+                    text = description,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.8f)
+                )
+            }
+
+            RadioButton(
+                selected = isSelected,
+                onClick = onClick,
+                colors = RadioButtonDefaults.colors(
+                    selectedColor = MaterialTheme.colorScheme.primary
+                )
+            )
         }
     }
 }

--- a/Android/app/src/main/java/com/droidspaces/app/ui/screen/StorageLocationScreen.kt
+++ b/Android/app/src/main/java/com/droidspaces/app/ui/screen/StorageLocationScreen.kt
@@ -1,0 +1,641 @@
+package com.droidspaces.app.ui.screen
+
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.automirrored.filled.ArrowForward
+import androidx.compose.material.icons.filled.*
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Dialog
+import androidx.compose.ui.window.DialogProperties
+import com.droidspaces.app.R
+import com.droidspaces.app.ui.component.DsTextFieldDefaults
+import com.droidspaces.app.ui.component.PrimaryActionBottomBar
+import com.droidspaces.app.ui.component.StorageDestinationPicker
+import com.droidspaces.app.ui.util.LoadingIndicator
+import com.droidspaces.app.ui.util.LoadingSize
+import com.droidspaces.app.util.FilesystemCapabilityReport
+import com.droidspaces.app.util.StorageChecker
+import kotlinx.coroutines.launch
+
+/**
+ * Lets the user choose where a new container's rootfs (or rootfs.img) is stored:
+ * the default internal location, or a custom path such as an SD card / USB-OTG mount point.
+ *
+ * For external storage:
+ * - Sparse image mode is forced by default because FAT32/exFAT/NTFS drives do not
+ *   support Linux POSIX permissions, ownership, or symbolic links.
+ * - Comprehensive filesystem checks are performed for directory mode, with a
+ *   "DANGEROUS TERRITORY" bypass mechanism for advanced users.
+ */
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalLayoutApi::class)
+@Composable
+fun StorageLocationScreen(
+    initialPath: String?,
+    useSparseImage: Boolean,
+    onSwitchToSparseImage: () -> Unit = {},
+    onNext: (path: String?) -> Unit,
+    onBack: () -> Unit
+) {
+    val context = LocalContext.current
+    var useCustomLocation by remember { mutableStateOf(!initialPath.isNullOrBlank()) }
+    var customPath by remember { mutableStateOf(initialPath ?: "") }
+    var detectedVolumes by remember { mutableStateOf<List<String>>(emptyList()) }
+    var sharedStoragePath by remember { mutableStateOf<String?>(null) }
+    var isDetecting by remember { mutableStateOf(false) }
+
+    // Filesystem capability check state
+    var fsReport by remember { mutableStateOf<FilesystemCapabilityReport?>(null) }
+    var isCheckingFs by remember { mutableStateOf(false) }
+    var isBypassed by remember { mutableStateOf(false) }
+    var showDangerousDialog by remember { mutableStateOf(false) }
+    var bypassInputText by remember { mutableStateOf("") }
+
+    val scope = rememberCoroutineScope()
+
+    val trimmedCustomPath = StorageChecker.normalizeStorageDir(customPath.trim())
+    val isCustomPathValid = trimmedCustomPath.startsWith("/")
+
+    fun detectVolumes() {
+        isDetecting = true
+        scope.launch {
+            detectedVolumes = StorageChecker.listStorageVolumes()
+            sharedStoragePath = StorageChecker.getSharedStoragePath()
+            isDetecting = false
+        }
+    }
+
+    fun checkFsCapabilities(path: String) {
+        if (path.isNotBlank() && path.startsWith("/")) {
+            isCheckingFs = true
+            scope.launch {
+                fsReport = StorageChecker.inspectFilesystemCapabilities(path, context)
+                isCheckingFs = false
+            }
+        } else {
+            fsReport = null
+        }
+    }
+
+    LaunchedEffect(Unit) {
+        detectVolumes()
+        if (useCustomLocation && trimmedCustomPath.isNotBlank() && !useSparseImage) {
+            checkFsCapabilities(trimmedCustomPath)
+        }
+    }
+
+    LaunchedEffect(trimmedCustomPath, useSparseImage, useCustomLocation) {
+        if (useCustomLocation && !useSparseImage && trimmedCustomPath.startsWith("/")) {
+            isBypassed = false
+            checkFsCapabilities(trimmedCustomPath)
+        }
+    }
+
+    // Determine if next is allowed
+    val isNextEnabled = when {
+        !useCustomLocation -> true
+        !isCustomPathValid -> false
+        useSparseImage -> true
+        isBypassed -> true
+        fsReport?.isFullyCompatibleWithDirectoryMode == true -> true
+        else -> false
+    }
+
+    // Dangerous Territory Confirmation Dialog
+    if (showDangerousDialog) {
+        val requiredPhrase = stringResource(R.string.i_understand_caps)
+        val isConfirmed = bypassInputText.trim() == requiredPhrase
+
+        Dialog(
+            onDismissRequest = { showDangerousDialog = false },
+            properties = DialogProperties(usePlatformDefaultWidth = false)
+        ) {
+            Surface(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 20.dp)
+                    .imePadding(),
+                shape = RoundedCornerShape(24.dp),
+                color = MaterialTheme.colorScheme.surfaceContainerHighest,
+                border = BorderStroke(1.5.dp, MaterialTheme.colorScheme.error),
+                tonalElevation = 0.dp
+            ) {
+                Column(
+                    modifier = Modifier
+                        .padding(24.dp)
+                        .verticalScroll(rememberScrollState()),
+                    verticalArrangement = Arrangement.spacedBy(16.dp)
+                ) {
+                    Row(
+                        verticalAlignment = Alignment.CenterVertically,
+                        horizontalArrangement = Arrangement.spacedBy(12.dp)
+                    ) {
+                        Icon(
+                            imageVector = Icons.Default.Warning,
+                            contentDescription = null,
+                            tint = MaterialTheme.colorScheme.error,
+                            modifier = Modifier.size(28.dp)
+                        )
+                        Text(
+                            text = stringResource(R.string.fs_compat_bypass_dialog_title),
+                            style = MaterialTheme.typography.titleLarge,
+                            fontWeight = FontWeight.ExtraBold,
+                            color = MaterialTheme.colorScheme.error
+                        )
+                    }
+
+                    Text(
+                        text = stringResource(
+                            R.string.fs_compat_dangerous_desc,
+                            fsReport?.fsType ?: "non-native"
+                        ),
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onSurface
+                    )
+
+                    Surface(
+                        shape = RoundedCornerShape(12.dp),
+                        color = MaterialTheme.colorScheme.errorContainer.copy(alpha = 0.4f),
+                        border = BorderStroke(1.dp, MaterialTheme.colorScheme.error.copy(alpha = 0.3f)),
+                        modifier = Modifier.fillMaxWidth()
+                    ) {
+                        Text(
+                            text = stringResource(R.string.privileged_disclaimer),
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onErrorContainer,
+                            modifier = Modifier.padding(12.dp)
+                        )
+                    }
+
+                    Text(
+                        text = stringResource(R.string.privileged_confirm_instruction),
+                        style = MaterialTheme.typography.labelMedium,
+                        fontWeight = FontWeight.SemiBold
+                    )
+
+                    OutlinedTextField(
+                        value = bypassInputText,
+                        onValueChange = { bypassInputText = it },
+                        placeholder = { Text(requiredPhrase) },
+                        singleLine = true,
+                        modifier = Modifier.fillMaxWidth(),
+                        shape = RoundedCornerShape(14.dp),
+                        colors = DsTextFieldDefaults.colors()
+                    )
+
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        horizontalArrangement = Arrangement.spacedBy(12.dp)
+                    ) {
+                        OutlinedButton(
+                            onClick = { showDangerousDialog = false },
+                            modifier = Modifier.weight(1f),
+                            shape = RoundedCornerShape(14.dp)
+                        ) {
+                            Text(stringResource(R.string.cancel))
+                        }
+
+                        Button(
+                            onClick = {
+                                isBypassed = true
+                                showDangerousDialog = false
+                            },
+                            enabled = isConfirmed,
+                            colors = ButtonDefaults.buttonColors(
+                                containerColor = MaterialTheme.colorScheme.error
+                            ),
+                            modifier = Modifier.weight(1f),
+                            shape = RoundedCornerShape(14.dp)
+                        ) {
+                            Text("Bypass")
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    Scaffold(
+        containerColor = Color.Transparent,
+        topBar = {
+            TopAppBar(
+                title = { Text(stringResource(R.string.storage_configuration)) },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = stringResource(R.string.back))
+                    }
+                }
+            )
+        },
+        bottomBar = {
+            PrimaryActionBottomBar(
+                label = stringResource(R.string.next_configuration),
+                icon = Icons.AutoMirrored.Filled.ArrowForward,
+                onClick = {
+                    onNext(if (useCustomLocation) trimmedCustomPath else null)
+                },
+                enabled = isNextEnabled
+            )
+        }
+    ) { innerPadding ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(innerPadding)
+                .consumeWindowInsets(innerPadding)
+                .imePadding()
+                .padding(horizontal = 24.dp)
+                .padding(top = 16.dp)
+                .verticalScroll(rememberScrollState()),
+            verticalArrangement = Arrangement.spacedBy(16.dp)
+        ) {
+            Text(
+                text = "Where should this container's data live?",
+                style = MaterialTheme.typography.headlineSmall,
+                fontWeight = FontWeight.Bold
+            )
+
+            if (!useSparseImage) {
+                Surface(
+                    modifier = Modifier.fillMaxWidth(),
+                    shape = RoundedCornerShape(20.dp),
+                    color = MaterialTheme.colorScheme.errorContainer.copy(alpha = 0.4f),
+                    border = BorderStroke(1.dp, MaterialTheme.colorScheme.error.copy(alpha = 0.3f))
+                ) {
+                    Row(
+                        modifier = Modifier.padding(16.dp),
+                        horizontalArrangement = Arrangement.spacedBy(12.dp)
+                    ) {
+                        Icon(
+                            imageVector = Icons.Default.Warning,
+                            contentDescription = null,
+                            tint = MaterialTheme.colorScheme.error,
+                            modifier = Modifier.size(22.dp)
+                        )
+                        Text(
+                            text = "Directory rootfs mode needs a Linux-native filesystem (ext4/f2fs). " +
+                                "Most SD cards and USB drives are FAT32/exFAT, which will break the container. " +
+                                "Go back and enable Sparse Image mode if you're using external/USB storage.",
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant
+                        )
+                    }
+                }
+            }
+
+            // Internal (default) option
+            Surface(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .clickable { useCustomLocation = false },
+                shape = RoundedCornerShape(20.dp),
+                color = if (!useCustomLocation) MaterialTheme.colorScheme.primary.copy(alpha = 0.08f)
+                else MaterialTheme.colorScheme.surfaceContainerHigh,
+                border = BorderStroke(
+                    1.dp,
+                    if (!useCustomLocation) MaterialTheme.colorScheme.primary.copy(alpha = 0.4f)
+                    else MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.5f)
+                ),
+                tonalElevation = 0.dp
+            ) {
+                Row(
+                    modifier = Modifier.fillMaxWidth().padding(20.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(16.dp)
+                ) {
+                    RadioButton(selected = !useCustomLocation, onClick = { useCustomLocation = false })
+                    Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
+                        Text(
+                            text = "Internal storage (recommended)",
+                            style = MaterialTheme.typography.titleMedium,
+                            fontWeight = FontWeight.SemiBold
+                        )
+                        Text(
+                            text = "Data lives in /data/local/Droidspaces on internal flash.",
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.7f)
+                        )
+                    }
+                }
+            }
+
+            // Custom / external option
+            Surface(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .clickable { useCustomLocation = true },
+                shape = RoundedCornerShape(20.dp),
+                color = if (useCustomLocation) MaterialTheme.colorScheme.primary.copy(alpha = 0.08f)
+                else MaterialTheme.colorScheme.surfaceContainerHigh,
+                border = BorderStroke(
+                    1.dp,
+                    if (useCustomLocation) MaterialTheme.colorScheme.primary.copy(alpha = 0.4f)
+                    else MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.5f)
+                ),
+                tonalElevation = 0.dp
+            ) {
+                Column(modifier = Modifier.fillMaxWidth().padding(20.dp)) {
+                    Row(
+                        verticalAlignment = Alignment.CenterVertically,
+                        horizontalArrangement = Arrangement.spacedBy(16.dp)
+                    ) {
+                        RadioButton(selected = useCustomLocation, onClick = { useCustomLocation = true })
+                        Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
+                            Text(
+                                text = "External / USB storage",
+                                style = MaterialTheme.typography.titleMedium,
+                                fontWeight = FontWeight.SemiBold
+                            )
+                            Text(
+                                text = "SD card, USB-OTG drive, or any custom mounted location.",
+                                style = MaterialTheme.typography.bodySmall,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.7f)
+                            )
+                        }
+                    }
+
+                    if (useCustomLocation) {
+                        Spacer(modifier = Modifier.height(16.dp))
+
+                        StorageDestinationPicker(
+                            path = customPath,
+                            onPathChange = {
+                                customPath = it
+                                if (!useSparseImage) {
+                                    checkFsCapabilities(it)
+                                }
+                            },
+                            placeholder = "/storage/1234-5678/Droidspaces",
+                            isError = trimmedCustomPath.isNotEmpty() && !isCustomPathValid,
+                            supportingText = {
+                                if (trimmedCustomPath.isNotEmpty() && !isCustomPathValid) {
+                                    Text("Path must be absolute -- start it with \"/\"")
+                                }
+                            },
+                            colors = DsTextFieldDefaults.colors(),
+                            dialogTitle = "Select Storage Location"
+                        )
+
+                        Spacer(modifier = Modifier.height(12.dp))
+
+                        // Filesystem capability check results for Directory Mode
+                        if (!useSparseImage) {
+                            if (isCheckingFs) {
+                                Row(
+                                    modifier = Modifier.fillMaxWidth().padding(vertical = 8.dp),
+                                    verticalAlignment = Alignment.CenterVertically,
+                                    horizontalArrangement = Arrangement.spacedBy(10.dp)
+                                ) {
+                                    LoadingIndicator(size = LoadingSize.Small)
+                                    Text(
+                                        text = stringResource(R.string.fs_compat_checking),
+                                        style = MaterialTheme.typography.bodySmall,
+                                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                                    )
+                                }
+                            } else if (fsReport != null) {
+                                val report = fsReport!!
+                                if (report.isFullyCompatibleWithDirectoryMode) {
+                                    Surface(
+                                        shape = RoundedCornerShape(14.dp),
+                                        color = MaterialTheme.colorScheme.primary.copy(alpha = 0.08f),
+                                        border = BorderStroke(1.dp, MaterialTheme.colorScheme.primary.copy(alpha = 0.3f)),
+                                        modifier = Modifier.fillMaxWidth()
+                                    ) {
+                                        Row(
+                                            modifier = Modifier.padding(14.dp),
+                                            verticalAlignment = Alignment.CenterVertically,
+                                            horizontalArrangement = Arrangement.spacedBy(10.dp)
+                                        ) {
+                                            Icon(
+                                                imageVector = Icons.Default.CheckCircle,
+                                                contentDescription = null,
+                                                tint = MaterialTheme.colorScheme.primary,
+                                                modifier = Modifier.size(20.dp)
+                                            )
+                                            Column {
+                                                Text(
+                                                    text = stringResource(R.string.fs_compat_valid_title),
+                                                    style = MaterialTheme.typography.titleSmall,
+                                                    fontWeight = FontWeight.Bold,
+                                                    color = MaterialTheme.colorScheme.primary
+                                                )
+                                                Text(
+                                                    text = "Filesystem '${report.fsType}' supports POSIX permissions and symbolic links.",
+                                                    style = MaterialTheme.typography.bodySmall,
+                                                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                                                )
+                                            }
+                                        }
+                                    }
+                                } else if (isBypassed) {
+                                    Surface(
+                                        shape = RoundedCornerShape(14.dp),
+                                        color = MaterialTheme.colorScheme.errorContainer.copy(alpha = 0.3f),
+                                        border = BorderStroke(1.dp, MaterialTheme.colorScheme.error.copy(alpha = 0.5f)),
+                                        modifier = Modifier.fillMaxWidth()
+                                    ) {
+                                        Row(
+                                            modifier = Modifier.padding(14.dp),
+                                            verticalAlignment = Alignment.CenterVertically,
+                                            horizontalArrangement = Arrangement.spacedBy(10.dp)
+                                        ) {
+                                            Icon(
+                                                imageVector = Icons.Default.Warning,
+                                                contentDescription = null,
+                                                tint = MaterialTheme.colorScheme.error,
+                                                modifier = Modifier.size(20.dp)
+                                            )
+                                            Column {
+                                                Text(
+                                                    text = stringResource(R.string.fs_compat_bypassed_tag),
+                                                    style = MaterialTheme.typography.titleSmall,
+                                                    fontWeight = FontWeight.Bold,
+                                                    color = MaterialTheme.colorScheme.error
+                                                )
+                                                Text(
+                                                    text = "Checks bypassed. Running directory rootfs on non-native '${report.fsType}' filesystem.",
+                                                    style = MaterialTheme.typography.bodySmall,
+                                                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                                                )
+                                            }
+                                        }
+                                    }
+                                } else {
+                                    // Incompatible card
+                                    Surface(
+                                        shape = RoundedCornerShape(14.dp),
+                                        color = MaterialTheme.colorScheme.errorContainer.copy(alpha = 0.4f),
+                                        border = BorderStroke(1.dp, MaterialTheme.colorScheme.error.copy(alpha = 0.4f)),
+                                        modifier = Modifier.fillMaxWidth()
+                                    ) {
+                                        Column(
+                                            modifier = Modifier.padding(14.dp),
+                                            verticalArrangement = Arrangement.spacedBy(10.dp)
+                                        ) {
+                                            Row(
+                                                verticalAlignment = Alignment.CenterVertically,
+                                                horizontalArrangement = Arrangement.spacedBy(10.dp)
+                                            ) {
+                                                Icon(
+                                                    imageVector = Icons.Default.ErrorOutline,
+                                                    contentDescription = null,
+                                                    tint = MaterialTheme.colorScheme.error,
+                                                    modifier = Modifier.size(22.dp)
+                                                )
+                                                Text(
+                                                    text = stringResource(R.string.fs_compat_invalid_title),
+                                                    style = MaterialTheme.typography.titleSmall,
+                                                    fontWeight = FontWeight.Bold,
+                                                    color = MaterialTheme.colorScheme.error
+                                                )
+                                            }
+
+                                            Text(
+                                                text = stringResource(R.string.fs_compat_external_force_sparse_msg),
+                                                style = MaterialTheme.typography.bodySmall,
+                                                color = MaterialTheme.colorScheme.onSurfaceVariant
+                                            )
+
+                                            // Check breakdown
+                                            Column(verticalArrangement = Arrangement.spacedBy(3.dp)) {
+                                                Text(
+                                                    text = "• Filesystem: ${report.fsType} (${if (report.isLinuxNativeFs) "POSIX Native" else "Non-native"})",
+                                                    style = MaterialTheme.typography.bodySmall
+                                                )
+                                                Text(
+                                                    text = "• Permissions (chmod/chown): ${if (report.supportsChmodChown) "Supported" else "Not supported"}",
+                                                    style = MaterialTheme.typography.bodySmall
+                                                )
+                                                Text(
+                                                    text = "• Symbolic links (symlinks): ${if (report.supportsSymlinks) "Supported" else "Not supported"}",
+                                                    style = MaterialTheme.typography.bodySmall
+                                                )
+                                                if (report.isNoExec) {
+                                                    Text(
+                                                        text = "• Mount flag: noexec (Binaries blocked from execution)",
+                                                        style = MaterialTheme.typography.bodySmall,
+                                                        color = MaterialTheme.colorScheme.error
+                                                    )
+                                                }
+                                            }
+
+                                            // Action buttons
+                                            Button(
+                                                onClick = onSwitchToSparseImage,
+                                                modifier = Modifier.fillMaxWidth(),
+                                                shape = RoundedCornerShape(12.dp)
+                                            ) {
+                                                Icon(Icons.Default.Storage, contentDescription = null, modifier = Modifier.size(18.dp))
+                                                Spacer(modifier = Modifier.width(8.dp))
+                                                Text(stringResource(R.string.fs_compat_switch_sparse))
+                                            }
+
+                                            TextButton(
+                                                onClick = {
+                                                    bypassInputText = ""
+                                                    showDangerousDialog = true
+                                                },
+                                                modifier = Modifier.align(Alignment.CenterHorizontally)
+                                            ) {
+                                                Icon(Icons.Default.Warning, contentDescription = null, tint = MaterialTheme.colorScheme.error, modifier = Modifier.size(16.dp))
+                                                Spacer(modifier = Modifier.width(6.dp))
+                                                Text(
+                                                    stringResource(R.string.fs_compat_bypass_button),
+                                                    color = MaterialTheme.colorScheme.error,
+                                                    style = MaterialTheme.typography.labelMedium
+                                                )
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+
+                        Spacer(modifier = Modifier.height(12.dp))
+
+                        Text(
+                            text = "Detected volumes",
+                            style = MaterialTheme.typography.labelLarge,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant
+                        )
+                        Spacer(modifier = Modifier.height(8.dp))
+
+                        if (isDetecting) {
+                            Text(
+                                text = "Scanning /storage ...",
+                                style = MaterialTheme.typography.bodySmall,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.7f)
+                            )
+                        } else if (detectedVolumes.isEmpty() && sharedStoragePath == null) {
+                            Text(
+                                text = "No external volumes detected. You can still type a path manually, " +
+                                        "or switch to SAF above to grant access to a USB drive Root Explorer can't see.",
+                                style = MaterialTheme.typography.bodySmall,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.7f)
+                            )
+                        } else {
+                            FlowRow(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                                sharedStoragePath?.let { shared ->
+                                    AssistChip(
+                                        onClick = {
+                                            customPath = "$shared/Droidspaces"
+                                            if (!useSparseImage) checkFsCapabilities("$shared/Droidspaces")
+                                        },
+                                        label = { Text("This device's storage") },
+                                        leadingIcon = {
+                                            Icon(
+                                                Icons.Default.Smartphone,
+                                                contentDescription = null,
+                                                modifier = Modifier.size(18.dp)
+                                            )
+                                        }
+                                    )
+                                }
+                                detectedVolumes.forEach { volume ->
+                                    AssistChip(
+                                        onClick = {
+                                            customPath = "$volume/Droidspaces"
+                                            if (!useSparseImage) checkFsCapabilities("$volume/Droidspaces")
+                                        },
+                                        label = { Text(volume.substringAfterLast("/")) },
+                                        leadingIcon = {
+                                            Icon(
+                                                Icons.Default.Usb,
+                                                contentDescription = null,
+                                                modifier = Modifier.size(18.dp)
+                                            )
+                                        }
+                                    )
+                                }
+                            }
+                        }
+
+                        Spacer(modifier = Modifier.height(4.dp))
+                        TextButton(onClick = { detectVolumes() }) {
+                            Icon(Icons.Default.Refresh, contentDescription = null, modifier = Modifier.size(18.dp))
+                            Spacer(modifier = Modifier.width(6.dp))
+                            Text("Rescan")
+                        }
+                    }
+                }
+            }
+
+            Spacer(modifier = Modifier.height(8.dp))
+        }
+    }
+}

--- a/Android/app/src/main/java/com/droidspaces/app/ui/viewmodel/ContainerInstallationViewModel.kt
+++ b/Android/app/src/main/java/com/droidspaces/app/ui/viewmodel/ContainerInstallationViewModel.kt
@@ -1,18 +1,32 @@
 package com.droidspaces.app.ui.viewmodel
 
+import android.content.Context
 import android.net.Uri
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.lifecycle.ViewModel
+import com.droidspaces.app.util.ContainerConfigState
 import com.droidspaces.app.util.ContainerInfo
 import com.droidspaces.app.util.ContainerManager
 import com.droidspaces.app.util.ContainerStatus
-import com.droidspaces.app.util.Constants
-
-import com.droidspaces.app.util.ContainerConfigState
+import com.droidspaces.app.util.ExistingImageManager
+import com.droidspaces.app.util.ImageInspectionResult
 import com.droidspaces.app.util.ValidationUtils
+import com.droidspaces.app.util.toConfigState
 import com.droidspaces.app.util.withConfig
+
+/**
+ * Modes for container rootfs storage.
+ */
+enum class ImageSourceMode {
+    /** Create a new sparse ext4 image (rootfs.img) and extract tarball into it. */
+    NEW_SPARSE_IMAGE,
+    /** Use an existing sparse ext4 rootfs image (e.g. from USB-OTG/SD card) directly. */
+    EXISTING_SPARSE_IMAGE,
+    /** Extract tarball directly into a rootfs folder. */
+    DIRECTORY
+}
 
 class ContainerInstallationViewModel : ViewModel() {
     var tarballUri: Uri? by mutableStateOf(null)
@@ -24,10 +38,40 @@ class ContainerInstallationViewModel : ViewModel() {
     var hostname: String by mutableStateOf("")
         private set
 
-    var useSparseImage: Boolean by mutableStateOf(true)
+    var imageSourceMode: ImageSourceMode by mutableStateOf(ImageSourceMode.NEW_SPARSE_IMAGE)
         private set
 
     var sparseImageSizeGB: Int by mutableStateOf(8)
+        private set
+
+    // Existing image portability state
+    var existingImagePath: String? by mutableStateOf(null)
+        private set
+
+    var existingImageInspection: ImageInspectionResult? by mutableStateOf(null)
+        private set
+
+    var isInspectingImage: Boolean by mutableStateOf(false)
+        private set
+
+    var useEmbeddedConfig: Boolean by mutableStateOf(false)
+        private set
+
+    var importedImageConfig: ContainerInfo? by mutableStateOf(null)
+        private set
+
+    val useSparseImage: Boolean
+        get() = imageSourceMode != ImageSourceMode.DIRECTORY
+
+    val isExistingImage: Boolean
+        get() = imageSourceMode == ImageSourceMode.EXISTING_SPARSE_IMAGE
+
+    /**
+     * Custom storage root chosen for this container's rootfs (e.g. an SD card or
+     * USB-OTG mount point such as "/storage/1234-5678"). Null means "use the default
+     * internal location" (CONTAINERS_BASE_PATH).
+     */
+    var customStorageLocation: String? by mutableStateOf(null)
         private set
 
     /** All editable networking/security/advanced config, hoisted as one value. */
@@ -43,9 +87,67 @@ class ContainerInstallationViewModel : ViewModel() {
         this.hostname = hostname
     }
 
+    fun updateImageSourceMode(mode: ImageSourceMode) {
+        this.imageSourceMode = mode
+    }
+
     fun setSparseImageConfig(useSparseImage: Boolean, sizeGB: Int) {
-        this.useSparseImage = useSparseImage
+        this.imageSourceMode = if (useSparseImage) ImageSourceMode.NEW_SPARSE_IMAGE else ImageSourceMode.DIRECTORY
         this.sparseImageSizeGB = sizeGB
+    }
+
+    fun setExistingImage(path: String?, inspection: ImageInspectionResult? = null) {
+        this.existingImagePath = path?.trim()?.takeIf { it.isNotEmpty() }
+        this.existingImageInspection = inspection
+        val embedded = inspection?.embeddedConfig
+        if (embedded != null) {
+            this.importedImageConfig = embedded
+            this.useEmbeddedConfig = true
+            this.configState = embedded.toConfigState()
+            if (hostname.isEmpty() || hostname == ValidationUtils.sanitizeHostname(containerName)) {
+                if (embedded.hostname.isNotEmpty()) {
+                    hostname = embedded.hostname
+                }
+            }
+        }
+    }
+
+    suspend fun inspectImage(context: Context, path: String) {
+        isInspectingImage = true
+        try {
+            val result = ExistingImageManager.inspect(path, context)
+            existingImageInspection = result
+            if (result.embeddedConfig != null) {
+                importedImageConfig = result.embeddedConfig
+                useEmbeddedConfig = true
+                configState = result.embeddedConfig.toConfigState()
+                if (hostname.isEmpty() || hostname == ValidationUtils.sanitizeHostname(containerName)) {
+                    if (result.embeddedConfig.hostname.isNotEmpty()) {
+                        hostname = result.embeddedConfig.hostname
+                    }
+                }
+            }
+        } finally {
+            isInspectingImage = false
+        }
+    }
+
+    fun applyImportedConfig(apply: Boolean) {
+        useEmbeddedConfig = apply
+        val imported = importedImageConfig ?: existingImageInspection?.embeddedConfig
+        if (apply && imported != null) {
+            configState = imported.toConfigState()
+            if (hostname.isEmpty() || hostname == ValidationUtils.sanitizeHostname(containerName)) {
+                if (imported.hostname.isNotEmpty()) {
+                    hostname = imported.hostname
+                }
+            }
+        }
+    }
+
+    /** Pass null to use the default internal storage location. */
+    fun setStorageLocation(path: String?) {
+        this.customStorageLocation = path?.trim()?.takeIf { it.isNotEmpty() }
     }
 
     fun setConfig(config: ContainerConfigState) {
@@ -53,20 +155,22 @@ class ContainerInstallationViewModel : ViewModel() {
     }
 
     fun buildConfig(): ContainerInfo? {
-        if (tarballUri == null) return null
         if (containerName.isEmpty()) return null
+        if (!isExistingImage && tarballUri == null) return null
+
+        val finalRootfsPath = when {
+            isExistingImage -> existingImagePath ?: ContainerManager.getSparseImagePath(containerName, customStorageLocation)
+            useSparseImage -> ContainerManager.getSparseImagePath(containerName, customStorageLocation)
+            else -> ContainerManager.getRootfsPath(containerName, customStorageLocation)
+        }
 
         return ContainerInfo(
             name = containerName,
             hostname = hostname.ifEmpty { ValidationUtils.sanitizeHostname(containerName) },
-            rootfsPath = if (useSparseImage) {
-                ContainerManager.getSparseImagePath(containerName)
-            } else {
-                ContainerManager.getRootfsPath(containerName)
-            },
-            status = ContainerStatus.STOPPED, // Default status for new container
+            rootfsPath = finalRootfsPath,
+            status = ContainerStatus.STOPPED,
             useSparseImage = useSparseImage,
-            sparseImageSizeGB = if (useSparseImage) sparseImageSizeGB else null,
+            sparseImageSizeGB = if (useSparseImage) (existingImageInspection?.sizeGB ?: sparseImageSizeGB) else null,
         ).withConfig(configState)
     }
 
@@ -74,9 +178,14 @@ class ContainerInstallationViewModel : ViewModel() {
         tarballUri = null
         containerName = ""
         hostname = ""
-        useSparseImage = true
+        imageSourceMode = ImageSourceMode.NEW_SPARSE_IMAGE
         sparseImageSizeGB = 8
+        existingImagePath = null
+        existingImageInspection = null
+        isInspectingImage = false
+        useEmbeddedConfig = false
+        importedImageConfig = null
+        customStorageLocation = null
         configState = ContainerConfigState()
     }
 }
-

--- a/Android/app/src/main/java/com/droidspaces/app/ui/viewmodel/ContainerOperationsViewModel.kt
+++ b/Android/app/src/main/java/com/droidspaces/app/ui/viewmodel/ContainerOperationsViewModel.kt
@@ -32,6 +32,12 @@ sealed class UninstallState {
     data class InProgress(val containerName: String, val message: String) : UninstallState()
 }
 
+/** Progress state for the move-storage flow (drives the ProgressDialog). */
+sealed class MoveStorageState {
+    data object Idle : MoveStorageState()
+    data class InProgress(val containerName: String, val message: String) : MoveStorageState()
+}
+
 /** A pending sparse-image operation awaiting a size from the user. */
 sealed class SparseOperation {
     data class Migrate(val container: ContainerInfo) : SparseOperation()
@@ -74,6 +80,15 @@ class ContainerOperationsViewModel(app: Application) : AndroidViewModel(app) {
     var uninstallLogsDialog by mutableStateOf<List<String>?>(null)
 
     fun dismissUninstallLogs() { uninstallLogsDialog = null }
+
+    /** Move-storage progress. */
+    var moveStorageState by mutableStateOf<MoveStorageState>(MoveStorageState.Idle)
+        private set
+
+    /** Non-null when a move-storage attempt failed and its logs should be shown. */
+    var moveStorageLogsDialog by mutableStateOf<List<String>?>(null)
+
+    fun dismissMoveStorageLogs() { moveStorageLogsDialog = null }
 
     /** Get-or-create the streaming log buffer for [name] (matches the previous inline pattern). */
     private fun logsFor(name: String): SnapshotStateList<Pair<Int, String>> {
@@ -139,7 +154,7 @@ class ContainerOperationsViewModel(app: Application) : AndroidViewModel(app) {
             tempArchive = File("${appContext.cacheDir}/${container.name}_export_tmp.tar.gz")
             tempArchive.delete()
 
-            val cmd = "\"${deployed.absolutePath}\" \"${container.name}\" \"${tempArchive.absolutePath}\""
+            val cmd = "sh \"${deployed.absolutePath}\" \"${container.name}\" \"${tempArchive.absolutePath}\""
             val success = ContainerOperationExecutor.executeCommand(
                 command = cmd,
                 operation = "export",
@@ -221,6 +236,61 @@ class ContainerOperationsViewModel(app: Application) : AndroidViewModel(app) {
         }
     }
 
+    // ── Move storage ────────────────────────────────────────────────────────────
+    /**
+     * Relocate a container's rootfs to [newStorageDir] (or back to the default
+     * internal location if null), stopping the container first if it's running,
+     * then rewriting its config to point at the new location.
+     */
+    suspend fun executeMoveStorage(
+        container: ContainerInfo,
+        newStorageDir: String?,
+        onError: (String) -> Unit,
+        onSuccess: (String) -> Unit,
+        onRefresh: () -> Unit,
+    ) {
+        val collectedLogs = mutableListOf<String>()
+        val logger = ViewModelLogger { _, message -> collectedLogs.add(message) }.apply { verbose = true }
+
+        try {
+            val isRunning = ContainerManager.checkContainerStatus(container.name).first
+            if (isRunning) {
+                moveStorageState = MoveStorageState.InProgress(container.name, string(R.string.stopping_container))
+                val stopCommand = ContainerCommandBuilder.buildStopCommand(container)
+                val stopResult = ContainerOperationExecutor.executeCommand(stopCommand, "stop", logger)
+                if (!stopResult) {
+                    moveStorageState = MoveStorageState.Idle
+                    if (collectedLogs.isNotEmpty()) moveStorageLogsDialog = collectedLogs
+                    else onError(string(R.string.failed_to_stop_container, container.name))
+                    onRefresh()
+                    return
+                }
+            }
+
+            moveStorageState = MoveStorageState.InProgress(container.name, "Moving container data...")
+            val result = ContainerManager.moveContainerStorage(appContext, container, newStorageDir, logger)
+            moveStorageState = MoveStorageState.Idle
+
+            if (result.isFailure) {
+                val msg = result.exceptionOrNull()?.message
+                if (!msg.isNullOrBlank()) onError(msg)
+                else if (collectedLogs.isNotEmpty()) moveStorageLogsDialog = collectedLogs
+                else onError("Failed to move ${container.name}'s storage")
+                onRefresh()
+            } else {
+                onSuccess("Moved ${container.name} to ${result.getOrNull()}")
+                onRefresh()
+            }
+        } catch (e: Exception) {
+            moveStorageState = MoveStorageState.Idle
+            collectedLogs.add("Exception: ${e.message}")
+            collectedLogs.add(e.stackTraceToString())
+            if (collectedLogs.isNotEmpty()) moveStorageLogsDialog = collectedLogs
+            else onError("Failed to move ${container.name}'s storage")
+            onRefresh()
+        }
+    }
+
     // ── Start / Stop / Restart ────────────────────────────────────────────────
     suspend fun executeOperation(
         container: ContainerInfo,
@@ -238,20 +308,26 @@ class ContainerOperationsViewModel(app: Application) : AndroidViewModel(app) {
         val logger = ViewModelLogger { level, message -> logs.add(level to message) }.apply { verbose = true }
 
         try {
+            val effectiveContainer = if (operation == "start" || operation == "restart") {
+                ContainerManager.autoDetectAndRemapContainerPath(appContext, container, logger)
+            } else {
+                container
+            }
+
             if (operation == "stop" || operation == "restart") {
                 appContext.startService(
                     Intent(appContext, TerminalSessionService::class.java).apply {
                         action = TerminalSessionService.ACTION_STOP_CONTAINER_SESSIONS
-                        putExtra(TerminalSessionService.EXTRA_CONTAINER_NAME, container.name)
+                        putExtra(TerminalSessionService.EXTRA_CONTAINER_NAME, effectiveContainer.name)
                     }
                 )
-                onClearUsage(container.name)
+                onClearUsage(effectiveContainer.name)
             }
 
             val command = when (operation) {
-                "start" -> ContainerCommandBuilder.buildStartCommand(container)
-                "stop" -> ContainerCommandBuilder.buildStopCommand(container)
-                "restart" -> ContainerCommandBuilder.buildRestartCommand(container)
+                "start" -> ContainerCommandBuilder.buildStartCommand(effectiveContainer)
+                "stop" -> ContainerCommandBuilder.buildStopCommand(effectiveContainer)
+                "restart" -> ContainerCommandBuilder.buildRestartCommand(effectiveContainer)
                 else -> {
                     runningOperationContainer = null
                     return
@@ -333,16 +409,25 @@ class ContainerOperationsViewModel(app: Application) : AndroidViewModel(app) {
             }
             Shell.cmd("chmod 755 \"${deployedFile.absolutePath}\"").exec()
 
-            val baseDir = ContainerManager.getContainerDirectory(container.name)
+            // Derive the container's actual data directory from its known rootfs path
+            // (parent of "rootfs" or "rootfs.img") rather than recomputing the default
+            // internal path -- this stays correct for containers on external storage.
+            val baseDir = container.rootfsPath.substringBeforeLast(
+                "/",
+                ContainerManager.getContainerDirectory(container.name)
+            )
             val cmd = when (operation) {
                 is SparseOperation.Migrate -> {
                     logger.i(string(R.string.starting_migration))
-                    "\"${deployedFile.absolutePath}\" -d \"$baseDir\" migrate $sizeGb"
+                    "sh \"${deployedFile.absolutePath}\" -d \"$baseDir\" migrate $sizeGb"
                 }
                 is SparseOperation.Resize -> {
                     logger.i(string(R.string.starting_resizing))
-                    val imgPath = ContainerManager.getSparseImagePath(container.name)
-                    "\"${deployedFile.absolutePath}\" -i \"$imgPath\" resize $sizeGb --yes"
+                    // Use the container's actual, already-known rootfs.img location
+                    // (which may live on external/custom storage) instead of
+                    // recomputing the default internal path.
+                    val imgPath = container.rootfsPath
+                    "sh \"${deployedFile.absolutePath}\" -i \"$imgPath\" resize $sizeGb --yes"
                 }
             }
 

--- a/Android/app/src/main/java/com/droidspaces/app/util/Constants.kt
+++ b/Android/app/src/main/java/com/droidspaces/app/util/Constants.kt
@@ -22,6 +22,7 @@ object Constants {
     const val DAEMON_MODE_FILE = "/data/local/Droidspaces/.daemon_mode"
     const val DAEMON_PID_FILE = "/data/local/Droidspaces/droidspacesd.pid"
     const val CONTAINER_CONFIG_FILE = "container.config"
+    const val EMBEDDED_CONFIG_RELATIVE_PATH = "etc/droidspaces.config"
     // Default network mode — the single source of truth for both the ContainerInfo
     // model default and the config parser default (they used to disagree).
     const val DEFAULT_NET_MODE = "nat"

--- a/Android/app/src/main/java/com/droidspaces/app/util/ContainerInstaller.kt
+++ b/Android/app/src/main/java/com/droidspaces/app/util/ContainerInstaller.kt
@@ -3,15 +3,12 @@ package com.droidspaces.app.util
 import android.content.Context
 import android.net.Uri
 import com.topjohnwu.superuser.Shell
-import com.topjohnwu.superuser.io.SuFile
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import java.io.File
 import java.io.FileOutputStream
-import java.io.InputStream
 
 object ContainerInstaller {
-    private const val CONTAINERS_BASE_PATH = Constants.CONTAINERS_BASE_PATH
     private const val BUSYBOX_PATH = Constants.BUSYBOX_BINARY_PATH
 
     /**
@@ -28,13 +25,16 @@ object ContainerInstaller {
         // Use sanitized name for directory (spaces -> dashes)
         val sanitizedName = ContainerManager.sanitizeContainerName(config.name)
         val containerPath = ContainerManager.getContainerDirectory(config.name)
-        val rootfsPath = if (config.useSparseImage) {
-            ContainerManager.getSparseImagePath(config.name)
-        } else {
-            ContainerManager.getRootfsPath(config.name)
-        }
+        // Use whatever rootfs location the caller already resolved (internal default,
+        // or a custom/external storage path picked in the wizard) instead of
+        // recomputing it -- config.rootfsPath is the single source of truth.
+        val rootfsPath = config.rootfsPath
+        // Parent directory of the rootfs/rootfs.img -- normally == containerPath, but
+        // differs when a custom external storage location was chosen.
+        val rootfsParentDir = rootfsPath.substringBeforeLast("/", containerPath)
+        val isExternalStorage = rootfsParentDir != containerPath
         val configFilePath = "$containerPath/${Constants.CONTAINER_CONFIG_FILE}"
-        var createdPaths = mutableListOf<String>()
+        val createdPaths = mutableListOf<String>()
 
         try {
             // Reject control chars in single-line config values (VULN V11).
@@ -43,11 +43,41 @@ object ContainerInstaller {
                 return@withContext Result.failure(Exception(it))
             }
 
-            // Step 1: Check storage space
+            // Step 1: Create container directory (metadata: config, .env, pidfile --
+            // this always stays on internal storage regardless of rootfs location)
+            logger.i("Creating container directory: $containerPath")
+            val mkdirResult = Shell.cmd("mkdir -p \"$containerPath\" 2>&1").exec()
+            if (!mkdirResult.isSuccess) {
+                val errorOutput = (mkdirResult.out + mkdirResult.err).joinToString("\n").trim()
+                val errorMsg = if (errorOutput.isNotEmpty()) errorOutput else "Unknown error (exit code: ${mkdirResult.code})"
+                throw Exception("Failed to create container directory: $errorMsg")
+            }
+            createdPaths.add(containerPath)
+
+            // Step 1.1: If the rootfs lives on external/custom storage, make sure
+            // its parent directory exists too (it won't have been created above).
+            // This MUST happen before the free-space check below -- stat/df need
+            // the target path to already exist.
+            if (isExternalStorage) {
+                StorageMountManager.ensureVolumeMounted(rootfsParentDir)
+                logger.i("Creating external storage directory: $rootfsParentDir")
+                val mkdirExtResult = RootNamespace.exec("mkdir -p \"$rootfsParentDir\" 2>&1", targetPath = rootfsParentDir)
+                if (!mkdirExtResult.isSuccess) {
+                    val errorOutput = (mkdirExtResult.out + mkdirExtResult.err).joinToString("\n").trim()
+                    val errorMsg = if (errorOutput.isNotEmpty()) errorOutput else "Unknown error (exit code: ${mkdirExtResult.code})"
+                    throw Exception("Failed to create external storage directory: $errorMsg")
+                }
+                createdPaths.add(rootfsParentDir)
+            }
+
+            // Step 2: Check storage space on the actual target volume (the external
+            // storage's mount point if one was chosen, otherwise /data). Runs after
+            // directory creation so the path being checked is guaranteed to exist.
             logger.i("Checking available storage space...")
-            val freeGB = StorageChecker.getFreeSpaceGB()
+            val spaceCheckPath = if (isExternalStorage) rootfsParentDir else "/data"
+            val freeGB = StorageChecker.getFreeSpaceGB(spaceCheckPath)
             if (freeGB != null) {
-                logger.i("/data partition has ${freeGB}GB free space")
+                logger.i("$spaceCheckPath has ${freeGB}GB free space")
                 val requiredGB = if (config.useSparseImage) {
                     (config.sparseImageSizeGB ?: 8) + Constants.MIN_STORAGE_GB
                 } else {
@@ -60,15 +90,30 @@ object ContainerInstaller {
                 logger.w("Warning: Unable to determine free space. Proceeding anyway...")
             }
 
-            // Step 2: Create container directory
-            logger.i("Creating container directory: $containerPath")
-            val mkdirResult = Shell.cmd("mkdir -p \"$containerPath\" 2>&1").exec()
-            if (!mkdirResult.isSuccess) {
-                val errorOutput = (mkdirResult.out + mkdirResult.err).joinToString("\n").trim()
-                val errorMsg = if (errorOutput.isNotEmpty()) errorOutput else "Unknown error (exit code: ${mkdirResult.code})"
-                throw Exception("Failed to create container directory: $errorMsg")
+            // Step 2.1: A sparse rootfs.img is one big file. FAT32 caps any single
+            // file at 4 GiB - 1 byte, so a "4GB" image (4294967296 bytes) is
+            // already 1 byte over the line -- mkfs.ext4/mke2fs then fails (or,
+            // worse, silently truncates) while writing the last block group's
+            // superblock backups near the end of the file, since the file can
+            // never actually reach its requested size. exFAT and ext4 have no
+            // such limit. Catch it up front with a clear message instead of a
+            // confusing low-level mkfs failure deep into the install.
+            if (isExternalStorage && config.useSparseImage) {
+                val fsTypeResult = RootNamespace.exec(
+                    "stat -f -c '%T' \"$rootfsParentDir\" 2>/dev/null",
+                    targetPath = rootfsParentDir
+                )
+                val destFsType = fsTypeResult.out.firstOrNull()?.trim()?.lowercase()
+                val isFat32 = destFsType == "msdos" || destFsType == "vfat" || destFsType == "fat"
+                val requestedSizeGB = config.sparseImageSizeGB ?: 8
+                if (isFat32 && requestedSizeGB >= 4) {
+                    throw Exception(
+                        "Destination is FAT32, which can't hold a single file of 4GB or more " +
+                        "(the sparse image would be ${requestedSizeGB}GB). Reformat the drive as " +
+                        "exFAT or ext4, or choose a sparse image size under 4GB."
+                    )
+                }
             }
-            createdPaths.add(containerPath)
 
             // Step 3: Copy tarball to temp location
             logger.i("Copying tarball to temporary location...")
@@ -94,11 +139,12 @@ object ContainerInstaller {
                     imgPath = rootfsPath,
                     mountPoint = "${containerPath}/rootfs",
                     sizeGB = config.sparseImageSizeGB ?: 8,
+                    configContent = config.toConfigContent(),
                     logger = logger
                 )
             } else {
                 // Create rootfs subdirectory
-                val mkdirRootfsResult = Shell.cmd("mkdir -p \"$rootfsPath\" 2>&1").exec()
+                val mkdirRootfsResult = RootNamespace.exec("mkdir -p \"$rootfsPath\" 2>&1", targetPath = rootfsPath)
                 if (!mkdirRootfsResult.isSuccess) {
                     val errorOutput = (mkdirRootfsResult.out + mkdirRootfsResult.err).joinToString("\n").trim()
                     val errorMsg = if (errorOutput.isNotEmpty()) errorOutput else "Unknown error (exit code: ${mkdirRootfsResult.code})"
@@ -113,9 +159,9 @@ object ContainerInstaller {
                     "cd \"$rootfsPath\" && $BUSYBOX_PATH tar -xzpf \"${tempTarball.absolutePath}\" 2>&1"
                 }
 
-                val extractResult = Shell.cmd(extractCmd).exec()
+                val extractResult = RootNamespace.exec(extractCmd, targetPath = rootfsPath)
                 if (!extractResult.isSuccess) {
-                    val errorMsg = extractResult.err.joinToString("\n")
+                    val errorMsg = (extractResult.out + extractResult.err).joinToString("\n")
                     logger.e("Extraction failed: $errorMsg")
                     throw Exception("Failed to extract tarball: $errorMsg")
                 }
@@ -128,18 +174,21 @@ object ContainerInstaller {
 
             // Step 5: Write container config
             logger.i("Writing container configuration...")
-            val configContent = config.toConfigContent()
+            val effectiveRootfsPath = if (isExternalStorage && config.useSparseImage) {
+                StorageMountManager.resolveToPhysicalPath(rootfsPath)
+            } else {
+                rootfsPath
+            }
+            val effectiveConfig = config.copy(rootfsPath = effectiveRootfsPath)
+            val configContent = effectiveConfig.toConfigContent()
 
             // Write config to temp file first (app can write to cache dir)
-            // Use sanitizedName to avoid issues with spaces in filename
             val tempConfigFile = File("${context.cacheDir}/container_${sanitizedName}.config")
             tempConfigFile.writeText(configContent)
 
             // Copy temp config to final location using shell (root required)
-            // Quote paths to handle any special characters
             val copyResult = Shell.cmd("cp \"${tempConfigFile.absolutePath}\" \"$configFilePath\" 2>&1").exec()
             if (!copyResult.isSuccess) {
-                // Check both stdout and stderr for error messages
                 val errorOutput = (copyResult.out + copyResult.err).joinToString("\n").trim()
                 val errorMsg = if (errorOutput.isNotEmpty()) errorOutput else "Unknown error (exit code: ${copyResult.code})"
                 logger.e("Failed to copy config: $errorMsg")
@@ -188,14 +237,14 @@ object ContainerInstaller {
             // Step 6: Verify installation
             logger.i("Verifying installation...")
             if (config.useSparseImage) {
-                val imgExists = Shell.cmd("test -f \"$rootfsPath\" && echo 'exists' || echo 'not_found'").exec()
+                val imgExists = RootNamespace.exec("test -f \"$rootfsPath\" && echo 'exists' || echo 'not_found'", targetPath = rootfsPath)
                 if (!imgExists.isSuccess || !imgExists.out.any { it.contains("exists") }) {
                     throw Exception("Container sparse image not found after extraction")
                 }
             } else {
-            val rootfsExists = Shell.cmd("test -d \"$rootfsPath\" && echo 'exists' || echo 'not_found'").exec()
-            if (!rootfsExists.isSuccess || !rootfsExists.out.any { it.contains("exists") }) {
-                throw Exception("Container rootfs directory not found after extraction")
+                val rootfsExists = RootNamespace.exec("test -d \"$rootfsPath\" && echo 'exists' || echo 'not_found'", targetPath = rootfsPath)
+                if (!rootfsExists.isSuccess || !rootfsExists.out.any { it.contains("exists") }) {
+                    throw Exception("Container rootfs directory not found after extraction")
                 }
             }
 
@@ -234,10 +283,7 @@ object ContainerInstaller {
             return@withContext when {
                 fileNameLower.endsWith(".tar.xz") -> ".xz"
                 fileNameLower.endsWith(".tar.gz") -> ".gz"
-                else -> {
-                    // Fallback: default to .gz if we can't determine
-                    ".gz"
-                }
+                else -> ".gz"
             }
         }
 
@@ -246,17 +292,13 @@ object ContainerInstaller {
         when {
             uriString.endsWith(".tar.xz") -> ".xz"
             uriString.endsWith(".tar.gz") -> ".gz"
-            else -> ".gz" // Default to .gz if we can't determine
+            else -> ".gz"
         }
     }
 
-
-
     /**
      * Inspect the tarball (without extracting) to confirm it contains a Linux
-     * rootfs, so users can't install arbitrary archives (photo backups, source
-     * zips, etc.). Throws on a confirmed-invalid archive; a validator that fails
-     * to load is treated as non-fatal (warn and continue).
+     * rootfs, so users can't install arbitrary archives.
      */
     private suspend fun validateRootfsTarball(
         context: Context,
@@ -265,7 +307,6 @@ object ContainerInstaller {
     ) {
         logger.i("Inspecting tarball to verify it is a Linux rootfs...")
 
-        // Copy validator script from assets
         val scriptFile = File("${context.cacheDir}/validate_rootfs.sh")
         try {
             context.assets.open("validate_rootfs.sh").use { inputStream ->
@@ -281,16 +322,14 @@ object ContainerInstaller {
         }
 
         try {
-            // Make script executable
             val chmodResult = Shell.cmd("chmod 755 \"${scriptFile.absolutePath}\" 2>&1").exec()
             if (!chmodResult.isSuccess) {
-                // Fail CLOSED — see FINDINGS_APP_VULN V12.
                 logger.e("Failed to make rootfs validator executable")
                 throw Exception("Could not verify rootfs: validator not executable")
             }
 
             val result = Shell.cmd(
-                "BUSYBOX_PATH=$BUSYBOX_PATH \"${scriptFile.absolutePath}\" \"${tarball.absolutePath}\" 2>&1"
+                "BUSYBOX_PATH=$BUSYBOX_PATH sh \"${scriptFile.absolutePath}\" \"${tarball.absolutePath}\" 2>&1"
             ).exec()
 
             if (!result.isSuccess) {
@@ -311,7 +350,7 @@ object ContainerInstaller {
     }
 
     /**
-     * Apply post-extraction fixes to the rootfs (both sparse and directory modes).
+     * Apply post-extraction fixes to the rootfs (directory mode).
      */
     private suspend fun applyPostExtractionFixes(
         context: Context,
@@ -343,7 +382,10 @@ object ContainerInstaller {
 
         try {
             // Execute the script
-            val result = Shell.cmd("BUSYBOX_PATH=$BUSYBOX_PATH \"${postFixScriptFile.absolutePath}\" \"$rootfsPath\" 2>&1").exec()
+            val result = RootNamespace.exec(
+                "BUSYBOX_PATH=$BUSYBOX_PATH sh \"${postFixScriptFile.absolutePath}\" \"$rootfsPath\" 2>&1",
+                targetPath = rootfsPath
+            )
 
             // Log all output from the script
             result.out.forEach { line ->
@@ -383,7 +425,10 @@ object ContainerInstaller {
     private suspend fun cleanup(paths: List<String>, logger: ContainerLogger) {
         paths.reversed().forEach { path ->
             try {
-                val result = Shell.cmd("rm -rf ${ContainerCommandBuilder.quote(path)} 2>&1").exec()
+                val result = RootNamespace.exec(
+                    "rm -rf ${ContainerCommandBuilder.quote(path)} 2>&1",
+                    targetPath = path
+                )
                 if (result.isSuccess) {
                     logger.d("Cleaned up: $path")
                 } else {
@@ -394,5 +439,146 @@ object ContainerInstaller {
             }
         }
     }
-}
 
+    /**
+     * Install / import a container from an existing sparse ext4 rootfs image.
+     * Sets up container metadata on internal storage, verifies or copies the image,
+     * applies host permissions, and syncs the embedded configuration inside the image.
+     */
+    suspend fun installFromExistingImage(
+        context: Context,
+        config: ContainerInfo,
+        existingImagePath: String,
+        logger: ContainerLogger
+    ): Result<Unit> = withContext(Dispatchers.IO) {
+        val sanitizedName = ContainerManager.sanitizeContainerName(config.name)
+        val containerPath = ContainerManager.getContainerDirectory(config.name)
+        val rootfsPath = config.rootfsPath
+        val rootfsParentDir = rootfsPath.substringBeforeLast("/", containerPath)
+        val isExternalStorage = rootfsParentDir != containerPath
+        val configFilePath = "$containerPath/${Constants.CONTAINER_CONFIG_FILE}"
+        val createdPaths = mutableListOf<String>()
+
+        try {
+            logger.i("Importing container from existing image...")
+            logger.i("Container: ${config.name}")
+            logger.i("Source Image: $existingImagePath")
+            logger.i("Target Rootfs: $rootfsPath")
+
+            // Reject control chars in config
+            ValidationUtils.validateConfigValues(config).errorMessage?.let {
+                logger.e(it)
+                return@withContext Result.failure(Exception(it))
+            }
+
+            // Step 1: Create container directory for metadata
+            logger.i("Creating container directory: $containerPath")
+            val mkdirResult = Shell.cmd("mkdir -p \"$containerPath\" 2>&1").exec()
+            if (!mkdirResult.isSuccess) {
+                val err = (mkdirResult.out + mkdirResult.err).joinToString("\n").trim()
+                throw Exception("Failed to create container directory: $err")
+            }
+            createdPaths.add(containerPath)
+
+            // Step 1.1: Ensure target parent directory exists if external
+            if (isExternalStorage) {
+                StorageMountManager.ensureVolumeMounted(rootfsParentDir)
+                logger.i("Creating external storage directory: $rootfsParentDir")
+                val mkdirExtResult = RootNamespace.exec("mkdir -p \"$rootfsParentDir\" 2>&1", targetPath = rootfsParentDir)
+                if (!mkdirExtResult.isSuccess) {
+                    val err = (mkdirExtResult.out + mkdirExtResult.err).joinToString("\n").trim()
+                    throw Exception("Failed to create external storage directory: $err")
+                }
+                createdPaths.add(rootfsParentDir)
+            }
+
+            // Step 2: Handle Image placement
+            val isSamePath = existingImagePath.trim() == rootfsPath.trim()
+            if (!isSamePath) {
+                logger.i("Copying image to target storage location...")
+                val qSrc = ContainerCommandBuilder.quote(existingImagePath)
+                val qDst = ContainerCommandBuilder.quote(rootfsPath)
+                val copyResult = RootNamespace.exec(
+                    "cp -a $qSrc $qDst 2>&1",
+                    forceNsenter = isExternalStorage || RootNamespace.isExternalStorage(existingImagePath)
+                )
+                if (!copyResult.isSuccess) {
+                    val err = (copyResult.out + copyResult.err).joinToString("\n").trim()
+                    throw Exception("Failed to copy image to $rootfsPath: $err")
+                }
+                createdPaths.add(rootfsPath)
+            } else {
+                logger.i("Using existing image in-place at $rootfsPath")
+            }
+
+            // Step 3: Set permissions and SELinux context
+            val qRootfs = ContainerCommandBuilder.quote(rootfsPath)
+            RootNamespace.exec("chmod 644 $qRootfs 2>&1", targetPath = rootfsPath)
+            if (rootfsPath.startsWith("/data/")) {
+                RootNamespace.exec("chcon u:object_r:vold_data_file:s0 $qRootfs 2>/dev/null", targetPath = rootfsPath)
+            }
+
+            // Step 4: Verify filesystem integrity
+            logger.i("Verifying image filesystem integrity (e2fsck)...")
+            val checkResult = RootNamespace.exec("e2fsck -fy $qRootfs", targetPath = rootfsPath)
+            if (checkResult.code >= 4) {
+                val err = (checkResult.out + checkResult.err).joinToString("\n").trim()
+                throw Exception("Filesystem check failed (e2fsck error ${checkResult.code}): $err")
+            }
+            logger.i("Filesystem verified.")
+
+            // Step 5: Write container config on host
+            logger.i("Writing container configuration...")
+            val effectiveRootfsPath = if (isExternalStorage && config.useSparseImage) {
+                StorageMountManager.resolveToPhysicalPath(rootfsPath)
+            } else {
+                rootfsPath
+            }
+            val effectiveConfig = config.copy(rootfsPath = effectiveRootfsPath)
+            val configContent = effectiveConfig.toConfigContent()
+            val tempConfigFile = File("${context.cacheDir}/container_${sanitizedName}.config")
+            tempConfigFile.writeText(configContent)
+
+            val copyConfigRes = Shell.cmd("cp \"${tempConfigFile.absolutePath}\" \"$configFilePath\" 2>&1").exec()
+            tempConfigFile.delete()
+            if (!copyConfigRes.isSuccess) {
+                val err = (copyConfigRes.out + copyConfigRes.err).joinToString("\n").trim()
+                throw Exception("Failed to save container config: $err")
+            }
+            Shell.cmd("chmod 644 \"$configFilePath\" 2>&1").exec()
+            createdPaths.add(configFilePath)
+
+            // Step 5.1: Write .env file if present
+            if (!config.envFileContent.isNullOrBlank()) {
+                val envFilePath = "$containerPath/.env"
+                val tempEnvFile = File("${context.cacheDir}/.env_${sanitizedName}")
+                try {
+                    tempEnvFile.writeText(config.envFileContent + "\n")
+                    Shell.cmd("cp \"${tempEnvFile.absolutePath}\" \"$envFilePath\" 2>&1").exec()
+                    Shell.cmd("chmod 644 \"$envFilePath\"").exec()
+                    createdPaths.add(envFilePath)
+                } finally {
+                    tempEnvFile.delete()
+                }
+            }
+
+            // Step 5.2: Refresh embedded config inside the image
+            logger.i("Syncing embedded configuration inside image for portability...")
+            ExistingImageManager.embedConfig(rootfsPath, configContent, context)
+
+            // Step 6: Verify installation
+            val imgExists = RootNamespace.exec("test -f $qRootfs && echo 'exists' || echo 'not_found'", targetPath = rootfsPath)
+            if (!imgExists.isSuccess || !imgExists.out.any { it.contains("exists") }) {
+                throw Exception("Container rootfs image not found after import")
+            }
+
+            logger.i("Container imported and configured successfully!")
+            Result.success(Unit)
+        } catch (e: Exception) {
+            logger.e("Import failed: ${e.message}")
+            logger.e(e.stackTraceToString())
+            cleanup(createdPaths, logger)
+            Result.failure(e)
+        }
+    }
+}

--- a/Android/app/src/main/java/com/droidspaces/app/util/ContainerManager.kt
+++ b/Android/app/src/main/java/com/droidspaces/app/util/ContainerManager.kt
@@ -161,16 +161,32 @@ object ContainerManager {
 
     /**
      * Get the rootfs path for a container (LXC-style: /rootfs subdirectory).
+     *
+     * @param customStorageDir Optional external/custom storage root (e.g. an SD card or
+     * USB-OTG mount point). When provided, the container's rootfs lives under
+     * "$customStorageDir/<sanitizedName>/rootfs" instead of the default internal
+     * CONTAINERS_BASE_PATH. The container's own metadata (config file, .env, pidfile)
+     * always stays under CONTAINERS_BASE_PATH regardless of this setting.
      */
-    fun getRootfsPath(name: String): String {
-        return "${getContainerDirectory(name)}/rootfs"
+    fun getRootfsPath(name: String, customStorageDir: String? = null): String {
+        return if (customStorageDir != null) {
+            "${customStorageDir.trimEnd('/')}/${sanitizeContainerName(name)}/rootfs"
+        } else {
+            "${getContainerDirectory(name)}/rootfs"
+        }
     }
 
     /**
      * Get the sparse image path for a container.
+     *
+     * @param customStorageDir Optional external/custom storage root — see [getRootfsPath].
      */
-    fun getSparseImagePath(name: String): String {
-        return "${getContainerDirectory(name)}/rootfs.img"
+    fun getSparseImagePath(name: String, customStorageDir: String? = null): String {
+        return if (customStorageDir != null) {
+            "${customStorageDir.trimEnd('/')}/${sanitizeContainerName(name)}/rootfs.img"
+        } else {
+            "${getContainerDirectory(name)}/rootfs.img"
+        }
     }
 
     /**
@@ -452,7 +468,10 @@ object ContainerManager {
 
     /**
      * Update container configuration.
-     * Only updates the configurable options (hostname, flags), not name or rootfsPath.
+     * Updates the configurable options (hostname, flags, rootfsPath, etc.), not the
+     * container's name. Note: changing rootfsPath here only rewrites the config file --
+     * it does NOT move any data on disk. Use [moveContainerStorage] to actually relocate
+     * a container's rootfs and update its config together.
      *
      * @param context Android context for temporary file creation
      * @param containerName Name of the container to update (will be sanitized)
@@ -523,7 +542,273 @@ object ContainerManager {
             // Clean up temp config file
             tempConfigFile.delete()
 
+            // Best-effort sync embedded config inside sparse image for portability
+            if (newConfig.useSparseImage && newConfig.rootfsPath.isNotBlank()) {
+                try {
+                    ExistingImageManager.embedConfig(newConfig.rootfsPath, configContent, context)
+                } catch (e: Exception) {
+                    // Non-fatal
+                }
+            }
+
             Result.success(Unit)
+        } catch (e: Exception) {
+            Result.failure(e)
+        }
+    }
+
+    /**
+     * Auto-detects if an external container's rootfs or image path has changed
+     * due to USB storage eject/remount (e.g. volume UUID or mount point change).
+     * If found on another active external storage volume, updates container.config on disk
+     * and returns the updated ContainerInfo.
+     */
+    suspend fun autoDetectAndRemapContainerPath(
+        context: Context,
+        container: ContainerInfo,
+        logger: ContainerLogger? = null
+    ): ContainerInfo = withContext(Dispatchers.IO) {
+        val oldPath = container.rootfsPath.trim()
+        if (oldPath.isBlank()) return@withContext container
+
+        // Ensure stale loop devices and mounts are cleaned first
+        StorageMountManager.cleanupStaleMountsAndLoopDevices()
+        StorageMountManager.ensureVolumeMounted(oldPath)
+
+        val oldVolId = StorageMountManager.extractVolumeId(oldPath)
+
+        // For external sparse images, ALWAYS ensure the physical path (/mnt/media_rw/...)
+        // is used in container.config so loop mounting bypasses Android FUSE layer (which returns ENXIO).
+        if (oldVolId != null && container.useSparseImage) {
+            val physicalPath = StorageMountManager.resolveToPhysicalPath(oldPath)
+            val qPhys = ContainerCommandBuilder.quote(physicalPath)
+            val physExists = Shell.cmd("[ -f $qPhys ] && echo yes || echo no").exec().out.firstOrNull()?.trim() == "yes"
+            if (physExists) {
+                if (oldPath != physicalPath) {
+                    logger?.i("Using raw physical storage path for loop mount: $physicalPath")
+                    val updated = container.copy(rootfsPath = physicalPath)
+                    updateContainerConfig(context, container.name, updated)
+                    return@withContext updated
+                }
+                return@withContext container
+            }
+        }
+
+        // Check if current path exists and is accessible
+        val qOld = ContainerCommandBuilder.quote(oldPath)
+        val exists = Shell.cmd("[ -e $qOld ] && echo yes || echo no").exec().out.firstOrNull()?.trim() == "yes"
+        if (exists) {
+            return@withContext container
+        }
+
+        if (oldVolId == null) return@withContext container
+
+        // Extract subpath after the old volume ID
+        val subPath = oldPath.substringAfter(oldVolId, "").trimStart('/')
+        val filename = oldPath.substringAfterLast("/")
+
+        // Discover all currently connected storage volumes
+        val activeVolumes = StorageMountManager.listAllStorageVolumes()
+        for (volPath in activeVolumes) {
+            val candidatePaths = mutableListOf<String>()
+            if (subPath.isNotEmpty()) {
+                candidatePaths.add("$volPath/$subPath")
+            }
+            candidatePaths.add("$volPath/${sanitizeContainerName(container.name)}/rootfs.img")
+            candidatePaths.add("$volPath/${sanitizeContainerName(container.name)}/rootfs")
+            if (filename.isNotEmpty() && filename != "rootfs.img" && filename != "rootfs") {
+                candidatePaths.add("$volPath/$filename")
+            }
+
+            for (cand in candidatePaths.distinct()) {
+                val qCand = ContainerCommandBuilder.quote(cand)
+                val candExists = Shell.cmd("[ -e $qCand ] && echo yes || echo no").exec().out.firstOrNull()?.trim() == "yes"
+                if (candExists) {
+                    val targetPath = if (container.useSparseImage) {
+                        StorageMountManager.resolveToPhysicalPath(cand)
+                    } else {
+                        cand
+                    }
+                    logger?.i("Storage remount detected: container rootfs relocated from $oldPath to $targetPath")
+                    val updated = container.copy(rootfsPath = targetPath)
+                    updateContainerConfig(context, container.name, updated)
+                    return@withContext updated
+                }
+            }
+        }
+
+        logger?.w("Warning: Container rootfs not found at $oldPath and no matching path found on connected storage drives.")
+        container
+    }
+
+    /**
+     * Move a container's rootfs (or rootfs.img) to a different storage location and
+     * update its config file to match. This is the "storage relocation" companion to
+     * [ContainerInstaller.installContainer]'s initial storage-location choice.
+     *
+     * The container's small metadata (config file, .env, pidfile) always stays under the
+     * internal CONTAINERS_BASE_PATH -- only the (large) rootfs data is relocated.
+     *
+     * @param context Android context, needed by [updateContainerConfig]
+     * @param container The container to move (must be stopped)
+     * @param newStorageDir Destination storage root, e.g. "/storage/1234-5678/Droidspaces".
+     *   Pass null to move the container back to the default internal location.
+     * @param logger Optional logger for progress/diagnostic messages
+     * @return Result.success(newRootfsPath) on success, Result.failure with a
+     *   human-readable message on error. On failure, no partial state is left behind:
+     *   either the move completed and the config was updated, or nothing changed.
+     */
+    suspend fun moveContainerStorage(
+        context: Context,
+        container: ContainerInfo,
+        newStorageDir: String?,
+        logger: ContainerLogger? = null
+    ): Result<String> = withContext(Dispatchers.IO) {
+        try {
+            // Refuse to move a running container -- the rootfs may be actively
+            // mounted/in use and moving it out from under a live process is unsafe.
+            val (isRunning, _) = checkContainerStatus(container.name)
+            if (isRunning) {
+                return@withContext Result.failure(
+                    Exception("Stop the container before moving its storage.")
+                )
+            }
+
+            // /mnt/media_rw/<vol> is vold's raw mount of removable media. Writing
+            // there directly is unreliable -- see StorageChecker.normalizeStorageDir.
+            val normalizedStorageDir = newStorageDir?.let { StorageChecker.normalizeStorageDir(it) }
+
+            val containerPath = getContainerDirectory(container.name)
+            val oldRootfsPath = container.rootfsPath
+            val newRootfsPath = if (container.useSparseImage) {
+                getSparseImagePath(container.name, normalizedStorageDir)
+            } else {
+                getRootfsPath(container.name, normalizedStorageDir)
+            }
+
+            if (oldRootfsPath == newRootfsPath) {
+                return@withContext Result.failure(
+                    Exception("Container is already at that location.")
+                )
+            }
+
+            val isExternal = RootNamespace.isExternalStorage(oldRootfsPath) || RootNamespace.isExternalStorage(newRootfsPath)
+            val quotedOld = ContainerCommandBuilder.quote(oldRootfsPath)
+            val quotedNew = ContainerCommandBuilder.quote(newRootfsPath)
+
+            // Verify the current rootfs actually exists before doing anything.
+            val existsCheck = RootNamespace.exec("[ -e $quotedOld ] && echo yes || echo no", forceNsenter = isExternal)
+            if (existsCheck.out.firstOrNull()?.trim() != "yes") {
+                return@withContext Result.failure(
+                    Exception("Current rootfs not found at $oldRootfsPath")
+                )
+            }
+
+            val newParentDir = newRootfsPath.substringBeforeLast("/", newRootfsPath)
+
+            // Best-effort free-space check at the destination (non-fatal if it can't
+            // be determined -- some filesystems/paths don't report du/df cleanly).
+            logger?.i("Checking free space at $newParentDir ...")
+            val sizeResult = RootNamespace.exec(
+                "du -sk $quotedOld 2>/dev/null | ${Constants.BUSYBOX_BINARY_PATH} awk '{print \$1}'",
+                forceNsenter = isExternal
+            )
+            val neededKB = sizeResult.out.firstOrNull()?.trim()?.toLongOrNull()
+            val mkdirParentResult = RootNamespace.exec(
+                "mkdir -p ${ContainerCommandBuilder.quote(newParentDir)} 2>&1",
+                forceNsenter = isExternal
+            )
+            if (!mkdirParentResult.isSuccess) {
+                val err = (mkdirParentResult.out + mkdirParentResult.err).joinToString("\n").trim()
+                return@withContext Result.failure(Exception("Failed to create destination directory: $err"))
+            }
+            if (neededKB != null) {
+                val freeGB = StorageChecker.getFreeSpaceGB(newParentDir)
+                val neededGB = (neededKB / 1024 / 1024).toInt() + 1 // round up + 1GB margin
+                if (freeGB != null && freeGB < neededGB) {
+                    return@withContext Result.failure(
+                        Exception("Not enough free space at destination (~${neededGB}GB needed, ${freeGB}GB free)")
+                    )
+                }
+            }
+
+            // FAT32 caps any single file at 4 GiB. cp/mv into a FAT32 destination
+            // fail mid-copy with "short write: No space left on device" once the
+            // destination file crosses that line, even with plenty of free space on
+            // the volume -- catch it up front with a clear message instead. exFAT
+            // and ext4 have no such limit.
+            val fsTypeResult = RootNamespace.exec(
+                "stat -f -c '%T' ${ContainerCommandBuilder.quote(newParentDir)} 2>/dev/null",
+                forceNsenter = isExternal
+            )
+            val destFsType = fsTypeResult.out.firstOrNull()?.trim()?.lowercase()
+            val isFat32 = destFsType == "msdos" || destFsType == "vfat" || destFsType == "fat"
+            if (isFat32 && neededKB != null && neededKB > 4L * 1024 * 1024) {
+                return@withContext Result.failure(
+                    Exception(
+                        "Destination is FAT32, which can't hold a single file over 4GB " +
+                        "(this container's data is ~${neededKB / 1024 / 1024}GB). " +
+                        "Reformat the drive as exFAT or ext4, or pick a different destination."
+                    )
+                )
+            }
+
+            // Try a plain rename first (instant, but only works within the same
+            // filesystem). Falls back to copy-then-delete for cross-filesystem moves,
+            // which is the common case (internal storage -> SD card / USB-OTG).
+            logger?.i("Moving rootfs from $oldRootfsPath to $newRootfsPath ...")
+            val mvResult = RootNamespace.exec("mv $quotedOld $quotedNew 2>&1", forceNsenter = isExternal)
+            if (!mvResult.isSuccess) {
+                logger?.i("Direct rename unavailable (different filesystem) -- copying instead. This may take a while for large containers.")
+                val cpResult = RootNamespace.exec("cp -a $quotedOld $quotedNew 2>&1", forceNsenter = isExternal)
+                if (!cpResult.isSuccess) {
+                    val err = (cpResult.out + cpResult.err).joinToString("\n").trim()
+                    // Clean up any partial copy so a retry starts clean.
+                    RootNamespace.exec("rm -rf $quotedNew 2>&1", forceNsenter = isExternal)
+                    return@withContext Result.failure(Exception("Failed to copy rootfs to new location: $err"))
+                }
+
+                // Data is safely copied to the new location -- now update the config
+                // BEFORE deleting the old copy, so a crash here never leaves the
+                // container pointing at data that no longer exists.
+                val updateResult = updateContainerConfig(
+                    context, container.name, container.copy(rootfsPath = newRootfsPath)
+                )
+                if (updateResult.isFailure) {
+                    RootNamespace.exec("rm -rf $quotedNew 2>&1", forceNsenter = isExternal)
+                    return@withContext Result.failure(
+                        updateResult.exceptionOrNull() ?: Exception("Failed to update container config")
+                    )
+                }
+
+                logger?.i("Removing old copy at $oldRootfsPath ...")
+                val rmResult = RootNamespace.exec("rm -rf $quotedOld 2>&1", forceNsenter = isExternal)
+                if (!rmResult.isSuccess) {
+                    logger?.w("Move succeeded, but couldn't remove the old data at $oldRootfsPath -- remove it manually to free up space.")
+                }
+            } else {
+                // Plain rename succeeded -- update the config to match.
+                val updateResult = updateContainerConfig(
+                    context, container.name, container.copy(rootfsPath = newRootfsPath)
+                )
+                if (updateResult.isFailure) {
+                    // Move the data back so we don't leave the container broken.
+                    RootNamespace.exec("mv $quotedNew $quotedOld 2>&1", forceNsenter = isExternal)
+                    return@withContext Result.failure(
+                        updateResult.exceptionOrNull() ?: Exception("Failed to update container config")
+                    )
+                }
+            }
+
+            // Clean up the now-empty old external directory, if any (no-op/safe if
+            // it's not empty or was the internal container directory).
+            val oldParentDir = oldRootfsPath.substringBeforeLast("/", "")
+            if (oldParentDir.isNotEmpty() && oldParentDir != containerPath) {
+                RootNamespace.exec("rmdir ${ContainerCommandBuilder.quote(oldParentDir)} 2>/dev/null", forceNsenter = isExternal)
+            }
+
+            logger?.i("Move complete. New location: $newRootfsPath")
+            Result.success(newRootfsPath)
         } catch (e: Exception) {
             Result.failure(e)
         }
@@ -626,6 +911,23 @@ object ContainerManager {
             if (!deleteResult.isSuccess) {
                 logger.e("Failed to delete container directory (exit code: ${deleteResult.code})")
                 return@withContext Result.failure(Exception("Failed to delete container directory"))
+            }
+
+            // Step 2.1: If this container's rootfs lives on external/custom storage
+            // (outside the default container directory), it won't have been touched
+            // by the rm -rf above -- clean it up separately.
+            val rootfsParentDir = container.rootfsPath.substringBeforeLast("/", "")
+            if (rootfsParentDir.isNotEmpty() && rootfsParentDir != containerPath) {
+                logger.i("Removing external storage location: $rootfsParentDir")
+                val extDeleteResult = RootNamespace.exec(
+                    "rm -rf ${ContainerCommandBuilder.quote(rootfsParentDir)} 2>&1",
+                    targetPath = rootfsParentDir
+                )
+                if (!extDeleteResult.isSuccess) {
+                    logger.w("Warning: failed to remove external storage directory: $rootfsParentDir")
+                } else {
+                    logger.i("External storage location removed.")
+                }
             }
 
             // Verify deletion

--- a/Android/app/src/main/java/com/droidspaces/app/util/ExistingImageManager.kt
+++ b/Android/app/src/main/java/com/droidspaces/app/util/ExistingImageManager.kt
@@ -1,0 +1,371 @@
+package com.droidspaces.app.util
+
+import android.content.Context
+import com.topjohnwu.superuser.Shell
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import java.io.File
+import java.io.FileOutputStream
+
+/**
+ * Result of inspecting an existing sparse rootfs image (.img).
+ */
+data class ImageInspectionResult(
+    val path: String,
+    val sizeGB: Int = 0,
+    val actualSizeBytes: Long = 0L,
+    val isExt4: Boolean = false,
+    val embeddedConfig: ContainerInfo? = null,
+    val rawEmbeddedConfig: String? = null,
+    val osName: String? = null,
+    val isValid: Boolean = false,
+    val errorMessage: String? = null
+)
+
+/**
+ * Manages operations on existing sparse rootfs images:
+ * - Read-only inspection of filesystem integrity, size, OS release, and embedded config.
+ * - Embedding or refreshing self-describing container configuration inside the image.
+ *
+ * Direct physical mount operations are executed in the global root mount namespace
+ * on raw kernel mount paths (/mnt/media_rw/<volId>/...) using /data/local/tmp or /mnt/
+ * mountpoints to avoid Android SELinux app_data_file mounton blocks and FUSE loop blocks.
+ */
+object ExistingImageManager {
+
+    /**
+     * Inspects an existing .img file:
+     * - Validates ext4 filesystem integrity using `e2fsck -fy`.
+     * - Determines total image size and allocated disk space.
+     * - Mounts the image read-only to check for embedded configuration at the
+     *   single canonical location, [Constants.EMBEDDED_CONFIG_RELATIVE_PATH]
+     *   (`/etc/droidspaces/container.config` once mounted), and OS release info.
+     */
+    suspend fun inspect(imgPath: String, context: Context): ImageInspectionResult = withContext(Dispatchers.IO) {
+        val busybox = Constants.BUSYBOX_BINARY_PATH
+        val normalizedPath = SafPathResolver.normalizePath(imgPath)
+
+        try {
+            StorageMountManager.cleanupStaleMountsAndLoopDevices()
+            if (RootNamespace.isExternalStorage(normalizedPath)) {
+                StorageMountManager.ensureVolumeMounted(normalizedPath)
+            }
+
+            // Always resolve to physical mount path (e.g. /mnt/media_rw/FFF6-F07B/...) for loop/kernel operations
+            val physicalPath = StorageMountManager.resolveToPhysicalPath(normalizedPath)
+            val qPhys = ContainerCommandBuilder.quote(physicalPath)
+            val qNorm = ContainerCommandBuilder.quote(normalizedPath)
+
+            // Step 1: Check if file exists
+            val existsRes = Shell.cmd("[ -f $qPhys ] && echo yes || [ -f $qNorm ] && echo yes || echo no").exec()
+            if (existsRes.out.firstOrNull()?.trim() != "yes") {
+                return@withContext ImageInspectionResult(
+                    path = normalizedPath,
+                    errorMessage = "File does not exist or is not accessible at $normalizedPath"
+                )
+            }
+
+            // Target path to use for kernel operations (prefer physical to bypass FUSE)
+            val targetKernelPath = if (Shell.cmd("[ -f $qPhys ] && echo yes || echo no").exec().out.firstOrNull()?.trim() == "yes") {
+                physicalPath
+            } else {
+                normalizedPath
+            }
+            val qTarget = ContainerCommandBuilder.quote(targetKernelPath)
+
+            // Step 2: Get image size in bytes
+            val sizeRes = Shell.cmd("stat -c%s $qTarget 2>/dev/null || stat -f -c '%z' $qTarget 2>/dev/null || $busybox stat -c%s $qTarget 2>/dev/null").exec()
+            val sizeBytes = sizeRes.out.firstOrNull()?.trim()?.toLongOrNull() ?: 0L
+            val sizeGB = ((sizeBytes + (1024L * 1024L * 1024L - 1L)) / (1024L * 1024L * 1024L)).toInt().coerceAtLeast(1)
+
+            // Step 3: Check ext4 filesystem integrity (non-fatal if errors are auto-corrected)
+            val fsckRes = Shell.cmd("e2fsck -fy $qTarget").exec()
+            if (fsckRes.code >= 4) {
+                return@withContext ImageInspectionResult(
+                    path = normalizedPath,
+                    sizeGB = sizeGB,
+                    actualSizeBytes = sizeBytes,
+                    errorMessage = "Corrupted or invalid filesystem (e2fsck error ${fsckRes.code})"
+                )
+            }
+
+            // Step 4: Mount read-only to inspect embedded files
+            // Use /mnt/ or /data/local/tmp for mountpoint so SELinux allows mounton (denied on app_data_file)
+            val tempMountPoint = "/mnt/ds_inspect_mnt_${System.currentTimeMillis()}"
+            val scriptContent = buildInspectScript(
+                busybox = busybox,
+                primaryImgPath = targetKernelPath,
+                fallbackImgPath = normalizedPath,
+                mountPoint = tempMountPoint
+            )
+
+            val scriptFile = File("${context.cacheDir}/.ds_inspect_${System.currentTimeMillis()}.sh")
+            val inspectRes = try {
+                FileOutputStream(scriptFile).use { fos ->
+                    fos.write(scriptContent.toByteArray())
+                }
+                Shell.cmd("chmod 755 ${ContainerCommandBuilder.quote(scriptFile.absolutePath)}").exec()
+                // Execute via /system/bin/sh to avoid SELinux noexec denial on app-private cache files
+                Shell.cmd("/system/bin/sh ${ContainerCommandBuilder.quote(scriptFile.absolutePath)}").exec()
+            } finally {
+                try { scriptFile.delete() } catch (e: Exception) {}
+            }
+
+            var isExt4 = false
+            var embeddedConfigContent: String? = null
+            var osName: String? = null
+            val configLines = mutableListOf<String>()
+            var capturingConfig = false
+            var capturingOs = false
+
+            inspectRes.out.forEach { line ->
+                val trimmed = line.trim()
+                when {
+                    trimmed == "[INSPECT-MOUNT-OK]" -> isExt4 = true
+                    trimmed == "---BEGIN_CONFIG---" -> capturingConfig = true
+                    trimmed == "---END_CONFIG---" -> capturingConfig = false
+                    trimmed == "---BEGIN_OS---" -> capturingOs = true
+                    trimmed == "---END_OS---" -> capturingOs = false
+                    capturingConfig -> configLines.add(line)
+                    capturingOs && trimmed.isNotEmpty() -> {
+                        if (osName == null) osName = trimmed
+                    }
+                }
+            }
+
+            if (configLines.isNotEmpty()) {
+                embeddedConfigContent = configLines.joinToString("\n")
+            }
+
+            val parsedConfig = if (!embeddedConfigContent.isNullOrBlank()) {
+                ContainerManager.parseConfig(embeddedConfigContent, "imported")
+            } else null
+
+            ImageInspectionResult(
+                path = normalizedPath,
+                sizeGB = sizeGB,
+                actualSizeBytes = sizeBytes,
+                isExt4 = isExt4,
+                embeddedConfig = parsedConfig,
+                rawEmbeddedConfig = embeddedConfigContent,
+                osName = osName,
+                isValid = isExt4,
+                errorMessage = if (!isExt4) "Could not mount image as ext4 filesystem" else null
+            )
+        } catch (e: Exception) {
+            ImageInspectionResult(
+                path = normalizedPath,
+                errorMessage = e.message ?: "Failed to inspect image"
+            )
+        }
+    }
+
+    /**
+     * Mounts the image read-write and writes/refreshes the embedded container configuration.
+     */
+    suspend fun embedConfig(imgPath: String, configContent: String, context: Context): Result<Unit> = withContext(Dispatchers.IO) {
+        val busybox = Constants.BUSYBOX_BINARY_PATH
+        val normalizedPath = SafPathResolver.normalizePath(imgPath)
+        val physicalPath = StorageMountManager.resolveToPhysicalPath(normalizedPath)
+        val tempConfigFile = File("${context.cacheDir}/.ds_embed_${System.currentTimeMillis()}.config")
+        val tempMountPoint = "/mnt/ds_embed_mnt_${System.currentTimeMillis()}"
+        val scriptFile = File("${context.cacheDir}/.ds_embed_script_${System.currentTimeMillis()}.sh")
+
+        try {
+            if (RootNamespace.isExternalStorage(normalizedPath)) {
+                StorageMountManager.ensureVolumeMounted(normalizedPath)
+            }
+
+            FileOutputStream(tempConfigFile).use { fos ->
+                fos.write(configContent.toByteArray())
+            }
+
+            val targetKernelPath = if (Shell.cmd("[ -f ${ContainerCommandBuilder.quote(physicalPath)} ] && echo yes || echo no").exec().out.firstOrNull()?.trim() == "yes") {
+                physicalPath
+            } else {
+                normalizedPath
+            }
+
+            val scriptContent = buildEmbedScript(
+                busybox = busybox,
+                imgPath = targetKernelPath,
+                mountPoint = tempMountPoint,
+                configFilePath = tempConfigFile.absolutePath
+            )
+
+            FileOutputStream(scriptFile).use { fos ->
+                fos.write(scriptContent.toByteArray())
+            }
+            Shell.cmd("chmod 755 ${ContainerCommandBuilder.quote(scriptFile.absolutePath)}").exec()
+            // Execute via /system/bin/sh to avoid SELinux noexec denial on app-private cache files
+            val result = Shell.cmd("/system/bin/sh ${ContainerCommandBuilder.quote(scriptFile.absolutePath)}").exec()
+
+            if (result.isSuccess && result.out.any { it.contains("[EMBED-OK]") }) {
+                Result.success(Unit)
+            } else {
+                val err = (result.out + result.err).joinToString("\n")
+                Result.failure(Exception("Failed to embed configuration: $err"))
+            }
+        } catch (e: Exception) {
+            Result.failure(e)
+        } finally {
+            try { tempConfigFile.delete() } catch (e: Exception) {}
+            try { scriptFile.delete() } catch (e: Exception) {}
+        }
+    }
+
+    private fun buildInspectScript(
+        busybox: String,
+        primaryImgPath: String,
+        fallbackImgPath: String,
+        mountPoint: String
+    ): String = buildString {
+        val qPri = ContainerCommandBuilder.quote(primaryImgPath)
+        val qFall = ContainerCommandBuilder.quote(fallbackImgPath)
+        val qMnt = ContainerCommandBuilder.quote(mountPoint)
+
+        appendLine("#!/system/bin/sh")
+        appendLine("BUSYBOX=\"$busybox\"")
+        appendLine("IMG_PRI=$qPri")
+        appendLine("IMG_FALL=$qFall")
+        appendLine("MNT=$qMnt")
+        appendLine("LOOP_DEV=\"\"")
+        appendLine()
+        appendLine("mkdir -p \"\$MNT\" 2>/dev/null || \"\$BUSYBOX\" mkdir -p \"\$MNT\" 2>/dev/null || true")
+        appendLine()
+        appendLine("cleanup() {")
+        appendLine("    \"\$BUSYBOX\" umount -l \"\$MNT\" 2>/dev/null || umount -l \"\$MNT\" 2>/dev/null || true")
+        appendLine("    if [ -n \"\$LOOP_DEV\" ]; then")
+        appendLine("        \"\$BUSYBOX\" losetup -d \"\$LOOP_DEV\" 2>/dev/null || losetup -d \"\$LOOP_DEV\" 2>/dev/null || true")
+        appendLine("    fi")
+        appendLine("    \"\$BUSYBOX\" rmdir \"\$MNT\" 2>/dev/null || rmdir \"\$MNT\" 2>/dev/null || true")
+        appendLine("}")
+        appendLine("trap cleanup EXIT")
+        appendLine()
+        appendLine("MOUNT_OK=0")
+        appendLine("for target in \"\$IMG_PRI\" \"\$IMG_FALL\"; do")
+        appendLine("    [ -f \"\$target\" ] || continue")
+        appendLine("    LOOP_DEV=\$(losetup -f 2>/dev/null || \"\$BUSYBOX\" losetup -f 2>/dev/null || true)")
+        appendLine("    if [ -n \"\$LOOP_DEV\" ]; then")
+        appendLine("        if losetup -r \"\$LOOP_DEV\" \"\$target\" 2>/dev/null || \"\$BUSYBOX\" losetup -r \"\$LOOP_DEV\" \"\$target\" 2>/dev/null || \\")
+        appendLine("           losetup \"\$LOOP_DEV\" \"\$target\" 2>/dev/null || \"\$BUSYBOX\" losetup \"\$LOOP_DEV\" \"\$target\" 2>/dev/null; then")
+        appendLine("            if mount -t ext4 -o ro,noload \"\$LOOP_DEV\" \"\$MNT\" 2>/dev/null || \\")
+        appendLine("               \"\$BUSYBOX\" mount -t ext4 -o ro,noload \"\$LOOP_DEV\" \"\$MNT\" 2>/dev/null || \\")
+        appendLine("               mount -t ext4 -o ro \"\$LOOP_DEV\" \"\$MNT\" 2>/dev/null || \\")
+        appendLine("               \"\$BUSYBOX\" mount -t ext4 -o ro \"\$LOOP_DEV\" \"\$MNT\" 2>/dev/null; then")
+        appendLine("                MOUNT_OK=1")
+        appendLine("                break")
+        appendLine("            else")
+        appendLine("                losetup -d \"\$LOOP_DEV\" 2>/dev/null || \"\$BUSYBOX\" losetup -d \"\$LOOP_DEV\" 2>/dev/null || true")
+        appendLine("                LOOP_DEV=\"\"")
+        appendLine("            fi")
+        appendLine("        fi")
+        appendLine("    fi")
+        appendLine("    if [ \"\$MOUNT_OK\" -ne 1 ]; then")
+        appendLine("        if mount -t ext4 -o loop,ro,noload \"\$target\" \"\$MNT\" 2>/dev/null || \\")
+        appendLine("           \"\$BUSYBOX\" mount -t ext4 -o loop,ro,noload \"\$target\" \"\$MNT\" 2>/dev/null || \\")
+        appendLine("           mount -t ext4 -o loop,ro \"\$target\" \"\$MNT\" 2>/dev/null || \\")
+        appendLine("           \"\$BUSYBOX\" mount -t ext4 -o loop,ro \"\$target\" \"\$MNT\" 2>/dev/null; then")
+        appendLine("            MOUNT_OK=1")
+        appendLine("            break")
+        appendLine("        fi")
+        appendLine("    fi")
+        appendLine("done")
+        appendLine()
+        appendLine("if [ \"\$MOUNT_OK\" -ne 1 ]; then")
+        appendLine("    echo \"[INSPECT-MOUNT-FAIL]\"")
+        appendLine("    exit 1")
+        appendLine("fi")
+        appendLine()
+        appendLine("echo \"[INSPECT-MOUNT-OK]\"")
+        appendLine()
+        appendLine("# Embedded config")
+        appendLine("if [ -f \"\$MNT/${Constants.EMBEDDED_CONFIG_RELATIVE_PATH}\" ]; then")
+        appendLine("    echo \"---BEGIN_CONFIG---\"")
+        appendLine("    cat \"\$MNT/${Constants.EMBEDDED_CONFIG_RELATIVE_PATH}\"")
+        appendLine("    echo \"---END_CONFIG---\"")
+        appendLine("fi")
+        appendLine()
+        appendLine("# Check for /etc/os-release or /usr/lib/os-release")
+        appendLine("if [ -f \"\$MNT/etc/os-release\" ]; then")
+        appendLine("    echo \"---BEGIN_OS---\"")
+        appendLine("    grep \"^PRETTY_NAME=\" \"\$MNT/etc/os-release\" | cut -d'=' -f2 | tr -d '\"' || true")
+        appendLine("    echo \"---END_OS---\"")
+        appendLine("elif [ -f \"\$MNT/usr/lib/os-release\" ]; then")
+        appendLine("    echo \"---BEGIN_OS---\"")
+        appendLine("    grep \"^PRETTY_NAME=\" \"\$MNT/usr/lib/os-release\" | cut -d'=' -f2 | tr -d '\"' || true")
+        appendLine("    echo \"---END_OS---\"")
+        appendLine("fi")
+        appendLine()
+        appendLine("exit 0")
+    }
+
+    private fun buildEmbedScript(
+        busybox: String,
+        imgPath: String,
+        mountPoint: String,
+        configFilePath: String
+    ): String = buildString {
+        val qImg = ContainerCommandBuilder.quote(imgPath)
+        val qMnt = ContainerCommandBuilder.quote(mountPoint)
+        val qCfg = ContainerCommandBuilder.quote(configFilePath)
+
+        appendLine("#!/system/bin/sh")
+        appendLine("BUSYBOX=\"$busybox\"")
+        appendLine("IMG=$qImg")
+        appendLine("MNT=$qMnt")
+        appendLine("CFG=$qCfg")
+        appendLine("LOOP_DEV=\"\"")
+        appendLine()
+        appendLine("mkdir -p \"\$MNT\" 2>/dev/null || \"\$BUSYBOX\" mkdir -p \"\$MNT\" 2>/dev/null || true")
+        appendLine()
+        appendLine("cleanup() {")
+        appendLine("    \"\$BUSYBOX\" sync 2>/dev/null || sync 2>/dev/null || true")
+        appendLine("    \"\$BUSYBOX\" umount -l \"\$MNT\" 2>/dev/null || umount -l \"\$MNT\" 2>/dev/null || true")
+        appendLine("    if [ -n \"\$LOOP_DEV\" ]; then")
+        appendLine("        \"\$BUSYBOX\" losetup -d \"\$LOOP_DEV\" 2>/dev/null || losetup -d \"\$LOOP_DEV\" 2>/dev/null || true")
+        appendLine("    fi")
+        appendLine("    \"\$BUSYBOX\" rmdir \"\$MNT\" 2>/dev/null || rmdir \"\$MNT\" 2>/dev/null || true")
+        appendLine("}")
+        appendLine("trap cleanup EXIT")
+        appendLine()
+        appendLine("MOUNT_OK=0")
+        appendLine("LOOP_DEV=\$(losetup -f 2>/dev/null || \"\$BUSYBOX\" losetup -f 2>/dev/null || true)")
+        appendLine("if [ -n \"\$LOOP_DEV\" ]; then")
+        appendLine("    if losetup \"\$LOOP_DEV\" \"\$IMG\" 2>/dev/null || \"\$BUSYBOX\" losetup \"\$LOOP_DEV\" \"\$IMG\" 2>/dev/null; then")
+        appendLine("        if mount -t ext4 -o rw \"\$LOOP_DEV\" \"\$MNT\" 2>/dev/null || \\")
+        appendLine("           \"\$BUSYBOX\" mount -t ext4 -o rw \"\$LOOP_DEV\" \"\$MNT\" 2>/dev/null; then")
+        appendLine("            MOUNT_OK=1")
+        appendLine("        else")
+        appendLine("            losetup -d \"\$LOOP_DEV\" 2>/dev/null || \"\$BUSYBOX\" losetup -d \"\$LOOP_DEV\" 2>/dev/null || true")
+        appendLine("            LOOP_DEV=\"\"")
+        appendLine("        fi")
+        appendLine("    fi")
+        appendLine("fi")
+        appendLine("if [ \"\$MOUNT_OK\" -ne 1 ]; then")
+        appendLine("    if mount -t ext4 -o loop,rw \"\$IMG\" \"\$MNT\" 2>/dev/null || \\")
+        appendLine("       \"\$BUSYBOX\" mount -t ext4 -o loop,rw \"\$IMG\" \"\$MNT\" 2>/dev/null; then")
+        appendLine("        MOUNT_OK=1")
+        appendLine("    fi")
+        appendLine("fi")
+        appendLine()
+        appendLine("if [ \"\$MOUNT_OK\" -ne 1 ]; then")
+        appendLine("    echo \"[EMBED-MOUNT-FAIL]\"")
+        appendLine("    exit 1")
+        appendLine("fi")
+        appendLine()
+        appendLine("# Canonical embedded location: a file directly under /etc, which is")
+        appendLine("# guaranteed to already exist as a real directory in a validated rootfs --")
+        appendLine("# no mkdir, no possible directory/file collision with anything the rootfs ships.")
+        appendLine("EMBED_DEST=\"\$MNT/${Constants.EMBEDDED_CONFIG_RELATIVE_PATH}\"")
+        appendLine("cp \"\$CFG\" \"\$EMBED_DEST\" 2>/dev/null || true")
+        appendLine("chmod 644 \"\$EMBED_DEST\" 2>/dev/null || true")
+        appendLine("if [ -f \"\$EMBED_DEST\" ]; then")
+        appendLine("    echo \"[EMBED-OK]\"")
+        appendLine("else")
+        appendLine("    echo \"[EMBED-FAIL] could not verify write to \$EMBED_DEST\"")
+        appendLine("    exit 1")
+        appendLine("fi")
+        appendLine("exit 0")
+    }
+}

--- a/Android/app/src/main/java/com/droidspaces/app/util/FilePickerUtils.kt
+++ b/Android/app/src/main/java/com/droidspaces/app/util/FilePickerUtils.kt
@@ -90,11 +90,11 @@ object FilePickerUtils {
     }
 
     /**
-     * Check if a URI points to a valid tar.xz or tar.gz file.
+     * Check if a URI points to a valid tar.xz, tar.gz, or sparse .img file.
      *
      * @param context The context to use for ContentResolver
      * @param uri The URI to check
-     * @return Pair of (isValid, fileName) where isValid is true if the file is a tar.xz or tar.gz
+     * @return Pair of (isValid, fileName) where isValid is true if the file is a supported archive or image
      */
     suspend fun isValidTarball(context: Context, uri: Uri): Pair<Boolean, String?> {
         val fileName = getFileName(context, uri)
@@ -103,9 +103,18 @@ object FilePickerUtils {
         }
 
         val fileNameLower = fileName.lowercase()
-        val isValid = fileNameLower.endsWith(".tar.xz") || fileNameLower.endsWith(".tar.gz")
+        val isValid = fileNameLower.endsWith(".tar.xz") ||
+                fileNameLower.endsWith(".tar.gz") ||
+                fileNameLower.endsWith(".tar") ||
+                fileNameLower.endsWith(".img")
 
         return Pair(isValid, fileName)
+    }
+
+    /** Returns true if the URI points to an ext4 / sparse .img file. */
+    suspend fun isImageFile(context: Context, uri: Uri): Boolean {
+        val fileName = getFileName(context, uri) ?: return false
+        return fileName.lowercase().endsWith(".img")
     }
 }
 

--- a/Android/app/src/main/java/com/droidspaces/app/util/RootNamespace.kt
+++ b/Android/app/src/main/java/com/droidspaces/app/util/RootNamespace.kt
@@ -1,0 +1,209 @@
+package com.droidspaces.app.util
+
+import android.content.Context
+import android.os.Process
+import com.topjohnwu.superuser.Shell
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import java.io.File
+import java.io.FileOutputStream
+
+/**
+ * Utility for running root commands with synchronized external storage mounts.
+ *
+ * Background:
+ * 1. Vold (Android's volume manager) mounts external storage (SD cards, USB-OTG drives)
+ *    into `/mnt/media_rw/<volId>` in the root namespace and creates per-process mount namespaces.
+ * 2. In root's namespace, `/storage` is an empty in-memory tmpfs (~3GB).
+ * 3. By ensuring volume mounts are mirrored into `/storage/<volId>` via [StorageMountManager]
+ *    and optionally entering the app namespace when available, root commands seamlessly operate
+ *    on the real physical block device (e.g. 400GB USB drive) instead of the phantom tmpfs.
+ */
+object RootNamespace {
+    @Volatile
+    private var nsenterChecked: Boolean = false
+    @Volatile
+    private var nsenterCommand: String? = null // resolved invocation, e.g. "nsenter" or "<busybox path> nsenter"
+
+    /**
+     * Checks if `nsenter` is available and functioning on the device.
+     * Caches the result after the first check.
+     */
+    suspend fun isNsenterAvailable(): Boolean = withContext(Dispatchers.IO) {
+        resolveNsenterCommand() != null
+    }
+
+    /**
+     * Resolves a working `nsenter` invocation, trying the system binary first and
+     * falling back to the app's bundled BusyBox (which includes an `nsenter` applet).
+     * `nsenter` isn't a stock Android/toybox applet -- on many devices/ROMs it simply
+     * isn't on PATH at all, in which case relying on a bare `nsenter` call silently
+     * no-ops (the command falls through unwrapped) even when the caller explicitly
+     * asked for it. Falling back to BusyBox's copy, which this app already bundles
+     * and uses everywhere else, avoids that silent failure. Result is cached after
+     * the first successful/failed resolution.
+     */
+    private suspend fun resolveNsenterCommand(): String? = withContext(Dispatchers.IO) {
+        if (nsenterChecked) return@withContext nsenterCommand
+
+        val pid = Process.myPid()
+        val candidates = listOf("nsenter", "${Constants.BUSYBOX_BINARY_PATH} nsenter")
+        for (candidate in candidates) {
+            // Note: 'echo' is a shell builtin on Android, so we must invoke via sh -c
+            val result = Shell.cmd("$candidate -t $pid -m /system/bin/sh -c 'echo ok' 2>/dev/null").exec()
+            if (result.isSuccess && result.out.any { it.contains("ok") }) {
+                nsenterCommand = candidate
+                nsenterChecked = true
+                return@withContext candidate
+            }
+        }
+        nsenterChecked = true
+        nsenterCommand = null
+        null
+    }
+
+    /**
+     * Determines whether a given path is an external/removable storage path that
+     * requires mount namespace wrapping (e.g. `/storage/1234-5678/...`, `/mnt/media_rw/...`).
+     */
+    fun isExternalStorage(path: String?): Boolean {
+        if (path.isNullOrBlank()) return false
+        val normalized = path.trim()
+        return (normalized.startsWith("/storage/") && !normalized.startsWith("/storage/emulated")) ||
+                normalized.startsWith("/mnt/media_rw/") ||
+                normalized.startsWith("/mnt/pass_through/0/")
+    }
+
+    /**
+     * Wraps a shell command with `nsenter` if targeting external storage or if
+     * [forceNsenter] is set, provided `nsenter` is available.
+     *
+     * @param cmd The shell command string to execute
+     * @param targetPath Path being operated on (used to auto-detect if nsenter is needed)
+     * @param forceNsenter Explicitly force nsenter wrapping regardless of targetPath
+     */
+    suspend fun wrapCmd(
+        cmd: String,
+        targetPath: String? = null,
+        forceNsenter: Boolean = false
+    ): String {
+        val targetsExternal = targetPath != null && isExternalStorage(targetPath)
+        if (targetsExternal) {
+            StorageMountManager.ensureVolumeMounted(targetPath)
+        }
+        // Root's own mount namespace only sees external volumes if the bind-mount in
+        // ensureVolumeMounted actually took effect, which isn't reliable on every
+        // device/ROM. The app's own process already has a working FUSE-backed view of
+        // external storage (the same one e.g. the Files app uses) -- entering THAT
+        // namespace via nsenter (while keeping root privilege) is the reliable path,
+        // so external-storage targets always route through it, not just when a call
+        // site remembers to pass forceNsenter explicitly.
+        if (forceNsenter || targetsExternal) {
+            val nsenterCmd = resolveNsenterCommand()
+            if (nsenterCmd != null) {
+                val pid = Process.myPid()
+                return "$nsenterCmd -t $pid -m /system/bin/sh -c ${ContainerCommandBuilder.quote(cmd)}"
+            }
+        }
+        return cmd
+    }
+
+    /**
+     * Rewrites [cmd] so any occurrence of `/storage/<volId>` (the path derived
+     * from [targetPath]) is replaced with the CURRENT physical mount point for
+     * that volume (e.g. `/mnt/media_rw/<volId>`), if one can be found.
+     *
+     * This is preferred over bind-mounting or nsenter-ing into `/storage/<volId>`:
+     * that path is a *view* of the volume (a bind mount in root's namespace, or
+     * a FUSE passthrough in the app's namespace) that's only refreshed when
+     * something notices the volume changed. On USB disconnect/reconnect, vold
+     * tears down and recreates the *physical* mount fresh, but neither of those
+     * views necessarily follows along automatically -- root's bind mount can be
+     * left pointing at the old, dead mount instance, and even the app's own
+     * process's mount namespace was observed to need a full app restart to pick
+     * up a replugged drive. `/mnt/media_rw/<volId>` is vold's own live mount in
+     * root's *global*, always-current namespace, so operating on it directly
+     * sidesteps all of that staleness -- no bind mount, no nsenter, no restart.
+     *
+     * Returns null if [targetPath]'s volume can't be resolved to a physical
+     * mount right now (removed, or a provider we don't recognize), so the
+     * caller can fall back to the /storage/<volId> + nsenter path.
+     */
+    private suspend fun physicalizeCmd(cmd: String, targetPath: String): String? {
+        val volId = StorageMountManager.extractVolumeId(targetPath) ?: return null
+        val storagePrefix = "/storage/$volId"
+        if (!cmd.contains(storagePrefix)) return null
+        val physicalBase = StorageMountManager.findPhysicalMountPoint(volId) ?: return null
+        return cmd.replace(storagePrefix, physicalBase)
+    }
+
+    /**
+     * Executes a command using libsu, preferring the volume's physical mount
+     * point over `/storage/<volId>` when possible (see [physicalizeCmd]), and
+     * falling back to `/storage/<volId>` (bind-mounted/nsenter'd as needed) only
+     * when the physical mount can't be resolved.
+     */
+    suspend fun exec(
+        cmd: String,
+        targetPath: String? = null,
+        forceNsenter: Boolean = false
+    ): Shell.Result = withContext(Dispatchers.IO) {
+        if (targetPath != null && isExternalStorage(targetPath)) {
+            val physicalCmd = physicalizeCmd(cmd, targetPath)
+            if (physicalCmd != null) {
+                return@withContext Shell.cmd(physicalCmd).exec()
+            }
+            StorageMountManager.ensureVolumeMounted(targetPath)
+        }
+        val finalCmd = wrapCmd(cmd, targetPath, forceNsenter)
+        Shell.cmd(finalCmd).exec()
+    }
+
+    /**
+     * Writes a shell script to temporary cache, makes it executable, runs it --
+     * preferring the volume's physical mount point over `/storage/<volId>` when
+     * possible (see [physicalizeCmd]) -- and cleans it up afterwards.
+     */
+    suspend fun runScript(
+        scriptContent: String,
+        context: Context,
+        targetPath: String? = null,
+        forceNsenter: Boolean = false
+    ): Shell.Result = withContext(Dispatchers.IO) {
+        var content = scriptContent
+        var usedPhysical = false
+        if (targetPath != null && isExternalStorage(targetPath)) {
+            val physicalContent = physicalizeCmd(scriptContent, targetPath)
+            if (physicalContent != null) {
+                content = physicalContent
+                usedPhysical = true
+            } else {
+                StorageMountManager.ensureVolumeMounted(targetPath)
+            }
+        }
+        val scriptFile = File("${context.cacheDir}/.ds_ns_${System.currentTimeMillis()}_${Process.myPid()}.sh")
+        try {
+            FileOutputStream(scriptFile).use { fos ->
+                fos.write(content.toByteArray())
+            }
+            Shell.cmd("chmod 755 ${ContainerCommandBuilder.quote(scriptFile.absolutePath)}").exec()
+
+            // Invoke via `sh`, not a direct exec of the file path -- app-private cache
+            // directories can be SELinux/mount-labeled to deny direct execution even
+            // after chmod 755, failing with a misleading "No such file or directory".
+            // `sh "$script"` only needs read access, sidestepping that restriction.
+            val runCmd = "sh ${ContainerCommandBuilder.quote(scriptFile.absolutePath)}"
+            if (usedPhysical) {
+                Shell.cmd(runCmd).exec()
+            } else {
+                exec(runCmd, targetPath, forceNsenter)
+            }
+        } finally {
+            try {
+                scriptFile.delete()
+            } catch (e: Exception) {
+                // Ignore cleanup errors
+            }
+        }
+    }
+}

--- a/Android/app/src/main/java/com/droidspaces/app/util/SafPathResolver.kt
+++ b/Android/app/src/main/java/com/droidspaces/app/util/SafPathResolver.kt
@@ -1,0 +1,198 @@
+package com.droidspaces.app.util
+
+import android.content.Context
+import android.content.Intent
+import android.net.Uri
+import android.os.Environment
+import android.provider.DocumentsContract
+import android.provider.MediaStore
+import android.util.Log
+
+/**
+ * Resolves real filesystem paths from Android Storage Access Framework (SAF) Uris,
+ * supporting both Document Uris (from ACTION_OPEN_DOCUMENT / OpenDocument) and
+ * Tree Uris (from ACTION_OPEN_DOCUMENT_TREE / OpenDocumentTree).
+ *
+ * It seamlessly translates Android document IDs such as "FFF6-F07B:Test/h/rootfs.img"
+ * into canonical root paths such as "/storage/FFF6-F07B/Test/h/rootfs.img".
+ */
+object SafPathResolver {
+    private const val TAG = "SafPathResolver"
+    private const val EXTERNAL_STORAGE_AUTHORITY = "com.android.externalstorage.documents"
+    private const val DOWNLOADS_AUTHORITY = "com.android.providers.downloads.documents"
+    private const val MEDIA_AUTHORITY = "com.android.providers.media.documents"
+
+    /**
+     * Persist read/write access to [uri] across reboots.
+     */
+    fun takePersistablePermission(context: Context, uri: Uri) {
+        try {
+            val flags = Intent.FLAG_GRANT_READ_URI_PERMISSION or Intent.FLAG_GRANT_WRITE_URI_PERMISSION
+            context.contentResolver.takePersistableUriPermission(uri, flags)
+        } catch (e: Exception) {
+            Log.w(TAG, "Could not persist permission for $uri", e)
+        }
+    }
+
+    /**
+     * Converts any SAF Uri (Document or Tree) into an absolute filesystem path.
+     * E.g. "content://.../document/FFF6-F07B:Test/h/rootfs.img" -> "/storage/FFF6-F07B/Test/h/rootfs.img"
+     */
+    fun resolvePathFromUri(context: Context, uri: Uri): String? {
+        return try {
+            // 1. Direct file URI
+            if (uri.scheme == "file") {
+                return uri.path?.let { normalizePath(it) }
+            }
+
+            // 2. Standard ExternalStorageProvider
+            if (uri.authority == EXTERNAL_STORAGE_AUTHORITY) {
+                val docId = getDocId(context, uri) ?: extractDocIdFromUri(uri)
+                if (docId != null) {
+                    val resolved = parseDocIdToPath(docId)
+                    if (resolved != null) return resolved
+                }
+            }
+
+            // 3. Downloads Provider
+            if (uri.authority == DOWNLOADS_AUTHORITY) {
+                val docId = try { DocumentsContract.getDocumentId(uri) } catch (e: Exception) { null }
+                if (docId != null) {
+                    if (docId.startsWith("raw:")) {
+                        return normalizePath(docId.removePrefix("raw:"))
+                    }
+                    val resolved = parseDocIdToPath(docId)
+                    if (resolved != null) return resolved
+                }
+            }
+
+            // 4. Media Provider
+            if (uri.authority == MEDIA_AUTHORITY) {
+                try {
+                    val projection = arrayOf(MediaStore.MediaColumns.DATA)
+                    context.contentResolver.query(uri, projection, null, null, null)?.use { cursor ->
+                        if (cursor.moveToFirst()) {
+                            val colIndex = cursor.getColumnIndexOrThrow(MediaStore.MediaColumns.DATA)
+                            val path = cursor.getString(colIndex)
+                            if (!path.isNullOrBlank()) {
+                                return normalizePath(path)
+                            }
+                        }
+                    }
+                } catch (e: Exception) {
+                    Log.w(TAG, "Failed querying MediaStore column for $uri", e)
+                }
+            }
+
+            // 5. Fallback: Parse path string for encoded document IDs (e.g. /documents/FFF6-F07B:Test/...)
+            val rawPath = uri.path
+            if (!rawPath.isNullOrBlank()) {
+                val normalized = normalizePath(rawPath)
+                if (normalized.isNotBlank() && !normalized.startsWith("/documents/") && !normalized.startsWith("/document/")) {
+                    return normalized
+                }
+            }
+
+            uri.path?.let { normalizePath(it) }
+        } catch (e: Exception) {
+            Log.e(TAG, "Failed to resolve path from URI: $uri", e)
+            uri.path?.let { normalizePath(it) }
+        }
+    }
+
+    /**
+     * Backward-compatible alias for [resolvePathFromUri].
+     */
+    fun resolvePathFromTreeUri(context: Context, treeUri: Uri): String? {
+        return resolvePathFromUri(context, treeUri)
+    }
+
+    /**
+     * Extracts document ID safely from any SAF Document or Tree Uri without throwing.
+     */
+    private fun getDocId(context: Context, uri: Uri): String? {
+        return try {
+            if (DocumentsContract.isDocumentUri(context, uri)) {
+                DocumentsContract.getDocumentId(uri)
+            } else if (DocumentsContract.isTreeUri(uri)) {
+                DocumentsContract.getTreeDocumentId(uri)
+            } else {
+                null
+            }
+        } catch (e: Exception) {
+            null
+        }
+    }
+
+    /**
+     * Extracts docId by parsing the URI path directly if DocumentsContract methods fail.
+     */
+    private fun extractDocIdFromUri(uri: Uri): String? {
+        val path = uri.path ?: return null
+        val decoded = Uri.decode(path)
+
+        val match = Regex("""/(?:document|documents|tree)/([^/:]+:[^/]*.*)$""").find(decoded)
+            ?: Regex("""/(?:document|documents|tree)/([^/:]+:.*)""").find(decoded)
+        if (match != null) {
+            return match.groupValues[1]
+        }
+
+        if (decoded.contains(":")) {
+            val matchColon = Regex("""([^/:]+:[^/]*.*)$""").find(decoded)
+            if (matchColon != null) {
+                return matchColon.groupValues[1]
+            }
+        }
+
+        return null
+    }
+
+    /**
+     * Converts a document ID (e.g. "FFF6-F07B:Test/h/rootfs.img" or "primary:Download/img.img")
+     * to a filesystem path.
+     */
+    private fun parseDocIdToPath(docId: String): String? {
+        val cleanDocId = docId.removePrefix("raw:")
+        val split = cleanDocId.split(":", limit = 2)
+        if (split.isEmpty()) return null
+
+        val volumeId = split[0]
+        val relativePath = if (split.size > 1) split[1].trimStart('/') else ""
+
+        val basePath = if (volumeId.equals("primary", ignoreCase = true)) {
+            Environment.getExternalStorageDirectory().absolutePath
+        } else {
+            "/storage/$volumeId"
+        }
+
+        val fullPath = if (relativePath.isEmpty()) basePath else "$basePath/$relativePath"
+        return StorageChecker.normalizeStorageDir(fullPath)
+    }
+
+    /**
+     * Normalizes any path string that may contain SAF document syntax
+     * (e.g. "/documents/FFF6-F07B:Test/h/rootfs.img" -> "/storage/FFF6-F07B/Test/h/rootfs.img").
+     */
+    fun normalizePath(rawPath: String): String {
+        val trimmed = rawPath.trim()
+        val decoded = Uri.decode(trimmed)
+
+        // Check for colon notation: e.g. /documents/FFF6-F07B:Test/h/rootfs.img or FFF6-F07B:Test/h/rootfs.img
+        if (decoded.contains(":")) {
+            val match = Regex("""(?:^|/)(?:document|documents|tree)?/??([0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}|primary|[a-zA-Z0-9_-]+):(.*)""").find(decoded)
+            if (match != null) {
+                val volumeId = match.groupValues[1]
+                val relativePath = match.groupValues[2].trimStart('/')
+                val basePath = if (volumeId.equals("primary", ignoreCase = true)) {
+                    Environment.getExternalStorageDirectory().absolutePath
+                } else {
+                    "/storage/$volumeId"
+                }
+                val fullPath = if (relativePath.isEmpty()) basePath else "$basePath/$relativePath"
+                return StorageChecker.normalizeStorageDir(fullPath)
+            }
+        }
+
+        return StorageChecker.normalizeStorageDir(decoded)
+    }
+}

--- a/Android/app/src/main/java/com/droidspaces/app/util/SparseImageInstaller.kt
+++ b/Android/app/src/main/java/com/droidspaces/app/util/SparseImageInstaller.kt
@@ -11,10 +11,12 @@ import java.io.FileOutputStream
 /**
  * Native Kotlin implementation of the Sparse Image Installer.
  * Optimized for stability on Samsung and other devices with strict kernel policies.
- * Uses libsu directly to manage the lifecycle: Truncate -> Format -> Mount -> Extract -> Unmount.
+ * Manages the lifecycle: Truncate -> Format -> Mount -> Extract -> PostFix -> EmbedConfig -> Unmount.
+ *
+ * Uses [RootNamespace] and [StorageMountManager] when [imgPath] is located on external storage
+ * (SD card / USB-OTG) so operations target the real mount points.
  */
 object SparseImageInstaller {
-    private const val TAG = "SparseImageInstaller"
 
     /**
      * Extracts a tarball into a sparse image file.
@@ -24,6 +26,7 @@ object SparseImageInstaller {
      * @param imgPath The target path for the rootfs.img
      * @param mountPoint The temporary directory where the image will be mounted
      * @param sizeGB The desired size of the sparse image in GB
+     * @param configContent Optional container configuration content to embed into image for portability
      * @param logger Logger for real-time progress updates
      */
     suspend fun extract(
@@ -32,145 +35,301 @@ object SparseImageInstaller {
         imgPath: String,
         mountPoint: String,
         sizeGB: Int,
+        configContent: String? = null,
         logger: ContainerLogger
     ) = withContext(Dispatchers.IO) {
+        val busybox = Constants.BUSYBOX_BINARY_PATH
+        val quotedImg = ContainerCommandBuilder.quote(imgPath)
+        val postFixScriptFile = File("${context.cacheDir}/post_extract_fixes.sh")
+        val tempConfigFile = if (!configContent.isNullOrBlank()) {
+            File("${context.cacheDir}/.ds_embed_init_${System.currentTimeMillis()}.config")
+        } else null
+
         try {
+            // Ensure volume is synchronized if on external storage
+            if (RootNamespace.isExternalStorage(imgPath)) {
+                StorageMountManager.ensureVolumeMounted(imgPath)
+            }
+
             // 1. Create Sparse Image
             logger.i("[SPARSE] Creating sparse image: ${sizeGB}GB")
-            val truncateCmd = "truncate -s ${sizeGB}G \"$imgPath\" || ${Constants.BUSYBOX_BINARY_PATH} truncate -s ${sizeGB}G \"$imgPath\""
-            runRootCommand(truncateCmd, logger) ?: throw Exception("Failed to create sparse image file")
+            val truncateCmd = "truncate -s ${sizeGB}G $quotedImg || $busybox truncate -s ${sizeGB}G $quotedImg"
+            val truncateRes = RootNamespace.exec(truncateCmd, targetPath = imgPath)
+            if (!truncateRes.isSuccess) {
+                val err = (truncateRes.out + truncateRes.err).joinToString("\n").trim()
+                throw Exception("Failed to create sparse image file: $err")
+            }
 
-            // Wait for filesystem to settle
-            Shell.cmd("${Constants.BUSYBOX_BINARY_PATH} sync").exec()
+            // Settle filesystem
+            RootNamespace.exec("$busybox sync 2>/dev/null || sync 2>/dev/null", targetPath = imgPath)
             delay(1000)
 
             // 2. Format as ext4
             logger.i("[SPARSE] Formatting sparse image as ext4...")
-            val mkfsCmd = "mkfs.ext4 -F -E lazy_itable_init=0,lazy_journal_init=0 -L \"droidspaces-rootfs\" \"$imgPath\" || mke2fs -t ext4 -F -E lazy_itable_init=0,lazy_journal_init=0 -L \"droidspaces-rootfs\" \"$imgPath\""
-            runRootCommand(mkfsCmd, logger) ?: throw Exception("Failed to format sparse image as ext4")
+            val mkfsCmd = "mkfs.ext4 -F -E lazy_itable_init=0,lazy_journal_init=0 -L \"droidspaces-rootfs\" $quotedImg || " +
+                    "mke2fs -t ext4 -F -E lazy_itable_init=0,lazy_journal_init=0 -L \"droidspaces-rootfs\" $quotedImg"
+            val mkfsRes = RootNamespace.exec(mkfsCmd, targetPath = imgPath)
+            if (!mkfsRes.isSuccess) {
+                val err = (mkfsRes.out + mkfsRes.err).joinToString("\n").trim()
+                throw Exception("Failed to format sparse image as ext4: $err")
+            }
 
             // 2b. Reclaim reserved blocks (tune2fs -m 0)
             logger.i("[SPARSE] Reclaiming reserved disk space (tune2fs -m 0)...")
-            runRootCommand("tune2fs -m 0 \"$imgPath\"", logger)
+            RootNamespace.exec("tune2fs -m 0 $quotedImg", targetPath = imgPath)
 
             // 2c. Verify with e2fsck
             logger.i("[SPARSE] Verifying filesystem integrity (e2fsck)...")
-            val checkResult = Shell.cmd("e2fsck -fy \"$imgPath\"").exec()
-            // e2fsck exit codes: 0 (No Errors), 1 (Corrected), 2 (Reboot suggested - safe for us), 4 (Uncorrected)
+            val checkResult = RootNamespace.exec("e2fsck -fy $quotedImg", targetPath = imgPath)
+            // e2fsck exit codes: 0 (Clean), 1 (Corrected), 2 (Reboot suggested - safe for us), 4+ (Uncorrected/Error)
             if (checkResult.code >= 4) {
-                logger.e("[SPARSE] e2fsck failed with exit code ${checkResult.code}")
+                val err = (checkResult.out + checkResult.err).joinToString("\n").trim()
+                logger.e("[SPARSE] e2fsck failed with exit code ${checkResult.code}: $err")
                 throw Exception("Filesystem verification failed (e2fsck error ${checkResult.code})")
             }
             logger.i("[SPARSE] Filesystem integrity verified (code ${checkResult.code})")
 
-            // 2d. Settle Delay (Samsung/Kernel 3.18 stability)
+            // 2d. Settle Delay (Samsung/Kernel stability)
             logger.i("[SPARSE] Waiting for filesystem to settle (2.5s)...")
-            Shell.cmd("${Constants.BUSYBOX_BINARY_PATH} sync").exec()
+            RootNamespace.exec("$busybox sync 2>/dev/null || sync 2>/dev/null", targetPath = imgPath)
             delay(2500)
 
-            // 3. Create Mount Point
-            logger.i("[SPARSE] Creating mount point: $mountPoint")
-            runRootCommand("mkdir -p \"$mountPoint\"", logger) ?: throw Exception("Failed to create mount point")
-
-            // 3b. Apply correct SELinux context to the image file
-            logger.i("[SPARSE] Applying SELinux context (vold_data_file)...")
-            runRootCommand("chcon u:object_r:vold_data_file:s0 \"$imgPath\"", logger) ?: throw Exception("Failed to apply SELinux context to image")
-
-            // 4. Mount Image (Minimal options for Max compatibility)
-            logger.i("[SPARSE] Mounting sparse image (Minimal loop,rw)...")
-            val mountOptions = "loop,rw,nodelalloc,noatime,nodiratime,init_itable=0"
-            val mountCmd = "${Constants.BUSYBOX_BINARY_PATH} mount -t ext4 -o $mountOptions \"$imgPath\" \"$mountPoint\" || " +
-                          "mount -t ext4 -o $mountOptions \"$imgPath\" \"$mountPoint\""
-
-            runRootCommand(mountCmd, logger) ?: throw Exception("Failed to mount sparse image. Your kernel might not support loop mounts here.")
-
+            // 3. Prepare post-extraction fix script
             try {
-                // 5. Extract Tarball
-                logger.i("[SPARSE] Extracting tarball to mount point...")
-                val isXz = tarball.name.lowercase().endsWith(".xz")
-                val extractCmd = if (isXz) {
-                    "cd \"$mountPoint\" && ${Constants.BUSYBOX_BINARY_PATH} xzcat \"${tarball.absolutePath}\" | ${Constants.BUSYBOX_BINARY_PATH} tar -xpf - 2>&1"
-                } else {
-                    "cd \"$mountPoint\" && ${Constants.BUSYBOX_BINARY_PATH} tar -xzpf \"${tarball.absolutePath}\" 2>&1"
+                context.assets.open("post_extract_fixes.sh").use { inputStream ->
+                    FileOutputStream(postFixScriptFile).use { outputStream ->
+                        inputStream.copyTo(outputStream)
+                    }
                 }
-
-                // For extraction, we stream the output to the logger's debug level
-                val extractResult = Shell.cmd(extractCmd).exec()
-                if (!extractResult.isSuccess) {
-                    throw Exception("Tarball extraction failed: ${extractResult.err.joinToString("\n")}")
-                }
-                logger.i("[SPARSE] Extraction completed successfully")
-
-                // 6. Apply Post-Extraction Fixes (using script as requested)
-                applyScriptFixes(context, mountPoint, logger)
-
-            } finally {
-                // 7. Unmount (Always attempt)
-                logger.i("[SPARSE] Unmounting sparse image...")
-                Shell.cmd("${Constants.BUSYBOX_BINARY_PATH} sync").exec()
-                delay(1000)
-
-                val umountCmd = "${Constants.BUSYBOX_BINARY_PATH} umount -l \"$mountPoint\" || umount -l \"$mountPoint\""
-                Shell.cmd(umountCmd).exec()
-
-                // Cleanup mount point directory
-                Shell.cmd("rmdir \"$mountPoint\"").exec()
+                Shell.cmd("chmod 755 ${ContainerCommandBuilder.quote(postFixScriptFile.absolutePath)}").exec()
+            } catch (e: Exception) {
+                logger.w("[POST-FIX] Warning: Failed to load post_extract_fixes.sh: ${e.message}")
             }
 
-        } catch (e: Exception) {
-            logger.e("[SPARSE] Error: ${e.message}")
-            // Cleanup incomplete image on failure
-            Shell.cmd("rm -f \"$imgPath\"").exec()
-            throw e
-        }
-    }
-
-    /**
-     * Runs a root command and logs output. Returns result if successful, null otherwise.
-     */
-    private suspend fun runRootCommand(cmd: String, logger: ContainerLogger): Shell.Result? {
-        val result = Shell.cmd(cmd).exec()
-        result.out.forEach { line -> if (line.isNotBlank()) logger.d(line) }
-        result.err.forEach { line -> if (line.isNotBlank()) logger.w(line) }
-        return if (result.isSuccess) result else null
-    }
-
-    /**
-     * Runs the post_extract_fixes.sh script on the given rootfs path.
-     */
-    private suspend fun applyScriptFixes(context: Context, rootfs: String, logger: ContainerLogger) {
-        logger.i("[POST-FIX] Running post-extraction fixes script...")
-        val postFixScriptFile = File("${context.cacheDir}/post_extract_fixes.sh")
-        try {
-            context.assets.open("post_extract_fixes.sh").use { inputStream ->
-                FileOutputStream(postFixScriptFile).use { outputStream ->
-                    inputStream.copyTo(outputStream)
+            // Write temp config to embed if provided
+            if (tempConfigFile != null && configContent != null) {
+                FileOutputStream(tempConfigFile).use { fos ->
+                    fos.write(configContent.toByteArray())
                 }
             }
-            Shell.cmd("chmod 755 \"${postFixScriptFile.absolutePath}\"").exec()
 
-            val result = Shell.cmd("BUSYBOX_PATH=${Constants.BUSYBOX_BINARY_PATH} \"${postFixScriptFile.absolutePath}\" \"$rootfs\" 2>&1").exec()
+            // 4. Run Mount -> Extract -> PostFix -> EmbedConfig -> Unmount in a single atomic script
+            logger.i("[SPARSE] Mounting and extracting container filesystem...")
+            val isXz = tarball.name.lowercase().endsWith(".xz")
+            val scriptContent = buildInstallerScript(
+                busybox = busybox,
+                imgPath = imgPath,
+                mountPoint = mountPoint,
+                tarballPath = tarball.absolutePath,
+                postFixScriptPath = postFixScriptFile.absolutePath,
+                tempConfigPath = tempConfigFile?.absolutePath,
+                isXz = isXz
+            )
 
-            result.out.forEach { line ->
+            val installResult = RootNamespace.runScript(
+                scriptContent = scriptContent,
+                context = context,
+                targetPath = imgPath
+            )
+
+            // Process script output
+            var installFailed = !installResult.isSuccess
+            var failureReason = ""
+
+            installResult.out.forEach { line ->
                 val trimmed = line.trim()
                 if (trimmed.isNotEmpty()) {
                     when {
+                        trimmed.startsWith("[SPARSE-MOUNT-OK]") -> logger.i("[SPARSE] Sparse image mounted successfully")
+                        trimmed.startsWith("[SPARSE-EXTRACTING]") -> logger.i("[SPARSE] Extracting tarball to mount point...")
+                        trimmed.startsWith("[SPARSE-EXTRACT-WARN]") -> logger.w(trimmed)
+                        trimmed.startsWith("[SPARSE-POSTFIX]") -> logger.i("[POST-FIX] Running post-extraction fixes...")
+                        trimmed.startsWith("[SPARSE-EMBED-OK]") -> logger.i("[SPARSE] Embedded container configuration into image")
+                        trimmed.startsWith("[SPARSE-EMBED-FAIL]") -> logger.w("[SPARSE] Warning: $trimmed")
                         trimmed.startsWith("[POST-FIX-WARN]") -> logger.w(trimmed)
                         trimmed.startsWith("[POST-FIX]") -> logger.i(trimmed)
+                        trimmed.startsWith("[SPARSE-ERROR]") -> {
+                            installFailed = true
+                            failureReason = trimmed.removePrefix("[SPARSE-ERROR]").trim()
+                            logger.e(trimmed)
+                        }
+                        trimmed.startsWith("[SPARSE-SUCCESS]") -> logger.i("[SPARSE] Extraction completed successfully")
                         else -> logger.d(trimmed)
                     }
                 }
             }
 
-            if (!result.isSuccess) {
-                logger.w("Warning: Post-extraction fixes failed, but continuing.")
-            } else {
-                logger.i("[POST-FIX] Fixes applied successfully")
+            installResult.err.forEach { line ->
+                val trimmed = line.trim()
+                if (trimmed.isNotEmpty()) {
+                    logger.w(trimmed)
+                    if (failureReason.isEmpty()) {
+                        failureReason = trimmed
+                    }
+                }
             }
+
+            if (installFailed) {
+                val reason = if (failureReason.isNotEmpty()) failureReason else "Exit code: ${installResult.code}"
+                throw Exception("Failed to mount or extract sparse image: $reason")
+            }
+
+            logger.i("[SPARSE] Sparse image setup completed successfully.")
+
         } catch (e: Exception) {
-            logger.w("Warning: Failed to run post-fix script: ${e.message}")
+            logger.e("[SPARSE] Error: ${e.message}")
+            // Cleanup incomplete image on failure
+            RootNamespace.exec("rm -f $quotedImg 2>/dev/null", targetPath = imgPath)
+            throw e
         } finally {
-            postFixScriptFile.delete()
+            try {
+                postFixScriptFile.delete()
+                tempConfigFile?.delete()
+            } catch (e: Exception) {
+                // Ignore cleanup errors
+            }
         }
+    }
+
+    /**
+     * Builds the self-contained shell script that handles mount, extract, post-fixes,
+     * config embedding, and guaranteed unmount/cleanup via shell trap.
+     */
+    private fun buildInstallerScript(
+        busybox: String,
+        imgPath: String,
+        mountPoint: String,
+        tarballPath: String,
+        postFixScriptPath: String,
+        tempConfigPath: String?,
+        isXz: Boolean
+    ): String = buildString {
+        val qImg = ContainerCommandBuilder.quote(imgPath)
+        val qMnt = ContainerCommandBuilder.quote(mountPoint)
+        val qTar = ContainerCommandBuilder.quote(tarballPath)
+        val qPost = ContainerCommandBuilder.quote(postFixScriptPath)
+        val qCfg = tempConfigPath?.let { ContainerCommandBuilder.quote(it) }
+
+        appendLine("#!/system/bin/sh")
+        appendLine("set -e")
+        appendLine()
+        appendLine("BUSYBOX=\"$busybox\"")
+        appendLine("IMG=$qImg")
+        appendLine("MNT=$qMnt")
+        appendLine("TARBALL=$qTar")
+        appendLine("POST_FIX=$qPost")
+        if (qCfg != null) {
+            appendLine("TMP_CFG=$qCfg")
+        }
+        appendLine("LOOP_DEV=\"\"")
+        appendLine()
+        appendLine("# Ensure basic loop device nodes exist")
+        appendLine("for i in 0 1 2 3 4 5 6 7; do")
+        appendLine("    [ -e \"/dev/block/loop\$i\" ] || mknod \"/dev/block/loop\$i\" b 7 \"\$i\" 2>/dev/null || true")
+        appendLine("    [ -e \"/dev/loop\$i\" ] || mknod \"/dev/loop\$i\" b 7 \"\$i\" 2>/dev/null || true")
+        appendLine("done")
+        appendLine()
+        appendLine("# Create mount point")
+        appendLine("mkdir -p \"\$MNT\" 2>/dev/null || \"\$BUSYBOX\" mkdir -p \"\$MNT\" 2>/dev/null || true")
+        appendLine()
+        appendLine("# Best-effort SELinux context on /data")
+        appendLine("if echo \"\$IMG\" | grep -q \"^/data/\"; then")
+        appendLine("    chcon u:object_r:vold_data_file:s0 \"\$IMG\" 2>/dev/null || true")
+        appendLine("fi")
+        appendLine()
+        appendLine("# Cleanup handler - always unmounts and removes mount point")
+        appendLine("cleanup() {")
+        appendLine("    \"\$BUSYBOX\" sync 2>/dev/null || sync 2>/dev/null || true")
+        appendLine("    \"\$BUSYBOX\" umount -l \"\$MNT\" 2>/dev/null || umount -l \"\$MNT\" 2>/dev/null || true")
+        appendLine("    if [ -n \"\$LOOP_DEV\" ]; then")
+        appendLine("        \"\$BUSYBOX\" losetup -d \"\$LOOP_DEV\" 2>/dev/null || losetup -d \"\$LOOP_DEV\" 2>/dev/null || true")
+        appendLine("    fi")
+        appendLine("    \"\$BUSYBOX\" rmdir \"\$MNT\" 2>/dev/null || rmdir \"\$MNT\" 2>/dev/null || true")
+        appendLine("}")
+        appendLine("trap cleanup EXIT")
+        appendLine()
+        appendLine("# 1. Mount image")
+        appendLine("MOUNT_OK=0")
+        appendLine("if mount -t ext4 -o loop,rw \"\$IMG\" \"\$MNT\" 2>/dev/null || \\")
+        appendLine("   \"\$BUSYBOX\" mount -t ext4 -o loop,rw \"\$IMG\" \"\$MNT\" 2>/dev/null; then")
+        appendLine("    MOUNT_OK=1")
+        appendLine("else")
+        appendLine("    # Fallback: allocate loop device explicitly with losetup")
+        appendLine("    LOOP_DEV=\$(losetup -f 2>/dev/null || \"\$BUSYBOX\" losetup -f 2>/dev/null || true)")
+        appendLine("    if [ -n \"\$LOOP_DEV\" ]; then")
+        appendLine("        # Android reserves low loop indices (0-40+) for APEX modules mounted")
+        appendLine("        # at boot, so losetup -f often returns a high index (e.g. loop43) whose")
+        appendLine("        # device node was never created -- only 0-7 are pre-created above. Make")
+        appendLine("        # sure the SPECIFIC node losetup picked actually exists before using it.")
+        appendLine("        LOOP_NUM=\$(echo \"\$LOOP_DEV\" | \"\$BUSYBOX\" sed 's#.*loop##' 2>/dev/null || echo \"\$LOOP_DEV\" | sed 's#.*loop##')")
+        appendLine("        if [ -n \"\$LOOP_NUM\" ]; then")
+        appendLine("            [ -e \"\$LOOP_DEV\" ] || mknod \"\$LOOP_DEV\" b 7 \"\$LOOP_NUM\" 2>/dev/null || \"\$BUSYBOX\" mknod \"\$LOOP_DEV\" b 7 \"\$LOOP_NUM\" 2>/dev/null || true")
+        appendLine("            [ -e \"/dev/block/loop\$LOOP_NUM\" ] || mknod \"/dev/block/loop\$LOOP_NUM\" b 7 \"\$LOOP_NUM\" 2>/dev/null || true")
+        appendLine("            [ -e \"/dev/loop\$LOOP_NUM\" ] || mknod \"/dev/loop\$LOOP_NUM\" b 7 \"\$LOOP_NUM\" 2>/dev/null || true")
+        appendLine("        fi")
+        appendLine("        if losetup \"\$LOOP_DEV\" \"\$IMG\" 2>/dev/null || \"\$BUSYBOX\" losetup \"\$LOOP_DEV\" \"\$IMG\" 2>/dev/null; then")
+        appendLine("            if mount -t ext4 -o rw \"\$LOOP_DEV\" \"\$MNT\" 2>/dev/null || \\")
+        appendLine("               \"\$BUSYBOX\" mount -t ext4 -o rw \"\$LOOP_DEV\" \"\$MNT\" 2>/dev/null; then")
+        appendLine("                MOUNT_OK=1")
+        appendLine("            else")
+        appendLine("                losetup -d \"\$LOOP_DEV\" 2>/dev/null || \"\$BUSYBOX\" losetup -d \"\$LOOP_DEV\" 2>/dev/null || true")
+        appendLine("                LOOP_DEV=\"\"")
+        appendLine("            fi")
+        appendLine("        fi")
+        appendLine("    fi")
+        appendLine("fi")
+        appendLine()
+        appendLine("if [ \"\$MOUNT_OK\" -ne 1 ]; then")
+        appendLine("    echo \"[SPARSE-ERROR] Mount failed. Diagnostic output:\"")
+        appendLine("    echo \"[SPARSE-DIAG] LOOP_DEV=\$LOOP_DEV\"")
+        appendLine("    losetup -a 2>&1 || \"\$BUSYBOX\" losetup -a 2>&1 || true")
+        appendLine("    ls -la /dev/block/loop* 2>&1 || true")
+        appendLine("    mount -t ext4 -o loop,rw \"\$IMG\" \"\$MNT\" 2>&1 || true")
+        appendLine("    exit 1")
+        appendLine("fi")
+        appendLine()
+        appendLine("echo \"[SPARSE-MOUNT-OK]\"")
+        appendLine()
+        appendLine("# 2. Extract tarball")
+        appendLine("echo \"[SPARSE-EXTRACTING]\"")
+        appendLine("cd \"\$MNT\"")
+        appendLine("TAR_EXIT=0")
+        if (isXz) {
+            appendLine("\"$busybox\" xzcat \"$tarballPath\" | \"$busybox\" tar -xpf - 2>&1 || TAR_EXIT=\$?")
+        } else {
+            appendLine("\"$busybox\" tar -xzpf \"$tarballPath\" 2>&1 || TAR_EXIT=\$?")
+        }
+        appendLine("if [ \"\$TAR_EXIT\" -ne 0 ]; then")
+        appendLine("    echo \"[SPARSE-EXTRACT-WARN] tar exited \$TAR_EXIT (commonly harmless -- device nodes/xattrs/perm warnings on a real rootfs); continuing\"")
+        appendLine("fi")
+        appendLine("cd /")
+        appendLine()
+        appendLine("# 3. Post-extraction fixes")
+        appendLine("echo \"[SPARSE-POSTFIX]\"")
+        appendLine("if [ -f \"\$POST_FIX\" ]; then")
+        appendLine("    BUSYBOX_PATH=\"\$BUSYBOX\" sh \"\$POST_FIX\" \"\$MNT\" 2>&1 || true")
+        appendLine("fi")
+        appendLine()
+        if (qCfg != null) {
+            appendLine("# 4. Embed self-describing container configuration as a plain file directly")
+            appendLine("#    under /etc -- guaranteed to already exist as a real directory in a")
+            appendLine("#    validated rootfs, so no mkdir and no possible directory/file collision.")
+            appendLine("EMBED_DEST=\"\$MNT/${Constants.EMBEDDED_CONFIG_RELATIVE_PATH}\"")
+            appendLine("if [ ! -f \"\$TMP_CFG\" ]; then")
+            appendLine("    echo \"[SPARSE-EMBED-FAIL] source config missing at \$TMP_CFG\"")
+            appendLine("elif ! CP_ERR=\$(cp \"\$TMP_CFG\" \"\$EMBED_DEST\" 2>&1); then")
+            appendLine("    echo \"[SPARSE-EMBED-FAIL] cp to \$EMBED_DEST failed: \$CP_ERR\"")
+            appendLine("else")
+            appendLine("    chmod 644 \"\$EMBED_DEST\" 2>/dev/null || true")
+            appendLine("    if [ -f \"\$EMBED_DEST\" ]; then")
+            appendLine("        echo \"[SPARSE-EMBED-OK]\"")
+            appendLine("    else")
+            appendLine("        echo \"[SPARSE-EMBED-FAIL] cp reported success but \$EMBED_DEST still missing\"")
+            appendLine("    fi")
+            appendLine("fi")
+            appendLine()
+        }
+        appendLine("echo \"[SPARSE-SUCCESS]\"")
+        appendLine("exit 0")
     }
 }

--- a/Android/app/src/main/java/com/droidspaces/app/util/StorageChecker.kt
+++ b/Android/app/src/main/java/com/droidspaces/app/util/StorageChecker.kt
@@ -1,41 +1,98 @@
 package com.droidspaces.app.util
 
+import android.content.Context
 import com.topjohnwu.superuser.Shell
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
+
+/**
+ * Detailed capability report for a storage path/filesystem.
+ */
+data class FilesystemCapabilityReport(
+    val path: String,
+    val fsType: String = "unknown",
+    val isLinuxNativeFs: Boolean = false,
+    val supportsChmodChown: Boolean = false,
+    val supportsSetuid: Boolean = false,
+    val supportsSymlinks: Boolean = false,
+    val supportsHardlinks: Boolean = false,
+    val supportsFifo: Boolean = false,
+    val supportsDeviceNodes: Boolean = false,
+    val isNoExec: Boolean = false,
+    val isNodev: Boolean = false,
+    val isReadOnly: Boolean = false,
+    val isExternalStorage: Boolean = false,
+    val errors: List<String> = emptyList()
+) {
+    /**
+     * Directory mode requires:
+     * - Linux native filesystem (not vfat/exfat/ntfs/sdcardfs/fuse)
+     * - Full chmod/chown support (POSIX DAC)
+     * - Symlink creation
+     * - Not mounted noexec or ro
+     */
+    val isFullyCompatibleWithDirectoryMode: Boolean
+        get() = isLinuxNativeFs && supportsChmodChown && supportsSymlinks && !isNoExec && !isReadOnly && errors.isEmpty()
+}
 
 object StorageChecker {
     private const val BUSYBOX_PATH = Constants.BUSYBOX_BINARY_PATH
 
     /**
-     * Check available space in /data partition.
-     * Returns free space in GB, or null if unable to determine.
-     *
-     * Performance: ~10-50ms (runs in background)
+     * Normalizes a storage directory path, ensuring leading slash and clean structure.
      */
-    suspend fun getFreeSpaceGB(): Int? = withContext(Dispatchers.IO) {
+    fun normalizeStorageDir(path: String): String {
+        return path.trim().trimEnd('/')
+    }
+
+    /**
+     * Check available space at the given path's mount point.
+     *
+     * Ensures volume is synchronized via [StorageMountManager] and checks against the
+     * canonical physical mount point to avoid querying Android init's phantom 3GB tmpfs.
+     * Returns free space in GB, or null if unable to determine.
+     */
+    suspend fun getFreeSpaceGB(path: String = "/data"): Int? = withContext(Dispatchers.IO) {
         try {
-            // Try using stat first (more accurate)
-            val statResult = Shell.cmd("stat -f -c '%a %S' /data 2>&1").exec()
-            if (statResult.isSuccess && statResult.out.isNotEmpty()) {
-                val parts = statResult.out[0].trim().split(" ")
-                if (parts.size == 2) {
-                    val availBlocks = parts[0].toLongOrNull()
-                    val blockSize = parts[1].toLongOrNull()
-                    if (availBlocks != null && blockSize != null) {
-                        val freeGB = (availBlocks * blockSize / 1024 / 1024 / 1024).toInt()
-                        return@withContext freeGB
-                    }
-                }
+            val normPath = path.trim()
+            val isExternal = RootNamespace.isExternalStorage(normPath)
+
+            if (isExternal) {
+                // Ensure the external volume is bind-mounted in root's namespace
+                StorageMountManager.ensureVolumeMounted(normPath)
             }
 
-            // Fallback: use busybox df
-            val dfResult = Shell.cmd("$BUSYBOX_PATH df /data 2>&1 | $BUSYBOX_PATH tail -n1 | $BUSYBOX_PATH awk '{print \$4}'").exec()
-            if (dfResult.isSuccess && dfResult.out.isNotEmpty()) {
-                val freeKB = dfResult.out[0].trim().toLongOrNull()
-                if (freeKB != null && freeKB > 0) {
-                    val freeGB = (freeKB / 1024 / 1024).toInt()
-                    return@withContext freeGB
+            // Check using physical path first, then original path
+            val physicalPath = if (isExternal) StorageMountManager.resolveToPhysicalPath(normPath) else normPath
+            val pathsToCheck = if (physicalPath != normPath) listOf(physicalPath, normPath) else listOf(normPath)
+
+            for (target in pathsToCheck) {
+                val quoted = ContainerCommandBuilder.quote(target)
+
+                // Try stat -f first
+                val statResult = Shell.cmd("stat -f -c '%a %S' $quoted 2>/dev/null || $BUSYBOX_PATH stat -f -c '%a %S' $quoted 2>/dev/null").exec()
+                if (statResult.isSuccess && statResult.out.isNotEmpty()) {
+                    val parts = statResult.out[0].trim().split(" ")
+                    if (parts.size == 2) {
+                        val availBlocks = parts[0].toLongOrNull()
+                        val blockSize = parts[1].toLongOrNull()
+                        if (availBlocks != null && blockSize != null && blockSize > 0) {
+                            val freeGB = (availBlocks * blockSize / 1024 / 1024 / 1024).toInt()
+                            return@withContext freeGB
+                        }
+                    }
+                }
+
+                // Fallback: busybox df
+                val dfResult = Shell.cmd(
+                    "$BUSYBOX_PATH df -k $quoted 2>/dev/null | $BUSYBOX_PATH tail -n1 | $BUSYBOX_PATH awk '{print \$4}'"
+                ).exec()
+                if (dfResult.isSuccess && dfResult.out.isNotEmpty()) {
+                    val freeKB = dfResult.out[0].trim().toLongOrNull()
+                    if (freeKB != null && freeKB > 0) {
+                        val freeGB = (freeKB / 1024 / 1024).toInt()
+                        return@withContext freeGB
+                    }
                 }
             }
 
@@ -46,13 +103,242 @@ object StorageChecker {
     }
 
     /**
-     * Check if sufficient space is available (default 4GB minimum).
-     * Returns true if space is sufficient, false otherwise.
-     * Returns null if unable to determine.
+     * Get the primary shared storage path (usually /storage/emulated/0).
      */
-    suspend fun hasSufficientSpace(requiredGB: Int = Constants.MIN_STORAGE_GB): Boolean? = withContext(Dispatchers.IO) {
-        val freeGB = getFreeSpaceGB() ?: return@withContext null
+    suspend fun getSharedStoragePath(): String? = withContext(Dispatchers.IO) {
+        val result = RootNamespace.exec("[ -d /storage/emulated/0 ] && echo /storage/emulated/0", forceNsenter = true)
+        if (result.isSuccess && result.out.isNotEmpty()) {
+            result.out[0].trim()
+        } else {
+            null
+        }
+    }
+
+    /**
+     * Verify if a path exists and is writable by root.
+     */
+    suspend fun validateWritablePath(path: String): Result<Unit> = withContext(Dispatchers.IO) {
+        try {
+            val normPath = path.trim()
+            if (RootNamespace.isExternalStorage(normPath)) {
+                StorageMountManager.ensureVolumeMounted(normPath)
+            }
+
+            val quotedPath = ContainerCommandBuilder.quote(normPath)
+            val mkdirResult = RootNamespace.exec("mkdir -p $quotedPath 2>&1", targetPath = normPath)
+            if (!mkdirResult.isSuccess) {
+                val err = (mkdirResult.out + mkdirResult.err).joinToString("\n").trim()
+                val reason = if (err.isNotEmpty()) err else "Could not create or access directory"
+                return@withContext Result.failure(Exception(reason))
+            }
+            val testFile = "${normPath.trimEnd('/')}/.ds_write_test_${System.currentTimeMillis()}"
+            val quotedTestFile = ContainerCommandBuilder.quote(testFile)
+            val touchResult = RootNamespace.exec("touch $quotedTestFile && rm -f $quotedTestFile 2>&1", targetPath = normPath)
+            if (touchResult.isSuccess) {
+                Result.success(Unit)
+            } else {
+                val err = (touchResult.out + touchResult.err).joinToString("\n").trim()
+                val reason = if (err.isNotEmpty()) err else "Path is not writable (permission denied)"
+                Result.failure(Exception(reason))
+            }
+        } catch (e: Exception) {
+            Result.failure(e)
+        }
+    }
+
+    /**
+     * Check if sufficient space is available (default 4GB minimum) at the given path.
+     */
+    suspend fun hasSufficientSpace(requiredGB: Int = Constants.MIN_STORAGE_GB, path: String = "/data"): Boolean? = withContext(Dispatchers.IO) {
+        val freeGB = getFreeSpaceGB(path) ?: return@withContext null
         freeGB >= requiredGB
     }
-}
 
+    /**
+     * List mounted external storage volumes under /storage.
+     */
+    suspend fun listStorageVolumes(): List<String> = withContext(Dispatchers.IO) {
+        try {
+            StorageMountManager.listAllStorageVolumes()
+        } catch (e: Exception) {
+            emptyList()
+        }
+    }
+
+    /**
+     * Comprehensive filesystem capability inspection for directory-based containers.
+     * Tests filesystem type, POSIX chmod/chown, setuid, symlinks, hardlinks,
+     * FIFOs, device nodes, and mount options.
+     */
+    suspend fun inspectFilesystemCapabilities(path: String, context: Context): FilesystemCapabilityReport = withContext(Dispatchers.IO) {
+        val normPath = path.trim()
+        val isExternal = RootNamespace.isExternalStorage(normPath)
+
+        if (isExternal) {
+            StorageMountManager.ensureVolumeMounted(normPath)
+        }
+
+        val physicalPath = if (isExternal) StorageMountManager.resolveToPhysicalPath(normPath) else normPath
+        val qPath = ContainerCommandBuilder.quote(physicalPath)
+        val errorList = mutableListOf<String>()
+
+        try {
+            // Ensure target directory exists on physical volume
+            Shell.cmd("mkdir -p $qPath 2>/dev/null").exec()
+
+            val script = buildString {
+                appendLine("#!/system/bin/sh")
+                appendLine("BUSYBOX=\"${Constants.BUSYBOX_BINARY_PATH}\"")
+                appendLine("TARGET=$qPath")
+                appendLine("TEST_DIR=\"\$TARGET/.ds_compat_test_\$\$\"")
+                appendLine()
+                appendLine("mkdir -p \"\$TEST_DIR\" 2>/dev/null || \"\$BUSYBOX\" mkdir -p \"\$TEST_DIR\" 2>/dev/null || true")
+                appendLine()
+                appendLine("cleanup() {")
+                appendLine("    rm -rf \"\$TEST_DIR\" 2>/dev/null || \"\$BUSYBOX\" rm -rf \"\$TEST_DIR\" 2>/dev/null || true")
+                appendLine("}")
+                appendLine("trap cleanup EXIT")
+                appendLine()
+                appendLine("# 1. Get filesystem type")
+                appendLine("FS_TYPE=\$(stat -f -c %T \"\$TARGET\" 2>/dev/null || \"\$BUSYBOX\" stat -f -c %T \"\$TARGET\" 2>/dev/null || echo 'unknown')")
+                appendLine("echo \"FS_TYPE=\$FS_TYPE\"")
+                appendLine()
+                appendLine("# 2. Mount options")
+                appendLine("MOUNT_OPTS=\$(grep -F \" \$TARGET \" /proc/mounts 2>/dev/null | awk '{print \$4}' || echo '')")
+                appendLine("if [ -z \"\$MOUNT_OPTS\" ]; then")
+                appendLine("    MOUNT_OPTS=\$(\"\$BUSYBOX\" grep -F \" \$TARGET \" /proc/mounts 2>/dev/null | awk '{print \$4}' || echo '')")
+                appendLine("fi")
+                appendLine("echo \"MOUNT_OPTS=\$MOUNT_OPTS\"")
+                appendLine()
+                appendLine("# 3. Test POSIX permissions (chmod)")
+                appendLine("CHMOD_OK=0")
+                appendLine("echo test > \"\$TEST_DIR/perm_test\" 2>/dev/null || true")
+                appendLine("if chmod 700 \"\$TEST_DIR/perm_test\" 2>/dev/null; then")
+                appendLine("    PERM=\$(stat -c %a \"\$TEST_DIR/perm_test\" 2>/dev/null || echo '')")
+                appendLine("    if [ \"\$PERM\" = \"700\" ]; then")
+                appendLine("        CHMOD_OK=1")
+                appendLine("    fi")
+                appendLine("fi")
+                appendLine("echo \"CHMOD_OK=\$CHMOD_OK\"")
+                appendLine()
+                appendLine("# 4. Test setuid")
+                appendLine("SETUID_OK=0")
+                appendLine("if chmod 4755 \"\$TEST_DIR/perm_test\" 2>/dev/null; then")
+                appendLine("    PERM=\$(stat -c %a \"\$TEST_DIR/perm_test\" 2>/dev/null || echo '')")
+                appendLine("    if [ \"\$PERM\" = \"4755\" ]; then")
+                appendLine("        SETUID_OK=1")
+                appendLine("    fi")
+                appendLine("fi")
+                appendLine("echo \"SETUID_OK=\$SETUID_OK\"")
+                appendLine()
+                appendLine("# 5. Test Symlinks")
+                appendLine("SYMLINK_OK=0")
+                appendLine("if ln -s \"perm_test\" \"\$TEST_DIR/symlink_test\" 2>/dev/null; then")
+                appendLine("    if [ -L \"\$TEST_DIR/symlink_test\" ]; then")
+                appendLine("        SYMLINK_OK=1")
+                appendLine("    fi")
+                appendLine("fi")
+                appendLine("echo \"SYMLINK_OK=\$SYMLINK_OK\"")
+                appendLine()
+                appendLine("# 6. Test Hardlinks")
+                appendLine("HARDLINK_OK=0")
+                appendLine("if ln \"\$TEST_DIR/perm_test\" \"\$TEST_DIR/hardlink_test\" 2>/dev/null; then")
+                appendLine("    HARDLINK_OK=1")
+                appendLine("fi")
+                appendLine("echo \"HARDLINK_OK=\$HARDLINK_OK\"")
+                appendLine()
+                appendLine("# 7. Test FIFO (named pipes)")
+                appendLine("FIFO_OK=0")
+                appendLine("if mkfifo \"\$TEST_DIR/fifo_test\" 2>/dev/null || \"\$BUSYBOX\" mkfifo \"\$TEST_DIR/fifo_test\" 2>/dev/null; then")
+                appendLine("    if [ -p \"\$TEST_DIR/fifo_test\" ]; then")
+                appendLine("        FIFO_OK=1")
+                appendLine("    fi")
+                appendLine("fi")
+                appendLine("echo \"FIFO_OK=\$FIFO_OK\"")
+                appendLine()
+                appendLine("# 8. Test device nodes (mknod)")
+                appendLine("MKNOD_OK=0")
+                appendLine("if mknod \"\$TEST_DIR/null_test\" c 1 3 2>/dev/null || \"\$BUSYBOX\" mknod \"\$TEST_DIR/null_test\" c 1 3 2>/dev/null; then")
+                appendLine("    if [ -c \"\$TEST_DIR/null_test\" ]; then")
+                appendLine("        MKNOD_OK=1")
+                appendLine("    fi")
+                appendLine("fi")
+                appendLine("echo \"MKNOD_OK=\$MKNOD_OK\"")
+                appendLine()
+                appendLine("exit 0")
+            }
+
+            val scriptRes = RootNamespace.runScript(script, context, targetPath = normPath)
+
+            var rawFsType = "unknown"
+            var rawMountOpts = ""
+            var chmodOk = false
+            var setuidOk = false
+            var symlinkOk = false
+            var hardlinkOk = false
+            var fifoOk = false
+            var mknodOk = false
+
+            scriptRes.out.forEach { line ->
+                val trimmed = line.trim()
+                when {
+                    trimmed.startsWith("FS_TYPE=") -> rawFsType = trimmed.removePrefix("FS_TYPE=").trim()
+                    trimmed.startsWith("MOUNT_OPTS=") -> rawMountOpts = trimmed.removePrefix("MOUNT_OPTS=").trim()
+                    trimmed == "CHMOD_OK=1" -> chmodOk = true
+                    trimmed == "SETUID_OK=1" -> setuidOk = true
+                    trimmed == "SYMLINK_OK=1" -> symlinkOk = true
+                    trimmed == "HARDLINK_OK=1" -> hardlinkOk = true
+                    trimmed == "FIFO_OK=1" -> fifoOk = true
+                    trimmed == "MKNOD_OK=1" -> mknodOk = true
+                }
+            }
+
+            val lowerFs = rawFsType.lowercase()
+            val isNative = lowerFs.contains("ext4") || lowerFs.contains("f2fs") || lowerFs.contains("btrfs") ||
+                    lowerFs.contains("xfs") || lowerFs.contains("zfs")
+
+            val isNoExec = rawMountOpts.contains("noexec")
+            val isNodev = rawMountOpts.contains("nodev")
+            val isRo = rawMountOpts.contains("ro") && !rawMountOpts.contains("rw")
+
+            if (!isNative) {
+                errorList.add("Filesystem type is '$rawFsType'. Non-native filesystems (FAT32/exFAT/NTFS) do not support POSIX container semantics.")
+            }
+            if (!chmodOk) {
+                errorList.add("POSIX permission control (chmod/chown) is not supported.")
+            }
+            if (!symlinkOk) {
+                errorList.add("Symbolic links (symlinks) are not supported on this volume.")
+            }
+            if (isNoExec) {
+                errorList.add("Volume is mounted with 'noexec' flag (binary execution will be blocked).")
+            }
+            if (isRo) {
+                errorList.add("Volume is mounted read-only.")
+            }
+
+            FilesystemCapabilityReport(
+                path = normPath,
+                fsType = rawFsType,
+                isLinuxNativeFs = isNative,
+                supportsChmodChown = chmodOk,
+                supportsSetuid = setuidOk,
+                supportsSymlinks = symlinkOk,
+                supportsHardlinks = hardlinkOk,
+                supportsFifo = fifoOk,
+                supportsDeviceNodes = mknodOk,
+                isNoExec = isNoExec,
+                isNodev = isNodev,
+                isReadOnly = isRo,
+                isExternalStorage = isExternal,
+                errors = errorList
+            )
+        } catch (e: Exception) {
+            FilesystemCapabilityReport(
+                path = normPath,
+                isExternalStorage = isExternal,
+                errors = listOf("Failed to inspect filesystem: ${e.message}")
+            )
+        }
+    }
+}

--- a/Android/app/src/main/java/com/droidspaces/app/util/StorageMountManager.kt
+++ b/Android/app/src/main/java/com/droidspaces/app/util/StorageMountManager.kt
@@ -1,0 +1,232 @@
+package com.droidspaces.app.util
+
+import com.topjohnwu.superuser.Shell
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+
+/**
+ * Manages external and removable storage mounts (USB-OTG drives, SD cards) across
+ * Android namespaces and the root environment.
+ *
+ * Problem Context:
+ * 1. Android's Vold service mounts raw USB/SD block devices to `/mnt/media_rw/<volId>` in the root/global namespace.
+ * 2. In root's mount namespace, `/storage` is an in-memory `tmpfs` (~3GB) created by init.
+ * 3. Apps access external storage through a FUSE/virtualized layer (`/storage/<volId>` -> `/mnt/user/0/<volId>`).
+ * 4. If root executes commands directly on `/storage/<volId>`, it mistakenly writes to the 3GB tmpfs,
+ *    causing false space reports (e.g. "3GB free" on a 400GB drive) and causing loop-mount failures.
+ *
+ * This manager:
+ * - Discovers real physical kernel mount points (`/mnt/media_rw/<volId>`, `/mnt/pass_through/0/<volId>`).
+ * - Synchronizes root's mount namespace by bind-mounting the real volume to `/storage/<volId>`.
+ * - Resolves virtual storage paths to canonical physical paths for low-level kernel disk operations.
+ */
+object StorageMountManager {
+
+    /**
+     * Extracts the volume identifier (e.g. "FFF6-F07B" or "1234-5678") from any storage path.
+     * Returns null if path is internal (/data, /storage/emulated/0) or cannot be determined.
+     */
+    fun extractVolumeId(path: String?): String? {
+        if (path.isNullOrBlank()) return null
+        val normalized = SafPathResolver.normalizePath(path).trim()
+        val match = Regex("^(?:/storage|/mnt/media_rw|/mnt/pass_through/0|/mnt/user/0|/mnt/runtime/(?:default|read|write|full)|/documents|/document|/tree)/([^/:]+)").find(normalized)
+            ?: Regex("""([0-9A-Fa-f]{4}-[0-9A-Fa-f]{4})""").find(normalized)
+        val volId = match?.groupValues?.get(1)
+        if (volId != null && volId != "emulated" && volId != "self" && volId != "primary") {
+            return volId
+        }
+        return null
+    }
+
+    /**
+     * Discovers where Vold or the Linux kernel actually mounted the physical block device for [volId].
+     */
+    suspend fun findPhysicalMountPoint(volId: String): String? = withContext(Dispatchers.IO) {
+        if (volId.isBlank() || volId == "emulated" || volId == "self") return@withContext null
+
+        val candidates = listOf(
+            "/mnt/media_rw/$volId",
+            "/mnt/pass_through/0/$volId",
+            "/mnt/runtime/default/$volId",
+            "/mnt/runtime/write/$volId",
+            "/mnt/runtime/read/$volId",
+            "/mnt/user/0/$volId"
+        )
+        for (cand in candidates) {
+            val check = Shell.cmd("[ -d ${ContainerCommandBuilder.quote(cand)} ] && echo ok").exec()
+            if (check.isSuccess && check.out.any { it.contains("ok") }) {
+                return@withContext cand
+            }
+        }
+
+        // Case-insensitive search in /mnt/media_rw
+        val listMediaRw = Shell.cmd("for d in /mnt/media_rw/*; do [ -d \"${'$'}d\" ] && echo \"${'$'}d\"; done").exec()
+        if (listMediaRw.isSuccess && listMediaRw.out.isNotEmpty()) {
+            val match = listMediaRw.out.firstOrNull { it.substringAfterLast("/").equals(volId, ignoreCase = true) }
+            if (match != null) return@withContext match
+        }
+
+        // Fallback: search /proc/mounts for non-tmpfs, non-storage mounts containing volId
+        val mounts = Shell.cmd("grep -i -F \"$volId\" /proc/mounts 2>/dev/null | grep -v 'tmpfs' | awk '{print \$2}'").exec()
+        if (mounts.isSuccess && mounts.out.isNotEmpty()) {
+            val nonStorage = mounts.out.firstOrNull { it.contains(volId, ignoreCase = true) && !it.startsWith("/storage") }
+            if (nonStorage != null) return@withContext nonStorage
+            return@withContext mounts.out.firstOrNull()
+        }
+
+        // Single-volume fallback
+        if (listMediaRw.isSuccess && listMediaRw.out.size == 1) {
+            val single = listMediaRw.out.first().trim()
+            if (single.isNotEmpty() && !single.contains("*")) return@withContext single
+        }
+
+        null
+    }
+
+    /**
+     * Cleans up stale loop devices and stale mount points from previous USB/SD disconnects.
+     */
+    suspend fun cleanupStaleMountsAndLoopDevices() = withContext(Dispatchers.IO) {
+        val script = """
+            # 1. Ensure basic loop nodes exist (0-7 only if missing)
+            for i in 0 1 2 3 4 5 6 7; do
+                [ -e "/dev/block/loop${'$'}i" ] || mknod "/dev/block/loop${'$'}i" b 7 "${'$'}i" 2>/dev/null || true
+                [ -e "/dev/loop${'$'}i" ] || mknod "/dev/loop${'$'}i" b 7 "${'$'}i" 2>/dev/null || true
+            done
+
+            # 2. Detach stale or dead loop devices whose backing files no longer exist
+            for dev in ${'$'}(losetup -a 2>/dev/null | awk -F: '{print ${'$'}1}'); do
+                if [ -n "${'$'}dev" ]; then
+                    backing=${'$'}(losetup "${'$'}dev" 2>/dev/null | grep -o '([^)]*)' | tr -d '()')
+                    if [ -n "${'$'}backing" ] && [ ! -e "${'$'}backing" ]; then
+                        losetup -d "${'$'}dev" 2>/dev/null || true
+                    fi
+                fi
+            done
+
+            # 3. Check for stale bind mounts under /storage/*
+            for d in /storage/*; do
+                if [ -d "${'$'}d" ] && mountpoint -q "${'$'}d" 2>/dev/null; then
+                    if ! ls "${'$'}d" >/dev/null 2>&1; then
+                        umount -l "${'$'}d" 2>/dev/null || true
+                    fi
+                fi
+            done
+        """.trimIndent()
+
+        Shell.cmd(script).exec()
+    }
+
+    /**
+     * Ensures that in root's mount namespace, `/storage/<volId>` is bind-mounted to the
+     * real physical mount point (e.g. `/mnt/media_rw/<volId>`), ensuring that all root operations
+     * on `/storage/<volId>` directly hit the physical USB drive with its full capacity.
+     *
+     * Automatically verifies mount health and cleans up stale dead mounts from previous USB disconnects.
+     */
+    suspend fun ensureVolumeMounted(path: String?) = withContext(Dispatchers.IO) {
+        if (path.isNullOrBlank()) return@withContext
+        val volId = extractVolumeId(path) ?: return@withContext
+        val physicalMount = findPhysicalMountPoint(volId) ?: "/mnt/media_rw/$volId"
+
+        val qPhysical = ContainerCommandBuilder.quote(physicalMount)
+        val qStorage = ContainerCommandBuilder.quote("/storage/$volId")
+
+        val script = """
+            # Ensure basic loop device nodes exist
+            for i in 0 1 2 3 4 5 6 7; do
+                [ -e "/dev/block/loop${'$'}i" ] || mknod "/dev/block/loop${'$'}i" b 7 "${'$'}i" 2>/dev/null || true
+                [ -e "/dev/loop${'$'}i" ] || mknod "/dev/loop${'$'}i" b 7 "${'$'}i" 2>/dev/null || true
+            done
+
+            # A bind mount pins the specific mount INSTANCE it was created from,
+            # not the path. On USB disconnect/reconnect, vold tears down and
+            # re-creates the mount at $qPhysical from scratch -- but an existing
+            # bind mount at $qStorage still points at the old, now-defunct
+            # instance. `mountpoint -q` still reports it as mounted, and `ls`
+            # on it can still succeed (just showing an empty/stale directory)
+            # instead of failing, so that alone can't detect the staleness.
+            # Comparing the underlying device id of the bind-mount target
+            # against the CURRENT physical mount catches this reliably: after a
+            # reconnect they differ, and we redo the bind mount.
+            SRC_DEV=""
+            DST_DEV=""
+            [ -d $qPhysical ] && SRC_DEV=${'$'}(stat -c '%d' $qPhysical 2>/dev/null)
+            [ -d $qStorage ] && DST_DEV=${'$'}(stat -c '%d' $qStorage 2>/dev/null)
+
+            if mountpoint -q $qStorage 2>/dev/null; then
+                if [ -z "${'$'}SRC_DEV" ] || [ "${'$'}SRC_DEV" != "${'$'}DST_DEV" ] || ! ls $qStorage >/dev/null 2>&1; then
+                    umount -l $qStorage 2>/dev/null || true
+                fi
+            fi
+
+            # Bind mount physical storage to /storage/$volId if physical exists
+            if [ -d $qPhysical ]; then
+                mkdir -p $qStorage 2>/dev/null
+                if ! mountpoint -q $qStorage 2>/dev/null; then
+                    mount --bind $qPhysical $qStorage 2>/dev/null || true
+                fi
+                chmod 755 $qStorage 2>/dev/null || true
+            fi
+        """.trimIndent()
+
+        Shell.cmd(script).exec()
+    }
+
+    /**
+     * Resolves any storage path (such as `/storage/FFF6-F07B/dir`) to its canonical physical mount
+     * path (e.g. `/mnt/media_rw/FFF6-F07B/dir`) for direct kernel operations (losetup, stat -f, mke2fs, truncate).
+     */
+    suspend fun resolveToPhysicalPath(path: String): String = withContext(Dispatchers.IO) {
+        val trimmed = path.trim()
+        val volId = extractVolumeId(trimmed) ?: return@withContext trimmed
+        val physicalBase = findPhysicalMountPoint(volId) ?: return@withContext trimmed
+
+        val prefixRegex = Regex("^(?:/storage|/mnt/media_rw|/mnt/pass_through/0|/mnt/user/0|/mnt/runtime/(?:default|read|write|full))/$volId")
+        val subPath = trimmed.replaceFirst(prefixRegex, "")
+        "$physicalBase$subPath"
+    }
+
+    /**
+     * Scans and returns all available mounted external storage volumes.
+     * Ensures each found volume is bind-mounted to `/storage/<volId>` in root's namespace.
+     */
+    suspend fun listAllStorageVolumes(): List<String> = withContext(Dispatchers.IO) {
+        val detected = mutableSetOf<String>()
+
+        val scanScript = """
+            # Scan /mnt/media_rw
+            for d in /mnt/media_rw/*; do
+                [ -d "${'$'}d" ] && echo "${'$'}(basename "${'$'}d")"
+            done
+            # Scan /storage
+            for d in /storage/*; do
+                [ -d "${'$'}d" ] && echo "${'$'}(basename "${'$'}d")"
+            done
+            # Scan /mnt/pass_through/0
+            for d in /mnt/pass_through/0/*; do
+                [ -d "${'$'}d" ] && echo "${'$'}(basename "${'$'}d")"
+            done
+        """.trimIndent()
+
+        val result = Shell.cmd(scanScript).exec()
+        if (result.isSuccess) {
+            result.out.forEach { line ->
+                val name = line.trim()
+                if (name.isNotEmpty() && name != "self" && name != "emulated" && name != "knox" && !name.contains("*")) {
+                    detected.add(name)
+                }
+            }
+        }
+
+        // For each detected volume ID, ensure it is mirrored to /storage/<volId>
+        val volumePaths = mutableListOf<String>()
+        for (volId in detected) {
+            val targetStoragePath = "/storage/$volId"
+            ensureVolumeMounted(targetStoragePath)
+            volumePaths.add(targetStoragePath)
+        }
+
+        volumePaths.sorted()
+    }
+}

--- a/Android/app/src/main/res/values/strings.xml
+++ b/Android/app/src/main/res/values/strings.xml
@@ -338,6 +338,10 @@
     <string name="configuration_title">Configuration</string>
     <string name="container_options">Container Options</string>
     <string name="next_storage">Next: Storage</string>
+    <string name="next_summary">Next: Summary</string>
+    <string name="config_override_title">Configuration (Override)</string>
+    <string name="config_override_banner_title">Configuration Override</string>
+    <string name="config_override_banner_desc">This image contains its own saved container configuration. The settings below have been imported from the image. Any changes you make here will override the image configuration for this container on this device.</string>
 
     <!-- Installation Screen -->
     <string name="installing_container">Installing Container</string>
@@ -510,6 +514,40 @@
     <string name="maximum_size_512gb">Maximum size is 512 GB</string>
     <string name="size_gb">Size (GB)</string>
     <string name="enter_size_between_4_512_gb">Enter size between 4 and 512 GB</string>
+
+    <!-- Existing Image & Portability -->
+    <string name="storage_mode_new_image">New Sparse Image</string>
+    <string name="storage_mode_new_image_desc">Create a fresh ext4 image file and extract rootfs into it</string>
+    <string name="storage_mode_existing_image">Existing Image (.img)</string>
+    <string name="storage_mode_existing_image_desc">Use an existing rootfs image (USB/SD or internal) with portable config</string>
+    <string name="storage_mode_directory">Directory Mode</string>
+    <string name="storage_mode_directory_desc">Extract rootfs into a folder (not recommended for removable drives)</string>
+    <string name="existing_image_path">Existing Image File</string>
+    <string name="existing_image_path_hint">Select or enter .img path</string>
+    <string name="browse_existing_image">Browse Image (.img)</string>
+    <string name="inspecting_image">Inspecting image...</string>
+    <string name="valid_ext4_image">Valid ext4 Rootfs Image</string>
+    <string name="embedded_config_found">Embedded Configuration Found</string>
+    <string name="embedded_config_desc">This image contains self-describing container configuration. Apply it to prefill container settings.</string>
+    <string name="apply_embedded_config">Apply saved container configuration</string>
+    <string name="image_size_info">Image Size: %1$d GB (%2$s)</string>
+    <string name="os_detected">Distribution: %1$s</string>
+    <string name="invalid_existing_image">Please select a valid existing ext4 .img file</string>
+    <string name="existing_image_label">Source Image</string>
+    <string name="existing_path_label">Existing Path</string>
+    <string name="install_mode_existing">Import existing image (portable)</string>
+
+    <!-- Filesystem Capability & Dangerous Territory -->
+    <string name="fs_compat_checking">Checking filesystem capabilities...</string>
+    <string name="fs_compat_title">Filesystem Compatibility</string>
+    <string name="fs_compat_valid_title">Filesystem Compatible (POSIX Native)</string>
+    <string name="fs_compat_invalid_title">Incompatible Filesystem for Directory Mode</string>
+    <string name="fs_compat_external_force_sparse_msg">External storage volumes (SD card / USB-OTG) require a Sparse Image (.img) because FAT32, exFAT, and NTFS do not support Linux user permissions, ownership, or symbolic links.</string>
+    <string name="fs_compat_switch_sparse">Switch to Sparse Image (Recommended)</string>
+    <string name="fs_compat_bypass_dialog_title">DANGEROUS TERRITORY</string>
+    <string name="fs_compat_dangerous_desc">Forcing directory-based containers on a non-native filesystem (%1$s) will cause critical system failure:\n\n• Broken symlinks: Core binaries (/bin/sh, libc, systemd) will not work\n• Missing permission isolation: Multi-user security and /etc/shadow will be compromised\n• Package managers (apt/apk) will fail during installs\n• Data corruption will occur\n\nDo NOT report issues occurred while using Directory mode on external/non-native storage.</string>
+    <string name="fs_compat_bypass_button">Bypass Checks (Dangerous)</string>
+    <string name="fs_compat_bypassed_tag">CHECKS BYPASSED (DANGEROUS)</string>
 
     <!-- Container Log Viewer -->
     <string name="logs_title">Logs: %1$s</string>


### PR DESCRIPTION
This PR adds support for **external container storage, importing existing sparse rootfs images, and relocating existing containers**, along with the Android storage plumbing required to make these workflows reliable.

Previously, containers were restricted to internal storage and could only be created from a tarball.

### 1. Custom storage location for new containers

* Added `StorageLocationScreen` / `StorageDestinationPicker` to let users select an SD card or USB-OTG path via root-shell browsing or SAF.
* `ContainerManager.getRootfsPath()` / `getSparseImagePath()` now accept an optional `customStorageDir`.
* Container metadata (`config`, `.env`, PID file, etc.) remains under the internal `CONTAINERS_BASE_PATH`; only the rootfs / `rootfs.img` is relocated.
* Directory-mode rootfs now requires a POSIX-compatible filesystem such as **ext4/f2fs**.

  * `StorageChecker.inspectFilesystemCapabilities()` probes:

    * `chmod` / `chown`
    * symlink support
    * `noexec`
    * read-only mount state
  * Incompatible filesystems such as FAT32/exFAT are rejected.
  * Advanced users can explicitly bypass the check through a **"dangerous territory"** override.
* `ContainerInstaller`:

  * Creates the external parent directory before extraction.
  * Checks free space at the actual destination.
  * Rejects sparse images `>= 4 GiB` on FAT32 destinations up front, avoiding failures later due to FAT32's single-file size limit.

### 2. Import an existing sparse rootfs image

`SparseImageConfigScreen` now supports three modes:

1. New sparse image
2. Existing image
3. Directory

Existing `.img` files can be selected through the root browser, SAF, or by choosing an `.img` tarball during the naming step.

The selected image is processed through `ExistingImageManager.inspect()`, which:

* Loop-mounts the image read-only.
* Runs `e2fsck`.
* Detects filesystem/image size.
* Reads `/etc/os-release`.
* Detects an embedded `container.config`, when present.

If the image contains an embedded configuration, its settings can be used to prefill the setup wizard. `ContainerConfigScreen` displays an **override** banner when this occurs.

`ContainerInstaller.installFromExistingImage()`:

* Copies the image to the selected destination or uses it in-place.
* Runs `e2fsck`.
* Re-embeds the current container configuration at `/etc/droidspaces.config`.

This keeps imported images portable across devices.

`ContainerManager.updateContainerConfig()` also re-embeds the configuration whenever the container configuration is edited, keeping the embedded copy synchronized.

### 3. Move an existing container's storage

`ContainerCard` now provides a **Move storage location** action.

`ContainersScreen` displays a `MoveStorageDialog` that supports moving between internal and external/custom storage while reusing the same destination picker and filesystem validation used during creation.

`ContainerManager.moveContainerStorage()` performs a safe stop-and-move operation:

1. Verifies that the container is not running.
2. Checks destination free space.
3. Validates FAT32's 4 GiB file-size limitation.
4. Attempts a same-filesystem rename first.
5. Falls back to copy-then-delete when a rename is not possible.
6. Rewrites the container configuration to the new path.
7. Removes the old copy only after the configuration successfully points to the new location.

This ordering ensures that a crash during the move does not leave the container referencing missing data.

`ContainerOperationsViewModel.executeMoveStorage()` handles the UI flow, including:

* Stopping the container.
* Showing move progress.
* Surfacing errors and operation logs.

---

## Supporting Android External Storage Infrastructure

### `RootNamespace`

Root-shell commands targeting `/storage` or `/mnt/media_rw` are now routed through the volume's live physical mount point whenever possible.

When that is not possible, commands are executed inside the app's own mount namespace using `nsenter`. The app namespace already has a working FUSE view of external storage.

This avoids relying on root's namespace, which may not see external volumes unless a same-process bind mount happens to succeed. That behavior varies across devices and ROMs.

### `StorageMountManager`

* Resolves SD/USB volume IDs to their current physical kernel mount points:

  * `/mnt/media_rw/<volId>`
* Bind-mounts them into:

  * `/storage/<volId>`
* Detects stale bind mounts after USB disconnect/reconnect.
* Compares device IDs instead of relying solely on `mountpoint(1)`.

### `SafPathResolver`

Converts Android Storage Access Framework document/tree URIs into plain filesystem paths.

This is particularly important for USB drives that are visible to SAF before the root browser can access them.

### Automatic external-path recovery

`ContainerManager.autoDetectAndRemapContainerPath()` runs during container start/restart.

If an external rootfs path no longer exists—for example, because a USB drive was disconnected and later remounted with a different mount instance—it searches currently connected volumes for the matching rootfs and automatically rewrites the container configuration to the new path.

### `service.sh`

The boot script now:

* Pre-creates `/dev/loop0`–`/dev/loop7`.
* Bind-mounts `/mnt/media_rw/*` volumes into `/storage/*`.
* Performs this setup before containers are started.

This allows sparse images stored on external volumes to work during boot without depending on Android having already refreshed its storage views.

---

## Additional Reliability Fixes

* `SparseImageInstaller` now performs the complete mount/extract/postfix sequence as **one atomic root-shell script** with a trap-based cleanup handler.

  * Previously, these operations were split across multiple `Shell.cmd` calls.
  * An exception between commands could leave a loop device or mount attached.
* Export, migrate, and resize commands are now invoked explicitly through `sh`.

  * This avoids SELinux / `noexec` mount denials encountered on some devices.

## Result

This PR expands container storage from a fixed internal-only model into a more flexible system supporting:

* **Internal storage**
* **SD cards**
* **USB-OTG storage**
* **Existing sparse image imports**
* **In-place image usage**
* **Container storage relocation**
* **Automatic recovery after external-volume remounts**

while keeping container metadata internal and adding filesystem validation and failure-safe storage operations.
