### PR TITLE
garaho: activate IME for 12-key terminal input

### DIFF
--- a/Android/app/src/main/java/com/droidspaces/app/ui/screen/ContainerTerminalScreen.kt
+++ b/Android/app/src/main/java/com/droidspaces/app/ui/screen/ContainerTerminalScreen.kt
@@ -385,6 +385,7 @@ private fun TerminalTabView(
 
                         post {
                             requestFocus()
+                            (mClient as? TerminalBackEnd)?.activate12KeyInputMethodIfNeeded()
                             mEmulator?.mColors?.mCurrentColors?.apply {
                                 set(256, terminalForeground)
                                 set(258, terminalForeground)

--- a/Android/app/src/main/java/com/droidspaces/app/ui/terminal/TerminalBackEnd.kt
+++ b/Android/app/src/main/java/com/droidspaces/app/ui/terminal/TerminalBackEnd.kt
@@ -4,7 +4,6 @@ import android.content.ClipData
 import android.content.ClipboardManager
 import android.content.Context
 import android.content.res.Configuration
-import android.content.res.Resources
 import android.util.Log
 import android.view.KeyEvent
 import android.view.MotionEvent
@@ -83,8 +82,18 @@ class TerminalBackEnd(
     }
 
     override fun onSingleTapUp(e: MotionEvent) {
-        val hasHardwareKeyboard = Resources.getSystem().configuration.keyboard != Configuration.KEYBOARD_NOKEYS
-        if (!hasHardwareKeyboard) showSoftInput()
+        val keyboard = terminal.resources.configuration.keyboard
+        if (keyboard == Configuration.KEYBOARD_NOKEYS ||
+            keyboard == Configuration.KEYBOARD_12KEY) {
+            showSoftInput()
+        }
+    }
+
+    fun activate12KeyInputMethodIfNeeded() {
+        // A 12-key hardware keypad still depends on the IME for text composition.
+        if (terminal.resources.configuration.keyboard == Configuration.KEYBOARD_12KEY) {
+            showSoftInput()
+        }
     }
 
     override fun shouldBackButtonBeMappedToEscape(): Boolean = false


### PR DESCRIPTION
This patch will allow users to input things other than numbers on 12-key devices, a.k.a. [Garaho](https://garahowiki.com/phones:kyocera_digno_keitai_4:start).
However, we still need to think about how to emulate `ENTER` and `DELETE` keys.