### PR TITLE
UI improvements #4

### DIFF
--- a/Android/app/src/main/java/com/droidspaces/app/ui/component/ContainerConfigForm.kt
+++ b/Android/app/src/main/java/com/droidspaces/app/ui/component/ContainerConfigForm.kt
@@ -705,7 +705,7 @@ fun ContainerConfigForm(
             tonalElevation = 0.dp
         ) {
             Row(
-                modifier = Modifier.padding(horizontal = 16.dp, vertical = 14.dp),
+                modifier = Modifier.padding(14.dp),
                 verticalAlignment = Alignment.CenterVertically,
                 horizontalArrangement = Arrangement.Center
             ) {

--- a/Android/app/src/main/java/com/droidspaces/app/ui/component/ContainerUsersCard.kt
+++ b/Android/app/src/main/java/com/droidspaces/app/ui/component/ContainerUsersCard.kt
@@ -289,6 +289,7 @@ fun ContainerUsersCard(
                         }
                     },
                     modifier = Modifier.widthIn(min = 140.dp),
+                    shape = RoundedCornerShape(14.dp),
                     colors = ButtonDefaults.buttonColors(
                         containerColor = MaterialTheme.colorScheme.primary,
                         contentColor = MaterialTheme.colorScheme.onPrimary

--- a/Android/app/src/main/java/com/droidspaces/app/ui/component/DialogFooterRow.kt
+++ b/Android/app/src/main/java/com/droidspaces/app/ui/component/DialogFooterRow.kt
@@ -39,31 +39,56 @@ fun DialogFooterRow(
     confirmColor: Color = MaterialTheme.colorScheme.primary,
     confirmContentColor: Color = MaterialTheme.colorScheme.onPrimary,
 ) {
-    Row(modifier = modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(12.dp)) {
-        Surface(
-            modifier = Modifier.weight(1f).clip(RoundedCornerShape(14.dp)).clickable(onClick = onDismiss),
-            shape = RoundedCornerShape(14.dp),
-            color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.06f),
-            border = BorderStroke(1.dp, MaterialTheme.colorScheme.outlineVariant.copy(alpha = cancelBorderAlpha)),
-            tonalElevation = 0.dp
+    Surface(
+        modifier = modifier.fillMaxWidth(),
+        color = MaterialTheme.colorScheme.surfaceContainerHigh,
+        shape = RoundedCornerShape(20.dp),
+        border = BorderStroke(1.dp, MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.35f)),
+        tonalElevation = 0.dp
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(4.dp),
+            horizontalArrangement = Arrangement.spacedBy(4.dp)
         ) {
-            Box(modifier = Modifier.padding(14.dp), contentAlignment = Alignment.Center) {
-                Text(dismissLabel, style = MaterialTheme.typography.labelLarge, fontWeight = textFontWeight)
+            Surface(
+                modifier = Modifier
+                    .weight(1f)
+                    .clip(RoundedCornerShape(16.dp))
+                    .clickable(onClick = onDismiss),
+                shape = RoundedCornerShape(16.dp),
+                color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.06f),
+                border = BorderStroke(1.dp, MaterialTheme.colorScheme.outlineVariant.copy(alpha = cancelBorderAlpha)),
+                tonalElevation = 0.dp
+            ) {
+                Box(modifier = Modifier.padding(14.dp), contentAlignment = Alignment.Center) {
+                    Text(dismissLabel, style = MaterialTheme.typography.labelLarge, fontWeight = textFontWeight)
+                }
             }
-        }
-        Surface(
-            modifier = Modifier.weight(1f).clip(RoundedCornerShape(14.dp)).clickable(enabled = confirmEnabled, onClick = onConfirm),
-            shape = RoundedCornerShape(14.dp),
-            color = if (confirmEnabled) confirmColor else MaterialTheme.colorScheme.onSurface.copy(alpha = 0.12f),
-            tonalElevation = 0.dp
-        ) {
-            Box(modifier = Modifier.padding(14.dp), contentAlignment = Alignment.Center) {
-                Text(
-                    confirmLabel,
-                    style = MaterialTheme.typography.labelLarge,
-                    fontWeight = textFontWeight,
-                    color = if (confirmEnabled) confirmContentColor else MaterialTheme.colorScheme.onSurface.copy(alpha = 0.38f)
-                )
+
+            val confirmBtnColor = if (confirmEnabled) confirmColor.copy(alpha = 0.15f) else MaterialTheme.colorScheme.onSurface.copy(alpha = 0.08f)
+            val confirmAccent = if (confirmEnabled) confirmColor else MaterialTheme.colorScheme.outlineVariant
+            val confirmTextColor = if (confirmEnabled) confirmColor else MaterialTheme.colorScheme.onSurface.copy(alpha = 0.38f)
+
+            Surface(
+                modifier = Modifier
+                    .weight(1f)
+                    .clip(RoundedCornerShape(16.dp))
+                    .clickable(enabled = confirmEnabled, onClick = onConfirm),
+                shape = RoundedCornerShape(16.dp),
+                color = confirmBtnColor,
+                border = BorderStroke(1.dp, confirmAccent.copy(alpha = 0.35f)),
+                tonalElevation = 0.dp
+            ) {
+                Box(modifier = Modifier.padding(14.dp), contentAlignment = Alignment.Center) {
+                    Text(
+                        confirmLabel,
+                        style = MaterialTheme.typography.labelLarge,
+                        fontWeight = textFontWeight,
+                        color = confirmTextColor
+                    )
+                }
             }
         }
     }

--- a/Android/app/src/main/java/com/droidspaces/app/ui/screen/ContainerDetailsScreen.kt
+++ b/Android/app/src/main/java/com/droidspaces/app/ui/screen/ContainerDetailsScreen.kt
@@ -447,6 +447,7 @@ private fun TerminalCard(
             Button(
                 onClick = onOpenTerminal,
                 modifier = Modifier.widthIn(min = 140.dp),
+                shape = RoundedCornerShape(14.dp),
                 colors = ButtonDefaults.buttonColors(
                     containerColor = MaterialTheme.colorScheme.primary,
                     contentColor = MaterialTheme.colorScheme.onPrimary
@@ -652,6 +653,7 @@ private fun PremiumInitSystemCard(
                             onClick = {},
                             enabled = false,
                             modifier = Modifier.widthIn(min = 140.dp),
+                            shape = RoundedCornerShape(14.dp),
                             colors = ButtonDefaults.filledTonalButtonColors(
                                 disabledContainerColor = MaterialTheme.colorScheme.surfaceContainerHigh,
                                 disabledContentColor = MaterialTheme.colorScheme.onSurfaceVariant
@@ -671,6 +673,7 @@ private fun PremiumInitSystemCard(
                             onClick = {},
                             enabled = false,
                             modifier = Modifier.widthIn(min = 140.dp),
+                            shape = RoundedCornerShape(14.dp),
                             colors = ButtonDefaults.filledTonalButtonColors(
                                 disabledContainerColor = MaterialTheme.colorScheme.errorContainer.copy(alpha = 0.3f),
                                 disabledContentColor = MaterialTheme.colorScheme.onErrorContainer
@@ -683,6 +686,7 @@ private fun PremiumInitSystemCard(
                         Button(
                             onClick = { onNavigateToServices(currentState.initSystem) },
                             modifier = Modifier.widthIn(min = 140.dp),
+                            shape = RoundedCornerShape(14.dp),
                             colors = ButtonDefaults.buttonColors(
                                 containerColor = MaterialTheme.colorScheme.primary,
                                 contentColor = MaterialTheme.colorScheme.onPrimary

--- a/Android/app/src/main/java/com/droidspaces/app/ui/screen/ContainerTerminalScreen.kt
+++ b/Android/app/src/main/java/com/droidspaces/app/ui/screen/ContainerTerminalScreen.kt
@@ -10,16 +10,19 @@ import androidx.activity.compose.BackHandler
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
+import androidx.compose.animation.slideInHorizontally
+import androidx.compose.animation.slideOutHorizontally
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
-import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Add
-import androidx.compose.material.icons.filled.Close
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
@@ -34,6 +37,7 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.viewinterop.AndroidView
 import com.droidspaces.app.service.TerminalSessionService
+import com.droidspaces.app.ui.component.DialogFooterRow
 import com.droidspaces.app.ui.terminal.TerminalBackEnd
 import com.droidspaces.app.ui.terminal.TerminalScreenState
 import com.droidspaces.app.ui.terminal.virtualkeys.VirtualKeysConstants
@@ -59,7 +63,7 @@ private data class TerminalTab(
     val label: String,
 )
 
-@OptIn(ExperimentalMaterial3Api::class)
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalFoundationApi::class)
 @Composable
 fun ContainerTerminalScreen(
     containerName: String,
@@ -68,6 +72,7 @@ fun ContainerTerminalScreen(
 ) {
     val context = LocalContext.current
     val activity = context as? Activity
+    val terminalDarkTheme = remember { PreferencesManager.getInstance(context).terminalDarkTheme }
 
     val keyboardController = LocalSoftwareKeyboardController.current
     var binder by remember { mutableStateOf<TerminalSessionService.SessionBinder?>(null) }
@@ -98,6 +103,20 @@ fun ContainerTerminalScreen(
     val tabs = remember { mutableStateListOf<TerminalTab>() }
     var activeTabId by remember { mutableStateOf("") }
     var showUserPicker by remember { mutableStateOf(false) }
+    var tabToClose by remember { mutableStateOf<TerminalTab?>(null) }
+
+    val currentTabIndex = remember(activeTabId, tabs.size) {
+        tabs.indexOfFirst { it.id == activeTabId }.coerceAtLeast(0)
+    }
+    var previousTabIndex by remember { mutableIntStateOf(currentTabIndex) }
+    var isMovingForward by remember { mutableStateOf(true) }
+
+    LaunchedEffect(currentTabIndex) {
+        if (currentTabIndex != previousTabIndex) {
+            isMovingForward = currentTabIndex > previousTabIndex
+            previousTabIndex = currentTabIndex
+        }
+    }
 
     // Resolve hostname reactively; picker is shown only after binder+hostname are both ready
     var hostname by remember(containerName) {
@@ -192,10 +211,22 @@ fun ContainerTerminalScreen(
         )
     }
 
+    if (tabToClose != null) {
+        CloseSessionConfirmationDialog(
+            tabLabel = tabToClose!!.label,
+            onConfirm = {
+                val target = tabToClose!!
+                tabToClose = null
+                closeTab(target)
+            },
+            onDismiss = { tabToClose = null }
+        )
+    }
+
     Scaffold(
         topBar = {
             Column {
-                TopAppBar(
+                CenterAlignedTopAppBar(
                     title = {
                         Text(
                             containerName,
@@ -215,62 +246,72 @@ fun ContainerTerminalScreen(
                             Icon(Icons.Default.Add, contentDescription = "New tab")
                         }
                     },
-                    colors = TopAppBarDefaults.topAppBarColors(
+                    colors = TopAppBarDefaults.centerAlignedTopAppBarColors(
                         containerColor = MaterialTheme.colorScheme.surfaceContainerLow
                     )
                 )
 
                 if (tabs.isNotEmpty()) {
                     ScrollableTabRow(
-                        selectedTabIndex = tabs.indexOfFirst { it.id == activeTabId }.coerceAtLeast(0),
+                        selectedTabIndex = currentTabIndex,
                         containerColor = MaterialTheme.colorScheme.surfaceContainerLow,
                         contentColor = MaterialTheme.colorScheme.primary,
-                        edgePadding = 0.dp,
+                        edgePadding = 12.dp,
                         divider = {},
-                        modifier = Modifier.fillMaxWidth()
+                        indicator = {},
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(top = 0.dp, bottom = 6.dp)
                     ) {
                         tabs.forEach { tab ->
                             val isSelected = tab.id == activeTabId
-                            Tab(
-                                selected = isSelected,
-                                onClick = { activeTabId = tab.id },
-                                modifier = Modifier.height(40.dp)
+                            val innerColor = if (isSelected) MaterialTheme.colorScheme.primaryContainer.copy(alpha = 0.4f)
+                                             else MaterialTheme.colorScheme.onSurface.copy(alpha = 0.04f)
+                            val innerBorder = if (isSelected) MaterialTheme.colorScheme.primary.copy(alpha = 0.2f)
+                                              else MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.2f)
+                            // Outer outline — matches Start button outer pill
+                            Surface(
+                                modifier = Modifier.padding(horizontal = 3.dp),
+                                shape = RoundedCornerShape(16.dp),
+                                color = MaterialTheme.colorScheme.surfaceContainerHigh,
+                                border = BorderStroke(1.dp, MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.2f)),
+                                tonalElevation = 0.dp
                             ) {
-                                Row(
-                                    verticalAlignment = Alignment.CenterVertically,
-                                    horizontalArrangement = Arrangement.spacedBy(4.dp),
-                                    modifier = Modifier.padding(horizontal = 8.dp)
+                                // Inner button — matches Start button inner surface
+                                Surface(
+                                    modifier = Modifier
+                                        .padding(3.dp)
+                                        .height(28.dp)
+                                        .clip(RoundedCornerShape(12.dp))
+                                        .combinedClickable(
+                                            onClick = { activeTabId = tab.id },
+                                            onLongClick = { tabToClose = tab }
+                                        ),
+                                    shape = RoundedCornerShape(12.dp),
+                                    color = innerColor,
+                                    border = BorderStroke(1.dp, innerBorder),
+                                    tonalElevation = 0.dp
                                 ) {
-                                    Text(
-                                        tab.label,
-                                        style = MaterialTheme.typography.labelMedium,
-                                        fontWeight = if (isSelected) FontWeight.SemiBold else FontWeight.Normal,
-                                        maxLines = 1,
-                                        overflow = TextOverflow.Ellipsis,
-                                        modifier = Modifier.widthIn(max = 120.dp)
-                                    )
                                     Box(
-                                        Modifier.size(16.dp).clip(CircleShape),
+                                        modifier = Modifier
+                                            .fillMaxHeight()
+                                            .padding(horizontal = 12.dp),
                                         contentAlignment = Alignment.Center
                                     ) {
-                                        IconButton(
-                                            onClick = { closeTab(tab) },
-                                            modifier = Modifier.size(16.dp)
-                                        ) {
-                                            Icon(
-                                                Icons.Default.Close,
-                                                contentDescription = "Close tab",
-                                                modifier = Modifier.size(12.dp),
-                                                tint = if (isSelected) MaterialTheme.colorScheme.primary
-                                                       else MaterialTheme.colorScheme.onSurfaceVariant
-                                            )
-                                        }
+                                        Text(
+                                            tab.label,
+                                            style = MaterialTheme.typography.labelLarge,
+                                            fontWeight = if (isSelected) FontWeight.Bold else FontWeight.Medium,
+                                            color = if (isSelected) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.onSurfaceVariant,
+                                            maxLines = 1,
+                                            overflow = TextOverflow.Ellipsis
+                                        )
                                     }
                                 }
                             }
                         }
                     }
-                    HorizontalDivider(thickness = 0.5.dp, color = MaterialTheme.colorScheme.outlineVariant)
+                    HorizontalDivider(thickness = 0.5.dp, color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.5f))
                 }
             }
         }
@@ -279,7 +320,7 @@ fun ContainerTerminalScreen(
             modifier = Modifier
                 .fillMaxSize()
                 .padding(top = paddingValues.calculateTopPadding())
-                .background(MaterialTheme.colorScheme.surface)
+                .background(if (terminalDarkTheme) Color.Black else MaterialTheme.colorScheme.surface)
         ) {
             if (binder == null || tabs.isEmpty()) {
                 Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
@@ -293,6 +334,7 @@ fun ContainerTerminalScreen(
                             binder = binder!!,
                             containerName = containerName,
                             isVisible = tab.id == activeTabId,
+                            isMovingForward = isMovingForward,
                             activity = activity,
                             onSessionFinished = { closeTab(tab) },
                             modifier = Modifier.fillMaxSize()
@@ -310,6 +352,7 @@ private fun TerminalTabView(
     binder: TerminalSessionService.SessionBinder,
     containerName: String,
     isVisible: Boolean,
+    isMovingForward: Boolean,
     activity: Activity?,
     onSessionFinished: () -> Unit,
     modifier: Modifier = Modifier,
@@ -339,8 +382,14 @@ private fun TerminalTabView(
 
     AnimatedVisibility(
         visible = isVisible,
-        enter = fadeIn(animationSpec = AnimationUtils.fastSpec()),
-        exit = fadeOut(animationSpec = AnimationUtils.fastSpec()),
+        enter = slideInHorizontally(
+            initialOffsetX = { if (isMovingForward) (it * 0.08f).toInt() else -(it * 0.08f).toInt() },
+            animationSpec = AnimationUtils.mediumSpec()
+        ) + fadeIn(animationSpec = AnimationUtils.fastSpec()),
+        exit = slideOutHorizontally(
+            targetOffsetX = { if (isMovingForward) -(it * 0.08f).toInt() else (it * 0.08f).toInt() },
+            animationSpec = AnimationUtils.mediumSpec()
+        ) + fadeOut(animationSpec = AnimationUtils.fastSpec()),
         modifier = modifier
     ) {
         Column(modifier = Modifier.fillMaxSize()) {
@@ -563,6 +612,59 @@ private fun UserPickerDialog(
                         )
                     }
                 }
+            }
+        }
+    }
+}
+
+@Composable
+private fun CloseSessionConfirmationDialog(
+    tabLabel: String,
+    onConfirm: () -> Unit,
+    onDismiss: () -> Unit,
+) {
+    val context = LocalContext.current
+    val dialogShape = RoundedCornerShape(28.dp)
+
+    androidx.compose.ui.window.Dialog(
+        onDismissRequest = onDismiss,
+        properties = androidx.compose.ui.window.DialogProperties(usePlatformDefaultWidth = false)
+    ) {
+        Surface(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 24.dp)
+                .wrapContentHeight(),
+            shape = dialogShape,
+            color = MaterialTheme.colorScheme.surfaceContainer,
+            border = BorderStroke(1.dp, MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.4f)),
+            tonalElevation = 0.dp
+        ) {
+            Column(
+                modifier = Modifier.padding(24.dp),
+                verticalArrangement = Arrangement.spacedBy(16.dp)
+            ) {
+                Text(
+                    text = "Close this session?",
+                    style = MaterialTheme.typography.titleLarge,
+                    fontWeight = FontWeight.Bold,
+                    color = MaterialTheme.colorScheme.onSurface
+                )
+
+                Text(
+                    text = "Are you sure you want to close session \"$tabLabel\"?",
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.8f)
+                )
+
+                DialogFooterRow(
+                    dismissLabel = context.getString(android.R.string.cancel),
+                    confirmLabel = context.getString(R.string.ok),
+                    onDismiss = onDismiss,
+                    onConfirm = onConfirm,
+                    confirmColor = MaterialTheme.colorScheme.error,
+                    confirmContentColor = MaterialTheme.colorScheme.onError
+                )
             }
         }
     }


### PR DESCRIPTION
session tabs, dialog buttons, animations and terminal dark mode fix

- update button radius to 14dp for Copy login, Manage, and Terminal buttons
- add common button outline and even padding to dialog footer buttons
- update popup dialog buttons to use translucent container fill and visible accent outline
- wrap dialog footer buttons in outer segment Surface container with common outline
- refactor terminal screen (centered title, double outline tabs, long press confirmation, slide animations)
- update terminal tab double-outline segment container shape and add bidirectional slide animation
- separate double-outline card per session tab and polished 48dp bidirectional slide animation
- fix terminal session tabs and animation consistency
- separate outline per session tab, match button radius and padding
- restyle session tabs to match Start button pattern
- double outline session tabs matching Start button pattern
- fix white flicker on tab switch when terminal is dark in light mode