### PR TITLE
nix: working-droidspaces-rootfs-minimal, Update journald configuration

### DIFF
--- a/nix/nixos.nix
+++ b/nix/nixos.nix
@@ -110,15 +110,15 @@
         };
 
         # Journald configuration (skip Audit, KMsg, etc)
-        services.journald.extraConfig = ''
-          ReadKMsg=no
-          Audit=no
-          Storage=volatile
-          SystemMaxUse=50M
-          RuntimeMaxUse=10M
-          MaxRetentionSec=7day
-          MaxLevelStore=info
-        '';
+        services.journald.settings.Journal = {
+          ReadKMsg="no";
+          Audit="no";
+          Storage="volatile";
+          SystemMaxUse="50M";
+          RuntimeMaxUse="10M";
+          MaxRetentionSec="7day";
+          MaxLevelStore="info";
+        };
 
         services.logrotate.settings.header.maxsize = "50M";
 


### PR DESCRIPTION
fix 
```
       error:
       Failed assertions:
       - The option definition `services.journald.extraConfig' in `/nix/store/hn39lrlfnpnqm1vzfx49l0viffac28qw-source/nix/nixos.nix, via option flake.nixosModules.working-droidspaces-rootfs-minimal' no longer has any effect; please remove it.
       Use services.journald.settings.Journal instead.
```
fellow https://github.com/NixOS/nixpkgs/pull/536538